### PR TITLE
Fix off-by-one error for strings of certain sizes

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -502,6 +502,7 @@ inline std::string String::Utf8Value() const {
   if (status != napi_ok) throw Error::New(_env);
 
   std::string value;
+  value.reserve(length + 1);
   value.resize(length);
   status = napi_get_value_string_utf8(_env, _value, &value[0], value.capacity(), nullptr);
   if (status != napi_ok) throw Error::New(_env);
@@ -514,6 +515,7 @@ inline std::u16string String::Utf16Value() const {
   if (status != napi_ok) throw Error::New(_env);
 
   std::u16string value;
+  value.reserve(length + 1);
   value.resize(length);
   status = napi_get_value_string_utf16(_env, _value, &value[0], value.capacity(), nullptr);
   if (status != napi_ok) throw Error::New(_env);

--- a/test/name.cc
+++ b/test/name.cc
@@ -5,6 +5,19 @@ using namespace Napi;
 const char* testValueUtf8 = "123456789";
 const char16_t* testValueUtf16 = u"123456789";
 
+Value EchoString(const CallbackInfo& info) {
+  String value = info[0].As<String>();
+  String encoding = info[1].As<String>();
+
+  if (encoding.Utf8Value() == "utf8") {
+    return String::New(info.Env(), value.Utf8Value().c_str());
+  } else if (encoding.Utf8Value() == "utf16") {
+    return String::New(info.Env(), value.Utf16Value().c_str());
+  } else {
+    throw Error::New(info.Env(), "Invalid encoding.");
+  }
+}
+
 Value CreateString(const CallbackInfo& info) {
   String encoding = info[0].As<String>();
   Number length = info[1].As<Number>();
@@ -69,6 +82,7 @@ Value CheckSymbol(const CallbackInfo& info) {
 Object InitName(Env env) {
   Object exports = Object::New(env);
 
+  exports["echoString"] = Function::New(env, EchoString);
   exports["createString"] = Function::New(env, CreateString);
   exports["checkString"] = Function::New(env, CheckString);
   exports["createSymbol"] = Function::New(env, CreateSymbol);

--- a/test/name.js
+++ b/test/name.js
@@ -40,3 +40,12 @@ assert.ok(binding.name.checkSymbol(sym1));
 const sym2 = binding.name.createSymbol('test');
 assert.strictEqual(typeof sym2, 'symbol');
 assert.ok(binding.name.checkSymbol(sym1));
+
+// Check for off-by-one errors which might only appear for strings of certain sizes,
+// due to how std::string increments its capacity in chunks.
+const longString = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+for (let i = 10; i <= longString.length; i++) {
+   const str = longString.substr(0, i);
+   assert.strictEqual(binding.name.echoString(str, 'utf8'), str);
+   assert.strictEqual(binding.name.echoString(str, 'utf16'), str);
+}


### PR DESCRIPTION
Resizing a `std::string` to the number of chars to be copied into it usually worked because of how `std::string` usually allocates a little more memory than what is requested. But sometimes there would be no extra capacity, so the `capacity()` value passed to `napi_get_value_string()` was too short by one (due to the null-terminator). The result was strings of certain lengths could have one char trimmed off the end.