### PR TITLE
Conditional support for C++ exceptions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ before_install:
 install:
   - npm install $NPMOPT
 script:
+  # Travis CI sets NVM_NODEJS_ORG_MIRROR, but it makes node-gyp fail to download headers for nightly builds.
+  - unset NVM_NODEJS_ORG_MIRROR
+
   - npm test $NPMOPT
 after_success:
   - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
     - NODEJS_VERSION=chakracore-nightly
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: NODEJS_VERSION=nightly
+    - env: NODEJS_VERSION=chakracore-nightly
 sudo: false
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ To use N-API in a native module:
   'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
 ```
 
-  3. Ensure C++ exceptions are enabled in `binding.gyp`.
-     The N-API C++ wrapper classes use exceptions for error-handling;
-     the base ABI-stable C APIs do not.
+  3. Decide whether the package will enable C++ exceptions in the N-API wrapper.
+     The base ABI-stable C APIs do not throw or handle C++ exceptions, but the
+     N-API C++ wrapper classes may _optionally_
+     [integrate C++ and JavaScript exception-handling
+     ](https://nodejs.github.io/node-addon-api/class_napi_1_1_error.html).
+     To enable that capability, C++ exceptions must be enabled in `binding.gyp`:
 ```gyp
   'cflags!': [ '-fno-exceptions' ],
   'cflags_cc!': [ '-fno-exceptions' ],
@@ -40,6 +43,10 @@ To use N-API in a native module:
   'msvs_settings': {
     'VCCLCompilerTool': { 'ExceptionHandling': 1 },
   },
