### PR TITLE
Update CI to include node 4, 6, 8, nightly, CC nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,21 @@ language: c++
 compiler:
   - clang
   - gcc
-env:
-  - TRAVIS_NODE_VERSION="4"
-  - TRAVIS_NODE_VERSION="6"
-  - TRAVIS_NODE_VERSION="7"
+# For Linux, use an Ubuntu 14 image
+dist: trusty
 os:
   - linux
   - osx
+env:
+  global:
+    # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+    - NVS_VERSION=1.2.0
+  matrix:
+    - NODEJS_VERSION=node/4
+    - NODEJS_VERSION=node/6
+    - NODEJS_VERSION=node/8
+    - NODEJS_VERSION=nightly
+    - NODEJS_VERSION=chakracore-nightly
 matrix:
   fast_finish: true
 sudo: false
@@ -23,21 +31,22 @@ addons:
     packages:
       - g++-4.9
 before_install:
-  - echo "$TRAVIS_NODE_VERSION"
-  - export "PATH=./node_modules/.bin:$PWD/node_modules/.bin:$HOME/.local/bin:$PATH"
   # coveralls
   - pip install --user cpp-coveralls
   # compilers
   - if [ "$CXX" = "g++" -a "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-4.9" CC="gcc-4.9" AR="gcc-ar-4.9" RANLIB="gcc-ranlib-4.9" NM="gcc-nm-4.9" ; fi
   - if [ "$CXX" = "clang++" ]; then export NPMOPT=--clang=1 ; fi
-  # node versions
-  - rm -rf ~/.nvm
-  - git clone --branch v0.33.2 https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install "$TRAVIS_NODE_VERSION"
-  - node --version
   - export CFLAGS="$CFLAGS -O3 --coverage" LDFLAGS="$LDFLAGS --coverage"
   - echo "CFLAGS=\"$CFLAGS\" LDFLAGS=\"$LDFLAGS\""
+  # nvs
+  - git clone --branch v$NVS_VERSION --depth 1 https://github.com/jasongin/nvs ~/.nvs
+  - . ~/.nvs/nvs.sh
+  - nvs --version
+  # node.js
+  - nvs add $NODEJS_VERSION
+  - nvs use $NODEJS_VERSION
+  - node --version
+  - npm --version
 install:
   - npm install $NPMOPT
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,31 @@
-# https://www.appveyor.com/docs/lang/nodejs-iojs/#testing-under-multiple-versions-of-nodejs-or-iojs
 environment:
+  # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+  NVS_VERSION: 1.2.0
   fast_finish: true
   matrix:
-    - nodejs_version: "7"
-    - nodejs_version: "4"
-    - nodejs_version: "6"
+    - NODEJS_VERSION: node/4
+    - NODEJS_VERSION: node/6
+    - NODEJS_VERSION: node/8
+    - NODEJS_VERSION: nightly
+    - NODEJS_VERSION: chakracore-nightly
 
 platform:
   - x86
   - x64
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
+  # nvs
+  - git clone --branch v%NVS_VERSION% --depth 1 https://github.com/jasongin/nvs %LOCALAPPDATA%\nvs
+  - set PATH=%LOCALAPPDATA%\nvs;%PATH%
+  - nvs --version
+  # node.js
+  - nvs add %NODEJS_VERSION%/%PLATFORM%
+  - nvs use %NODEJS_VERSION%/%PLATFORM%
+  - node --version
   - node -p process.arch
-  - node -p process.version
+  - npm --version
+  # app
+  - npm install
 
 test_script:
   - npm test


### PR DESCRIPTION
Travis run: https://travis-ci.org/jasongin/node-addon-api/builds/237732241
AppVeyor run: https://ci.appveyor.com/project/jasongin/node-api/build/3

All jobs in the matrix are passing with the exception of those that use node nightly builds, which fail due to https://github.com/nodejs/build/issues/743