### PR TITLE
Set up CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: c++
+compiler:
+  - clang
+  - gcc
+env:
+  - TRAVIS_NODE_VERSION="4"
+  - TRAVIS_NODE_VERSION="6"
+  - TRAVIS_NODE_VERSION="7"
+os:
+  - linux
+  - osx
+matrix:
+  fast_finish: true
+sudo: false
+cache:
+  directories:
+    - node_modules
+    - $HOME/.npm
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
+before_install:
+  - echo "$TRAVIS_NODE_VERSION"
+  - export "PATH=./node_modules/.bin:$PWD/node_modules/.bin:$HOME/.local/bin:$PATH"
+  # coveralls
+  - pip install --user cpp-coveralls
+  # compilers
+  - if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-4.9" CC="gcc-4.9" AR="gcc-ar-4.9" RANLIB="gcc-ranlib-4.9" NM="gcc-nm-4.9" ; fi
+  - if [ "$CXX" = "clang++" ]; then export NPMOPT=--clang=1 ; fi
+  # node versions
+  - rm -rf ~/.nvm
+  - git clone --branch v0.33.2 https://github.com/creationix/nvm.git ~/.nvm
+  - source ~/.nvm/nvm.sh
+  - nvm install "$TRAVIS_NODE_VERSION"
+  - node --version
+  - export CFLAGS="$CFLAGS -O3 --coverage" LDFLAGS="$LDFLAGS --coverage"
+  - echo "CFLAGS=\"$CFLAGS\" LDFLAGS=\"$LDFLAGS\""
+install:
+  - npm install $NPMOPT
+script:
+  - npm test $NPMOPT
+after_success:
+  - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+# https://www.appveyor.com/docs/lang/nodejs-iojs/#testing-under-multiple-versions-of-nodejs-or-iojs
+environment:
+  fast_finish: true
+  matrix:
+    - nodejs_version: "7"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - node -p process.arch
+  - node -p process.version
+
+test_script:
+  - npm test
+
+build: off
+
+version: "{build}"
+
+cache:
+  - node_modules


### PR DESCRIPTION
Run for this PR:
* https://ci.appveyor.com/project/addaleax/node-api/build/7
* https://travis-ci.org/addaleax/node-api/builds/234598724

Notably, builds are currently failing on Node 4 or 6 on macOS with:

```
/Users/travis/build/addaleax/node-api/src/../napi.h:6:10: fatal error: 'initializer_list' file not found
```

Everything else is green, though.

(Coverage doesn’t seem to be working quite yet but that might just be because tests are failing.)