### PR TITLE
Include-path-juggle node_api.h instead of napi.h (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use N-API in a native module:
 
   2. Reference this package's include directory and gyp file in `binding.gyp`:
 ```gyp
-  'include_dirs': ["<!(node -p \"require('node-addon-api').include\")"],
+  'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
   'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
 ```
 

--- a/external-napi/node_api.h
+++ b/external-napi/node_api.h
@@ -1,0 +1,7 @@
+#ifndef EXTERNAL_NODE_API_H_
+#define EXTERNAL_NODE_API_H_
+
+#define EXTERNAL_NAPI
+#include "../src/node_api.h"
+
+#endif

--- a/index.js
+++ b/index.js
@@ -4,18 +4,18 @@ var path = require('path');
 // or detect presence of built-in N-API by some other mechanism TBD.
 var isNodeApiBuiltin = process.versions.modules >= 52;  // Node 8.x
 
-var include = __dirname;
+var include = path.join(__dirname, 'src');
 var gyp = path.join(__dirname, 'src', 'node_api.gyp');
 
 if (isNodeApiBuiltin) {
    gyp += ':nothing';
 } else {
    gyp += ':node-api';
-   include = path.join(__dirname, 'src');
+   include = path.join(__dirname, 'external-napi');
 }
 
 module.exports = {
-   include: include,
+   include: [ '"' + include + '"', '"' + __dirname + '"' ].join(' '),
    gyp: gyp,
    isNodeApiBuiltin: isNodeApiBuiltin,
 };

--- a/src/napi.h
+++ b/src/napi.h
@@ -1,2 +1,0 @@
-#define EXTERNAL_NAPI
-#include "../napi.h"


### PR DESCRIPTION
Instead of making the path from which napi.h is included conditional
upon the Node.js version, make the path of node_api.h thusly
conditional. This way, no additional modification needs to be made to a
dependent's binding.gyp in order to add the EXTERNAL_NAPI preprocessor
directive when the C++ wrappers are not used.

By this mechanism the C++ wrapper napi.h will also refer to the correct
version of node_api.h.

~~Fixes https://github.com/nodejs/node-api/issues/40~~
Fixes https://github.com/nodejs/node-api/issues/41