+```
+  Alternatively, disable use of C++ exceptions in N-API:
+```gyp
+  'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
 ```
 
   4. Include `napi.h` in the native module code.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,12 @@ environment:
     - NODEJS_VERSION: nightly
     - NODEJS_VERSION: chakracore-nightly
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - NODEJS_VERSION: nightly
+    - NODEJS_VERSION: chakracore-nightly
+
 platform:
   - x86
   - x64

--- a/napi.h
+++ b/napi.h
@@ -18,14 +18,10 @@
   #endif
 #endif
 
-#ifdef NAPI_CPP_EXCEPTIONS
-  #ifdef _NOEXCEPT
-    #define NAPI_NOEXCEPT _NOEXCEPT
-  #else
-    #define NAPI_NOEXCEPT noexcept
-  #endif
+#ifdef _NOEXCEPT
+  #define NAPI_NOEXCEPT _NOEXCEPT
 #else
-  #define NAPI_NOEXCEPT
+  #define NAPI_NOEXCEPT noexcept
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "pretest": "node-gyp rebuild -C test",
     "test": "node test"
   },
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/test/arraybuffer.cc
+++ b/test/arraybuffer.cc
@@ -27,7 +27,8 @@ Value CreateBuffer(const CallbackInfo& info) {
   ArrayBuffer buffer = ArrayBuffer::New(info.Env(), testLength);
 
   if (buffer.ByteLength() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(static_cast<uint8_t*>(buffer.Data()), testLength);
@@ -40,11 +41,13 @@ Value CreateExternalBuffer(const CallbackInfo& info) {
   ArrayBuffer buffer = ArrayBuffer::New(info.Env(), testData, testLength);
 
   if (buffer.ByteLength() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != testData) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(testData, testLength);
@@ -66,11 +69,13 @@ Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
     });
 
   if (buffer.ByteLength() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != data) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(data, testLength);
@@ -94,11 +99,13 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
     hint);
 
   if (buffer.ByteLength() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != data) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(data, testLength);
@@ -107,17 +114,20 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
 
 void CheckBuffer(const CallbackInfo& info) {
   if (!info[0].IsArrayBuffer()) {
-    throw Error::New(info.Env(), "A buffer was expected.");
+    Error::New(info.Env(), "A buffer was expected.").ThrowAsJavaScriptException();
+    return;
   }
 
   ArrayBuffer buffer = info[0].As<ArrayBuffer>();
 
   if (buffer.ByteLength() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return;
   }
 
   if (!VerifyData(static_cast<uint8_t*>(buffer.Data()), testLength)) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return;
   }
 }
 

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -1,53 +1,57 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-testUtil.runGCTests([
-  'Internal ArrayBuffer',
-  () => {
-    const test = binding.arraybuffer.createBuffer();
-    binding.arraybuffer.checkBuffer(test);
-    assert.ok(test instanceof ArrayBuffer);
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-    const test2 = test.slice(0);
-    binding.arraybuffer.checkBuffer(test2);
-  },
+function test(binding) {
+  testUtil.runGCTests([
+    'Internal ArrayBuffer',
+    () => {
+      const test = binding.arraybuffer.createBuffer();
+      binding.arraybuffer.checkBuffer(test);
+      assert.ok(test instanceof ArrayBuffer);
 
-  'External ArrayBuffer',
-  () => {
-    const test = binding.arraybuffer.createExternalBuffer();
-    binding.arraybuffer.checkBuffer(test);
-    assert.ok(test instanceof ArrayBuffer);
-    assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
-  },
-  () => {
-    global.gc();
-    assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
-  },
+      const test2 = test.slice(0);
+      binding.arraybuffer.checkBuffer(test2);
+    },
 
-  'External ArrayBuffer with finalizer',
-  () => {
-    const test = binding.arraybuffer.createExternalBufferWithFinalize();
-    binding.arraybuffer.checkBuffer(test);
-    assert.ok(test instanceof ArrayBuffer);
-    assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
-  },
-  () => {
-    global.gc();
-    assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
-  },
+    'External ArrayBuffer',
+    () => {
+      const test = binding.arraybuffer.createExternalBuffer();
+      binding.arraybuffer.checkBuffer(test);
+      assert.ok(test instanceof ArrayBuffer);
+      assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
+    },
+    () => {
+      global.gc();
+      assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
+    },
 
-  'External ArrayBuffer with finalizer hint',
-  () => {
-    const test = binding.arraybuffer.createExternalBufferWithFinalizeHint();
-    binding.arraybuffer.checkBuffer(test);
-    assert.ok(test instanceof ArrayBuffer);
-    assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
-  },
-  () => {
-    global.gc();
-    assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
-  },
-]);
+    'External ArrayBuffer with finalizer',
+    () => {
+      const test = binding.arraybuffer.createExternalBufferWithFinalize();
+      binding.arraybuffer.checkBuffer(test);
+      assert.ok(test instanceof ArrayBuffer);
+      assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
+    },
+    () => {
+      global.gc();
+      assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
+    },
+
+    'External ArrayBuffer with finalizer hint',
+    () => {
+      const test = binding.arraybuffer.createExternalBufferWithFinalizeHint();
+      binding.arraybuffer.checkBuffer(test);
+      assert.ok(test instanceof ArrayBuffer);
+      assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
+    },
+    () => {
+      global.gc();
+      assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
+    },
+  ]);
+}

--- a/test/asyncworker.js
+++ b/test/asyncworker.js
@@ -1,25 +1,21 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-// Use setTimeout() when asserting after async callbacks because
-// unhandled JS exceptions in async callbacks are currently ignored.
-// See the TODO comment in AsyncWorker::OnWorkComplete().
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-binding.asyncworker.doWork(true, function (e) {
-  setTimeout(() => {
+function test(binding) {
+  binding.asyncworker.doWork(true, function (e) {
     assert.strictEqual(typeof e, 'undefined');
     assert.strictEqual(typeof this, 'object');
     assert.strictEqual(this.data, 'test data');
-  });
-}, 'test data');
+  }, 'test data');
 
-binding.asyncworker.doWork(false, function (e) {
-  setTimeout(() => {
+  binding.asyncworker.doWork(false, function (e) {
     assert.ok(e instanceof Error);
     assert.strictEqual(e.message, 'test error');
     assert.strictEqual(typeof this, 'object');
     assert.strictEqual(this.data, 'test data');
-  });
-}, 'test data');
+  }, 'test data');
+}

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -1,8 +1,6 @@
 {
-  'targets': [
-    {
-      'target_name': 'binding',
-      'sources': [
+  'target_defaults': {
+    'sources': [
         'arraybuffer.cc',
         'asyncworker.cc',
         'binding.cc',
@@ -16,16 +14,35 @@
       ],
       'include_dirs': ["<!@(node -p \"require('../').include\")"],
       'dependencies': ["<!(node -p \"require('../').gyp\")"],
+  },
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
-      'xcode_settings': {
-        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-        'CLANG_CXX_LIBRARY': 'libc++',
-        'MACOSX_DEPLOYMENT_TARGET': '10.7',
-      },
       'msvs_settings': {
         'VCCLCompilerTool': { 'ExceptionHandling': 1 },
       },
-    }
-  ]
+      'xcode_settings': {
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+      },
+    },
+    {
+      'target_name': 'binding_noexcept',
+      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+      'cflags': [ '-fno-exceptions' ],
+      'cflags_cc': [ '-fno-exceptions' ],
+      'msvs_settings': {
+        'VCCLCompilerTool': { 'ExceptionHandling': 0 },
+      },
+      'xcode_settings': {
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
+      },
+    },
+  ],
 }

--- a/test/buffer.cc
+++ b/test/buffer.cc
@@ -29,7 +29,8 @@ Value CreateBuffer(const CallbackInfo& info) {
   Buffer<uint16_t> buffer = Buffer<uint16_t>::New(info.Env(), testLength);
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(buffer.Data(), testLength);
@@ -45,11 +46,13 @@ Value CreateExternalBuffer(const CallbackInfo& info) {
     testLength);
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != testData) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(testData, testLength);
@@ -71,11 +74,13 @@ Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
     });
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != data) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(data, testLength);
@@ -99,11 +104,13 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
     hint);
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() != data) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   InitData(data, testLength);
@@ -117,15 +124,18 @@ Value CreateBufferCopy(const CallbackInfo& info) {
     info.Env(), testData, testLength);
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (buffer.Data() == testData) {
-    throw Error::New(info.Env(), "Copy should have different memory.");
+    Error::New(info.Env(), "Copy should have different memory.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   if (!VerifyData(buffer.Data(), buffer.Length())) {
-    throw Error::New(info.Env(), "Copy data is incorrect.");
+    Error::New(info.Env(), "Copy data is incorrect.").ThrowAsJavaScriptException();
+    return Value();
   }
 
   return buffer;
@@ -133,17 +143,20 @@ Value CreateBufferCopy(const CallbackInfo& info) {
 
 void CheckBuffer(const CallbackInfo& info) {
   if (!info[0].IsBuffer()) {
-    throw Error::New(info.Env(), "A buffer was expected.");
+    Error::New(info.Env(), "A buffer was expected.").ThrowAsJavaScriptException();
+    return;
   }
 
   Buffer<uint16_t> buffer = info[0].As<Buffer<uint16_t>>();
 
   if (buffer.Length() != testLength) {
-    throw Error::New(info.Env(), "Incorrect buffer length.");
+    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    return;
   }
 
   if (!VerifyData(buffer.Data(), testLength)) {
-    throw Error::New(info.Env(), "Incorrect buffer data.");
+    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    return;
   }
 }
 

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -1,61 +1,65 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-testUtil.runGCTests([
-  'Internal Buffer',
-  () => {
-    const test = binding.buffer.createBuffer();
-    binding.buffer.checkBuffer(test);
-    assert.ok(test instanceof Buffer);
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-    const test2 = Buffer.alloc(test.length);
-    test.copy(test2);
-    binding.buffer.checkBuffer(test2);
-  },
+function test(binding) {
+  testUtil.runGCTests([
+    'Internal Buffer',
+    () => {
+      const test = binding.buffer.createBuffer();
+      binding.buffer.checkBuffer(test);
+      assert.ok(test instanceof Buffer);
 
-  'Buffer copy',
-  () => {
-    const test = binding.buffer.createBufferCopy();
-    binding.buffer.checkBuffer(test);
-    assert.ok(test instanceof Buffer);
-  },
+      const test2 = Buffer.alloc(test.length);
+      test.copy(test2);
+      binding.buffer.checkBuffer(test2);
+    },
 
-  'External Buffer',
-  () => {
-    const test = binding.buffer.createExternalBuffer();
-    binding.buffer.checkBuffer(test);
-    assert.ok(test instanceof Buffer);
-    assert.strictEqual(0, binding.buffer.getFinalizeCount());
-  },
-  () => {
-      global.gc();
-      assert.strictEqual(0, binding.buffer.getFinalizeCount());
-  },
+    'Buffer copy',
+    () => {
+      const test = binding.buffer.createBufferCopy();
+      binding.buffer.checkBuffer(test);
+      assert.ok(test instanceof Buffer);
+    },
 
-  'External Buffer with finalizer',
-  () => {
-    const test = binding.buffer.createExternalBufferWithFinalize();
-    binding.buffer.checkBuffer(test);
-    assert.ok(test instanceof Buffer);
-    assert.strictEqual(0, binding.buffer.getFinalizeCount());
-  },
-  () => {
-      global.gc();
-      assert.strictEqual(1, binding.buffer.getFinalizeCount());
-  },
-
-  'External Buffer with finalizer hint',
-  () => {
-      const test = binding.buffer.createExternalBufferWithFinalizeHint();
+    'External Buffer',
+    () => {
+      const test = binding.buffer.createExternalBuffer();
       binding.buffer.checkBuffer(test);
       assert.ok(test instanceof Buffer);
       assert.strictEqual(0, binding.buffer.getFinalizeCount());
-  },
-  () => {
-      global.gc();
-      assert.strictEqual(1, binding.buffer.getFinalizeCount());
-  },
-]);
+    },
+    () => {
+        global.gc();
+        assert.strictEqual(0, binding.buffer.getFinalizeCount());
+    },
+
+    'External Buffer with finalizer',
+    () => {
+      const test = binding.buffer.createExternalBufferWithFinalize();
+      binding.buffer.checkBuffer(test);
+      assert.ok(test instanceof Buffer);
+      assert.strictEqual(0, binding.buffer.getFinalizeCount());
+    },
+    () => {
+        global.gc();
+        assert.strictEqual(1, binding.buffer.getFinalizeCount());
+    },
+
+    'External Buffer with finalizer hint',
+    () => {
+        const test = binding.buffer.createExternalBufferWithFinalizeHint();
+        binding.buffer.checkBuffer(test);
+        assert.ok(test instanceof Buffer);
+        assert.strictEqual(0, binding.buffer.getFinalizeCount());
+    },
+    () => {
+        global.gc();
+        assert.strictEqual(1, binding.buffer.getFinalizeCount());
+    },
+  ]);
+}

--- a/test/error.js
+++ b/test/error.js
@@ -1,55 +1,59 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-assert.throws(() => binding.error.throwApiError('test'), err => {
-   return err instanceof Error && err.message.includes('Invalid');
-});
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-assert.throws(() => binding.error.throwJSError('test'), err => {
-   return err instanceof Error && err.message === 'test';
-});
-
-assert.throws(() => binding.error.throwTypeError('test'), err => {
-   return err instanceof TypeError && err.message === 'test';
-});
-
-assert.throws(() => binding.error.throwRangeError('test'), err => {
-   return err instanceof RangeError && err.message === 'test';
-});
-
-assert.throws(
-  () => binding.error.doNotCatch(
-    () => {
-      throw new TypeError('test');
-    }),
-  err => {
-    return err instanceof TypeError && err.message === 'test' && !err.caught;
+function test(binding) {
+  assert.throws(() => binding.error.throwApiError('test'), err => {
+    return err instanceof Error && err.message.includes('Invalid');
   });
 
-assert.throws(
-  () => binding.error.catchAndRethrowError(
-    () => {
-      throw new TypeError('test');
-    }),
-  err => {
-    return err instanceof TypeError && err.message === 'test' && err.caught;
+  assert.throws(() => binding.error.throwJSError('test'), err => {
+    return err instanceof Error && err.message === 'test';
   });
 
-const err = binding.error.catchError(
-   () => { throw new TypeError('test'); });
-assert(err instanceof TypeError);
-assert.strictEqual(err.message, 'test');
+  assert.throws(() => binding.error.throwTypeError('test'), err => {
+    return err instanceof TypeError && err.message === 'test';
+  });
 
-const msg = binding.error.catchErrorMessage(
-   () => { throw new TypeError('test'); });
-assert.strictEqual(msg, 'test');
+  assert.throws(() => binding.error.throwRangeError('test'), err => {
+    return err instanceof RangeError && err.message === 'test';
+  });
 
-assert.throws(() => binding.error.throwErrorThatEscapesScope('test'), err => {
-   return err instanceof Error && err.message === 'test';
-});
+  assert.throws(
+    () => binding.error.doNotCatch(
+      () => {
+        throw new TypeError('test');
+      }),
+    err => {
+      return err instanceof TypeError && err.message === 'test' && !err.caught;
+    });
 
-assert.throws(() => binding.error.catchAndRethrowErrorThatEscapesScope('test'), err => {
-  return err instanceof Error && err.message === 'test' && err.caught;
-});
+  assert.throws(
+    () => binding.error.catchAndRethrowError(
+      () => {
+        throw new TypeError('test');
+      }),
+    err => {
+      return err instanceof TypeError && err.message === 'test' && err.caught;
+    });
+
+  const err = binding.error.catchError(
+    () => { throw new TypeError('test'); });
+  assert(err instanceof TypeError);
+  assert.strictEqual(err.message, 'test');
+
+  const msg = binding.error.catchErrorMessage(
+    () => { throw new TypeError('test'); });
+  assert.strictEqual(msg, 'test');
+
+  assert.throws(() => binding.error.throwErrorThatEscapesScope('test'), err => {
+    return err instanceof Error && err.message === 'test';
+  });
+
+  assert.throws(() => binding.error.catchAndRethrowErrorThatEscapesScope('test'), err => {
+    return err instanceof Error && err.message === 'test' && err.caught;
+  });
+}

--- a/test/external.cc
+++ b/test/external.cc
@@ -35,13 +35,15 @@ Value CreateExternalWithFinalizeHint(const CallbackInfo& info) {
 void CheckExternal(const CallbackInfo& info) {
    Value arg = info[0];
    if (arg.Type() != napi_external) {
-      throw Error::New(info.Env(), "An external argument was expected.");
+      Error::New(info.Env(), "An external argument was expected.").ThrowAsJavaScriptException();
+      return;
    }
 
    External<int> external = arg.As<External<int>>();
    int* externalData = external.Data();
    if (externalData == nullptr || *externalData != 1) {
-      throw Error::New(info.Env(), "An external value of 1 was expected.");
+      Error::New(info.Env(), "An external value of 1 was expected.").ThrowAsJavaScriptException();
+      return;
    }
 }
 

--- a/test/external.js
+++ b/test/external.js
@@ -1,40 +1,44 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-testUtil.runGCTests([
-  'External without finalizer',
-  () => {
-    const test = binding.external.createExternal();
-    assert.strictEqual(typeof test, 'object');
-    binding.external.checkExternal(test);
-    assert.strictEqual(0, binding.external.getFinalizeCount());
-  },
-  () => {
-    assert.strictEqual(0, binding.external.getFinalizeCount());
-  },
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-  'External with finalizer',
-  () => {
-    const test = binding.external.createExternalWithFinalize();
-    assert.strictEqual(typeof test, 'object');
-    binding.external.checkExternal(test);
-    assert.strictEqual(0, binding.external.getFinalizeCount());
-  },
-  () => {
-    assert.strictEqual(1, binding.external.getFinalizeCount());
-  },
+function test(binding) {
+  testUtil.runGCTests([
+    'External without finalizer',
+    () => {
+      const test = binding.external.createExternal();
+      assert.strictEqual(typeof test, 'object');
+      binding.external.checkExternal(test);
+      assert.strictEqual(0, binding.external.getFinalizeCount());
+    },
+    () => {
+      assert.strictEqual(0, binding.external.getFinalizeCount());
+    },
 
-  'External with finalizer hint',
-  () => {
-    const test = binding.external.createExternalWithFinalizeHint();
-    assert.strictEqual(typeof test, 'object');
-    binding.external.checkExternal(test);
-    assert.strictEqual(0, binding.external.getFinalizeCount());
-  },
-  () => {
-    assert.strictEqual(1, binding.external.getFinalizeCount());
-  },
-]);
+    'External with finalizer',
+    () => {
+      const test = binding.external.createExternalWithFinalize();
+      assert.strictEqual(typeof test, 'object');
+      binding.external.checkExternal(test);
+      assert.strictEqual(0, binding.external.getFinalizeCount());
+    },
+    () => {
+      assert.strictEqual(1, binding.external.getFinalizeCount());
+    },
+
+    'External with finalizer hint',
+    () => {
+      const test = binding.external.createExternalWithFinalizeHint();
+      assert.strictEqual(typeof test, 'object');
+      binding.external.checkExternal(test);
+      assert.strictEqual(0, binding.external.getFinalizeCount());
+    },
+    () => {
+      assert.strictEqual(1, binding.external.getFinalizeCount());
+    },
+  ]);
+}

--- a/test/function.cc
+++ b/test/function.cc
@@ -76,6 +76,11 @@ Value CallWithReceiverAndVector(const CallbackInfo& info) {
    return func.Call(receiver, args);
 }
 
+Value CallWithInvalidReceiver(const CallbackInfo& info) {
+   Function func = info[0].As<Function>();
+   return func.Call(Value(), {});
+}
+
 Value CallConstructorWithArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
    return func.New({ info[1], info[2], info[3] });
@@ -105,6 +110,7 @@ Object InitFunction(Env env) {
   exports["callWithVector"] = Function::New(env, CallWithVector);
   exports["callWithReceiverAndArgs"] = Function::New(env, CallWithReceiverAndArgs);
   exports["callWithReceiverAndVector"] = Function::New(env, CallWithReceiverAndVector);
+  exports["callWithInvalidReceiver"] = Function::New(env, CallWithInvalidReceiver);
   exports["callConstructorWithArgs"] = Function::New(env, CallConstructorWithArgs);
   exports["callConstructorWithVector"] = Function::New(env, CallConstructorWithVector);
   return exports;

--- a/test/function.js
+++ b/test/function.js
@@ -1,61 +1,69 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-let obj = {};
-assert.deepStrictEqual(binding.function.voidCallback(obj), undefined);
-assert.deepStrictEqual(obj, { "foo": "bar" });
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-assert.deepStrictEqual(binding.function.valueCallback(), { "foo": "bar" });
+function test(binding) {
+  let obj = {};
+  assert.deepStrictEqual(binding.function.voidCallback(obj), undefined);
+  assert.deepStrictEqual(obj, { "foo": "bar" });
 
-let args = null;
-let ret = null;
-let receiver = null;
-function testFunction() {
-   receiver = this;
-   args = [].slice.call(arguments);
-   return ret;
+  assert.deepStrictEqual(binding.function.valueCallback(), { "foo": "bar" });
+
+  let args = null;
+  let ret = null;
+  let receiver = null;
+  function testFunction() {
+    receiver = this;
+    args = [].slice.call(arguments);
+    return ret;
+  }
+  function testConstructor() {
+    args = [].slice.call(arguments);
+  }
+
+  ret = 4;
+  assert.equal(binding.function.callWithArgs(testFunction, 1, 2, 3), 4);
+  assert.strictEqual(receiver, undefined);
+  assert.deepStrictEqual(args, [ 1, 2, 3 ]);
+
+  ret = 5;
+  assert.equal(binding.function.callWithVector(testFunction, 2, 3, 4), 5);
+  assert.strictEqual(receiver, undefined);
+  assert.deepStrictEqual(args, [ 2, 3, 4 ]);
+
+  ret = 6;
+  assert.equal(binding.function.callWithReceiverAndArgs(testFunction, obj, 3, 4, 5), 6);
+  assert.deepStrictEqual(receiver, obj);
+  assert.deepStrictEqual(args, [ 3, 4, 5 ]);
+
+  ret = 7;
+  assert.equal(binding.function.callWithReceiverAndVector(testFunction, obj, 4, 5, 6), 7);
+  assert.deepStrictEqual(receiver, obj);
+  assert.deepStrictEqual(args, [ 4, 5, 6 ]);
+
+  assert.throws(() => {
+    binding.function.callWithInvalidReceiver();
+  }, /Invalid pointer/);
+
+  obj = binding.function.callConstructorWithArgs(testConstructor, 5, 6, 7);
+  assert(obj instanceof testConstructor);
+  assert.deepStrictEqual(args, [ 5, 6, 7 ]);
+
+  obj = binding.function.callConstructorWithVector(testConstructor, 6, 7, 8);
+  assert(obj instanceof testConstructor);
+  assert.deepStrictEqual(args, [ 6, 7, 8 ]);
+
+  obj = {};
+  assert.deepStrictEqual(binding.function.voidCallbackWithData(obj), undefined);
+  assert.deepStrictEqual(obj, { "foo": "bar", "data": 1 });
+
+  assert.deepStrictEqual(binding.function.valueCallbackWithData(), { "foo": "bar", "data": 1 });
+
+  assert.equal(binding.function.voidCallback.name, 'voidCallback');
+  assert.equal(binding.function.valueCallback.name, 'valueCallback');
+
+  // TODO: Function::MakeCallback tests
 }
-function testConstructor() {
-   args = [].slice.call(arguments);
-}
-
-ret = 4;
-assert.equal(binding.function.callWithArgs(testFunction, 1, 2, 3), 4);
-assert.strictEqual(receiver, undefined);
-assert.deepStrictEqual(args, [ 1, 2, 3 ]);
-
-ret = 5;
-assert.equal(binding.function.callWithVector(testFunction, 2, 3, 4), 5);
-assert.strictEqual(receiver, undefined);
-assert.deepStrictEqual(args, [ 2, 3, 4 ]);
-
-ret = 6;
-assert.equal(binding.function.callWithReceiverAndArgs(testFunction, obj, 3, 4, 5), 6);
-assert.deepStrictEqual(receiver, obj);
-assert.deepStrictEqual(args, [ 3, 4, 5 ]);
-
-ret = 7;
-assert.equal(binding.function.callWithReceiverAndVector(testFunction, obj, 4, 5, 6), 7);
-assert.deepStrictEqual(receiver, obj);
-assert.deepStrictEqual(args, [ 4, 5, 6 ]);
-
-obj = binding.function.callConstructorWithArgs(testConstructor, 5, 6, 7);
-assert(obj instanceof testConstructor);
-assert.deepStrictEqual(args, [ 5, 6, 7 ]);
-
-obj = binding.function.callConstructorWithVector(testConstructor, 6, 7, 8);
-assert(obj instanceof testConstructor);
-assert.deepStrictEqual(args, [ 6, 7, 8 ]);
-
-obj = {};
-assert.deepStrictEqual(binding.function.voidCallbackWithData(obj), undefined);
-assert.deepStrictEqual(obj, { "foo": "bar", "data": 1 });
-
-assert.deepStrictEqual(binding.function.valueCallbackWithData(), { "foo": "bar", "data": 1 });
-
-assert.equal(binding.function.voidCallback.name, 'voidCallback');
-assert.equal(binding.function.valueCallback.name, 'valueCallback');
-
-// TODO: Function::MakeCallback tests

--- a/test/name.cc
+++ b/test/name.cc
@@ -14,7 +14,8 @@ Value EchoString(const CallbackInfo& info) {
   } else if (encoding.Utf8Value() == "utf16") {
     return String::New(info.Env(), value.Utf16Value().c_str());
   } else {
-    throw Error::New(info.Env(), "Invalid encoding.");
+    Error::New(info.Env(), "Invalid encoding.").ThrowAsJavaScriptException();
+    return Value();
   }
 }
 
@@ -35,7 +36,8 @@ Value CreateString(const CallbackInfo& info) {
       return String::New(info.Env(), testValueUtf16, length.Uint32Value());
     }
   } else {
-    throw Error::New(info.Env(), "Invalid encoding.");
+    Error::New(info.Env(), "Invalid encoding.").ThrowAsJavaScriptException();
+    return Value();
   }
 }
 
@@ -61,7 +63,8 @@ Value CheckString(const CallbackInfo& info) {
     std::u16string stringValue = value;
     return Boolean::New(info.Env(), stringValue == testValue);
   } else {
-    throw Error::New(info.Env(), "Invalid encoding.");
+    Error::New(info.Env(), "Invalid encoding.").ThrowAsJavaScriptException();
+    return Value();
   }
 }
 

--- a/test/name.js
+++ b/test/name.js
@@ -1,51 +1,55 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-const expected = '123456789';
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-assert.ok(binding.name.checkString(expected, 'utf8'));
-assert.ok(binding.name.checkString(expected, 'utf16'));
-assert.ok(binding.name.checkString(expected.substr(0, 3), 'utf8', 3));
-assert.ok(binding.name.checkString(expected.substr(0, 3), 'utf16', 3));
+function test(binding) {
+  const expected = '123456789';
 
-const str1 = binding.name.createString('utf8');
-assert.strictEqual(str1, expected);
-assert.ok(binding.name.checkString(str1, 'utf8'));
-assert.ok(binding.name.checkString(str1, 'utf16'));
+  assert.ok(binding.name.checkString(expected, 'utf8'));
+  assert.ok(binding.name.checkString(expected, 'utf16'));
+  assert.ok(binding.name.checkString(expected.substr(0, 3), 'utf8', 3));
+  assert.ok(binding.name.checkString(expected.substr(0, 3), 'utf16', 3));
 
-const substr1 = binding.name.createString('utf8', 3);
-assert.strictEqual(substr1, expected.substr(0, 3));
-assert.ok(binding.name.checkString(substr1, 'utf8', 3));
-assert.ok(binding.name.checkString(substr1, 'utf16', 3));
+  const str1 = binding.name.createString('utf8');
+  assert.strictEqual(str1, expected);
+  assert.ok(binding.name.checkString(str1, 'utf8'));
+  assert.ok(binding.name.checkString(str1, 'utf16'));
 
-const str2 = binding.name.createString('utf16');
-assert.strictEqual(str1, expected);
-assert.ok(binding.name.checkString(str2, 'utf8'));
-assert.ok(binding.name.checkString(str2, 'utf16'));
+  const substr1 = binding.name.createString('utf8', 3);
+  assert.strictEqual(substr1, expected.substr(0, 3));
+  assert.ok(binding.name.checkString(substr1, 'utf8', 3));
+  assert.ok(binding.name.checkString(substr1, 'utf16', 3));
 
-const substr2 = binding.name.createString('utf16', 3);
-assert.strictEqual(substr1, expected.substr(0, 3));
-assert.ok(binding.name.checkString(substr2, 'utf8', 3));
-assert.ok(binding.name.checkString(substr2, 'utf16', 3));
+  const str2 = binding.name.createString('utf16');
+  assert.strictEqual(str1, expected);
+  assert.ok(binding.name.checkString(str2, 'utf8'));
+  assert.ok(binding.name.checkString(str2, 'utf16'));
 
-assert.ok(binding.name.checkSymbol(Symbol()));
-assert.ok(binding.name.checkSymbol(Symbol('test')));
+  const substr2 = binding.name.createString('utf16', 3);
+  assert.strictEqual(substr1, expected.substr(0, 3));
+  assert.ok(binding.name.checkString(substr2, 'utf8', 3));
+  assert.ok(binding.name.checkString(substr2, 'utf16', 3));
 
-const sym1 = binding.name.createSymbol();
-assert.strictEqual(typeof sym1, 'symbol');
-assert.ok(binding.name.checkSymbol(sym1));
+  assert.ok(binding.name.checkSymbol(Symbol()));
+  assert.ok(binding.name.checkSymbol(Symbol('test')));
 
-const sym2 = binding.name.createSymbol('test');
-assert.strictEqual(typeof sym2, 'symbol');
-assert.ok(binding.name.checkSymbol(sym1));
+  const sym1 = binding.name.createSymbol();
+  assert.strictEqual(typeof sym1, 'symbol');
+  assert.ok(binding.name.checkSymbol(sym1));
 
-// Check for off-by-one errors which might only appear for strings of certain sizes,
-// due to how std::string increments its capacity in chunks.
-const longString = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-for (let i = 10; i <= longString.length; i++) {
-   const str = longString.substr(0, i);
-   assert.strictEqual(binding.name.echoString(str, 'utf8'), str);
-   assert.strictEqual(binding.name.echoString(str, 'utf16'), str);
+  const sym2 = binding.name.createSymbol('test');
+  assert.strictEqual(typeof sym2, 'symbol');
+  assert.ok(binding.name.checkSymbol(sym1));
+
+  // Check for off-by-one errors which might only appear for strings of certain sizes,
+  // due to how std::string increments its capacity in chunks.
+  const longString = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  for (let i = 10; i <= longString.length; i++) {
+    const str = longString.substr(0, i);
+    assert.strictEqual(binding.name.echoString(str, 'utf8'), str);
+    assert.strictEqual(binding.name.echoString(str, 'utf16'), str);
+  }
 }

--- a/test/object.cc
+++ b/test/object.cc
@@ -70,11 +70,27 @@ void DefineValueProperty(const CallbackInfo& info) {
   obj.DefineProperty(PropertyDescriptor::Value(name, value));
 }
 
+Value GetProperty(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Name name = info[1].As<Name>();
+  Value value = obj.Get(name);
+  return value;
+}
+
+void SetProperty(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Name name = info[1].As<Name>();
+  Value value = info[2];
+  obj.Set(name, value);
+}
+
 Object InitObject(Env env) {
   Object exports = Object::New(env);
 
   exports["defineProperties"] = Function::New(env, DefineProperties);
   exports["defineValueProperty"] = Function::New(env, DefineValueProperty);
+  exports["getProperty"] = Function::New(env, GetProperty);
+  exports["setProperty"] = Function::New(env, SetProperty);
 
   return exports;
 }

--- a/test/object.js
+++ b/test/object.js
@@ -1,69 +1,91 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-function assertPropertyIs(obj, key, attribute) {
-   const propDesc = Object.getOwnPropertyDescriptor(obj, key);
-   assert.ok(propDesc);
-   assert.ok(propDesc[attribute]);
-}
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-function assertPropertyIsNot(obj, key, attribute) {
-   const propDesc = Object.getOwnPropertyDescriptor(obj, key);
-   assert.ok(propDesc);
-   assert.ok(!propDesc[attribute]);
-}
+function test(binding) {
+  function assertPropertyIs(obj, key, attribute) {
+    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+    assert.ok(propDesc);
+    assert.ok(propDesc[attribute]);
+  }
 
-function testDefineProperties(nameType) {
-  const obj = {};
-  binding.object.defineProperties(obj, nameType);
+  function assertPropertyIsNot(obj, key, attribute) {
+    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+    assert.ok(propDesc);
+    assert.ok(!propDesc[attribute]);
+  }
 
-  assertPropertyIsNot(obj, 'readonlyAccessor', 'enumerable');
-  assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
-  assert.strictEqual(obj.readonlyAccessor, true);
+  function testDefineProperties(nameType) {
+    const obj = {};
+    binding.object.defineProperties(obj, nameType);
 
-  assertPropertyIsNot(obj, 'readwriteAccessor', 'enumerable');
-  assertPropertyIsNot(obj, 'readwriteAccessor', 'configurable');
-  obj.readwriteAccessor = false;
-  assert.strictEqual(obj.readwriteAccessor, false);
-  obj.readwriteAccessor = true;
-  assert.strictEqual(obj.readwriteAccessor, true);
+    assertPropertyIsNot(obj, 'readonlyAccessor', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
+    assert.strictEqual(obj.readonlyAccessor, true);
 
-  assertPropertyIsNot(obj, 'readonlyValue', 'writable');
-  assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');
-  assertPropertyIsNot(obj, 'readonlyValue', 'configurable');
-  assert.strictEqual(obj.readonlyValue, true);
+    assertPropertyIsNot(obj, 'readwriteAccessor', 'enumerable');
+    assertPropertyIsNot(obj, 'readwriteAccessor', 'configurable');
+    obj.readwriteAccessor = false;
+    assert.strictEqual(obj.readwriteAccessor, false);
+    obj.readwriteAccessor = true;
+    assert.strictEqual(obj.readwriteAccessor, true);
 
-  assertPropertyIs(obj, 'readwriteValue', 'writable');
-  assertPropertyIsNot(obj, 'readwriteValue', 'enumerable');
-  assertPropertyIsNot(obj, 'readwriteValue', 'configurable');
-  obj.readwriteValue = false;
-  assert.strictEqual(obj.readwriteValue, false);
-  obj.readwriteValue = true;
-  assert.strictEqual(obj.readwriteValue, true);
+    assertPropertyIsNot(obj, 'readonlyValue', 'writable');
+    assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyValue', 'configurable');
+    assert.strictEqual(obj.readonlyValue, true);
 
-  assertPropertyIsNot(obj, 'enumerableValue', 'writable');
-  assertPropertyIs(obj, 'enumerableValue', 'enumerable');
-  assertPropertyIsNot(obj, 'enumerableValue', 'configurable');
+    assertPropertyIs(obj, 'readwriteValue', 'writable');
+    assertPropertyIsNot(obj, 'readwriteValue', 'enumerable');
+    assertPropertyIsNot(obj, 'readwriteValue', 'configurable');
+    obj.readwriteValue = false;
+    assert.strictEqual(obj.readwriteValue, false);
+    obj.readwriteValue = true;
+    assert.strictEqual(obj.readwriteValue, true);
 
-  assertPropertyIsNot(obj, 'configurableValue', 'writable');
-  assertPropertyIsNot(obj, 'configurableValue', 'enumerable');
-  assertPropertyIs(obj, 'configurableValue', 'configurable');
+    assertPropertyIsNot(obj, 'enumerableValue', 'writable');
+    assertPropertyIs(obj, 'enumerableValue', 'enumerable');
+    assertPropertyIsNot(obj, 'enumerableValue', 'configurable');
 
-  assertPropertyIsNot(obj, 'function', 'writable');
-  assertPropertyIsNot(obj, 'function', 'enumerable');
-  assertPropertyIsNot(obj, 'function', 'configurable');
-  assert.strictEqual(obj.function(), true);
-}
+    assertPropertyIsNot(obj, 'configurableValue', 'writable');
+    assertPropertyIsNot(obj, 'configurableValue', 'enumerable');
+    assertPropertyIs(obj, 'configurableValue', 'configurable');
 
-testDefineProperties('literal');
-testDefineProperties('string');
-testDefineProperties('value');
+    assertPropertyIsNot(obj, 'function', 'writable');
+    assertPropertyIsNot(obj, 'function', 'enumerable');
+    assertPropertyIsNot(obj, 'function', 'configurable');
+    assert.strictEqual(obj.function(), true);
+  }
 
-{
-  const obj = {};
-  const testSym = Symbol();
-  binding.object.defineValueProperty(obj, testSym, 1);
-  assert.strictEqual(obj[testSym], 1);
+  testDefineProperties('literal');
+  testDefineProperties('string');
+  testDefineProperties('value');
+
+  {
+    const obj = {};
+    const testSym = Symbol();
+    binding.object.defineValueProperty(obj, testSym, 1);
+    assert.strictEqual(obj[testSym], 1);
+  }
+
+  {
+    const obj = { test: 1 };
+    assert.strictEqual(binding.object.getProperty(obj, 'test'), 1);
+  }
+
+  {
+    const obj = {};
+    binding.object.setProperty(obj, 'test', 1);
+    assert.strictEqual(obj.test, 1);
+  }
+
+  assert.throws(() => {
+    binding.object.getProperty(undefined, 'test');
+  }, /object was expected/);
+  assert.throws(() => {
+    binding.object.setProperty(undefined, 'test', 1);
+  }, /object was expected/);
 }

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -38,8 +38,13 @@ Value CreateTypedArray(const CallbackInfo& info) {
     return buffer.IsUndefined() ? Float64Array::New(info.Env(), length)
       : Float64Array::New(info.Env(), length, buffer, bufferOffset);
   } else {
-    throw Error::New(info.Env(), "Invalid typed-array type.");
+    Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+    return Value();
   }
+}
+
+Value CreateInvalidTypedArray(const CallbackInfo& info) {
+  return Int8Array::New(info.Env(), 1, ArrayBuffer(), 0);
 }
 
 Value GetTypedArrayType(const CallbackInfo& info) {
@@ -90,7 +95,9 @@ Value GetTypedArrayElement(const CallbackInfo& info) {
       return Number::New(info.Env(), array.As<Float32Array>()[index]);
     case napi_float64_array:
       return Number::New(info.Env(), array.As<Float64Array>()[index]);
-    default: throw Error::New(info.Env(), "Invalid typed-array type.");
+    default:
+      Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+      return Value();
   }
 }
 
@@ -127,7 +134,7 @@ void SetTypedArrayElement(const CallbackInfo& info) {
       array.As<Float64Array>()[index] = value.DoubleValue();
       break;
     default:
-      throw Error::New(info.Env(), "Invalid typed-array type.");
+      Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
   }
 }
 
@@ -137,6 +144,7 @@ Object InitTypedArray(Env env) {
   Object exports = Object::New(env);
 
   exports["createTypedArray"] = Function::New(env, CreateTypedArray);
+  exports["createInvalidTypedArray"] = Function::New(env, CreateInvalidTypedArray);
   exports["getTypedArrayType"] = Function::New(env, GetTypedArrayType);
   exports["getTypedArrayLength"] = Function::New(env, GetTypedArrayLength);
   exports["getTypedArrayBuffer"] = Function::New(env, GetTypedArrayBuffer);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -1,22 +1,25 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
-const binding = require(`./build/${buildType}/binding.node`);
 const assert = require('assert');
 
-const testData = [
-   [ 'int8', Int8Array ],
-   [ 'uint8', Uint8Array ],
-   [ 'uint8_clamped', Uint8ClampedArray ],
-   [ 'int16', Int16Array ],
-   [ 'uint16', Uint16Array ],
-   [ 'int32', Int32Array ],
-   [ 'uint32', Uint32Array ],
-   [ 'float32', Float32Array ],
-   [ 'float64', Float64Array ],
-];
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
 
-testData.forEach(data => {
-   try {
+function test(binding) {
+  const testData = [
+    [ 'int8', Int8Array ],
+    [ 'uint8', Uint8Array ],
+    [ 'uint8_clamped', Uint8ClampedArray ],
+    [ 'int16', Int16Array ],
+    [ 'uint16', Uint16Array ],
+    [ 'int32', Int32Array ],
+    [ 'uint32', Uint32Array ],
+    [ 'float32', Float32Array ],
+    [ 'float64', Float64Array ],
+  ];
+
+  testData.forEach(data => {
+    try {
       const length = 4;
       const t = binding.typedarray.createTypedArray(data[0], length);
       assert.ok(t instanceof data[1]);
@@ -31,14 +34,14 @@ testData.forEach(data => {
 
       const b = binding.typedarray.getTypedArrayBuffer(t);
       assert.ok(b instanceof ArrayBuffer);
-   } catch (e) {
+    } catch (e) {
       console.log(data);
       throw e;
-   }
-});
+    }
+  });
 
-testData.forEach(data => {
-   try {
+  testData.forEach(data => {
+    try {
       const length = 4;
       const offset = 8;
       const b = new ArrayBuffer(offset + 64 * 4);
@@ -55,8 +58,13 @@ testData.forEach(data => {
       assert.strictEqual(t[3], 22);
 
       assert.strictEqual(binding.typedarray.getTypedArrayBuffer(t), b);
-   } catch (e) {
+    } catch (e) {
       console.log(data);
       throw e;
-   }
-});
+    }
+  });
+
+  assert.throws(() => {
+    binding.typedarray.createInvalidTypedArray();
+  }, /Invalid pointer/);
+}


### PR DESCRIPTION
Enable using the N-API C++ wrapper classes with or without C++ exceptions. See the updated `Napi::Error` class documentation for an overview of the developer experience.

 - Add a `NAPI_CPP_EXCEPTIONS` preprocessor symbol that is defined when C++ exceptions are enabled.
 - Add `Env::GetAndClearPendingException()` method.
 - Add `Value::IsEmpty()` method.
 - Update documentation on `Error` class to provide parallel explanation and examples for error-handling without C++ exceptions.
 - Update README to mention optional C++ exception support.
 - Define a `NAPI_THROW_IF_FAILED()` macro that throws either a C++ or JS exception depending on whether `NAPI_CPP_EXCEPTIONS` is defined.
 - Define a `details::WrapCallback()` helper function that catches C++ exceptions thrown from callbacks, only if `NAPI_CPP_EXCEPTIONS` is defined.
 - Update implementation of all methods to use `NAPI_THROW_IF_FAILED()` and `details::WrapCallback()` as appropriate.
 - Fix a bug in `Error::New()` when there was a pending exception but some different error status was reported by the last error info.
 - Update `test/binding.gyp` to build two separate modules, with and without C++ exceptions enabled.
 - Update test JS code to run the same tests against both modules.
 - Update test C++ code to throw JS exceptions (to be compatible with both modes).
 - Add some additional test cases to verify expected exceptions are observed from JS regardless of whether C++ exceptions are enabled or not.
 - Change CI config to ignore failures on nightly builds.