### PR TITLE
Add more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use N-API in a native module:
   1. Add a dependency on this package to `package.json`:
 ```json
   "dependencies": {
-    "node-addon-api": "0.2.0",
+    "node-addon-api": "0.3.3",
   }
 ```
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = N-API
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.1.0
+PROJECT_NUMBER         = 0.3.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "C++ wrapper classes for the ABI-stable C APIs for Node
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = 
+PROJECT_LOGO           =
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -162,7 +162,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        =
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -171,7 +171,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_INC_PATH    =
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -238,13 +238,13 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = 
+ALIASES                =
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              = 
+TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -291,7 +291,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      = 
+EXTENSION_MAPPING      =
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -648,7 +648,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the
@@ -690,7 +690,7 @@ SHOW_NAMESPACES        = YES
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.
 
-FILE_VERSION_FILTER    = 
+FILE_VERSION_FILTER    =
 
 # The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
 # by doxygen. The layout file controls the global structure of the generated
@@ -703,7 +703,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            = 
+LAYOUT_FILE            =
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
@@ -713,7 +713,7 @@ LAYOUT_FILE            =
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
 # search path. See also \cite for info how to create references.
 
-CITE_BIB_FILES         = 
+CITE_BIB_FILES         =
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -778,7 +778,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -831,7 +831,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -847,7 +847,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = 
+EXCLUDE_PATTERNS       =
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -858,13 +858,13 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = 
+EXAMPLE_PATH           =
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -884,7 +884,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = 
+IMAGE_PATH             =
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -905,7 +905,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           = 
+INPUT_FILTER           =
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -918,7 +918,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        = 
+FILTER_PATTERNS        =
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for
@@ -933,7 +933,7 @@ FILTER_SOURCE_FILES    = NO
 # *.ext= (so without naming a filter).
 # This tag requires that the tag FILTER_SOURCE_FILES is set to YES.
 
-FILTER_SOURCE_PATTERNS = 
+FILTER_SOURCE_PATTERNS =
 
 # If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
 # is part of the input, its contents will be placed on the main page
@@ -1045,7 +1045,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          = 
+CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1071,7 +1071,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -1115,7 +1115,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            = 
+HTML_HEADER            =
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1125,7 +1125,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            = 
+HTML_FOOTER            =
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1137,7 +1137,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        = 
+HTML_STYLESHEET        =
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1150,7 +1150,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = 
+HTML_EXTRA_STYLESHEET  =
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note
@@ -1160,7 +1160,7 @@ HTML_EXTRA_STYLESHEET  =
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = 
+HTML_EXTRA_FILES       =
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
@@ -1289,7 +1289,7 @@ GENERATE_HTMLHELP      = NO
 # written to the html output directory.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_FILE               = 
+CHM_FILE               =
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
 # including file name) of the HTML help compiler (hhc.exe). If non-empty,
@@ -1297,7 +1297,7 @@ CHM_FILE               =
 # The file has to be specified with full path.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-HHC_LOCATION           = 
+HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
 # (YES) or that it should be included in the master .chm file (NO).
@@ -1310,7 +1310,7 @@ GENERATE_CHI           = NO
 # and project file content.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 
 # The BINARY_TOC flag controls whether a binary table of contents is generated
 # (YES) or a normal table of contents (NO) in the .chm file. Furthermore it
@@ -1341,7 +1341,7 @@ GENERATE_QHP           = NO
 # the HTML output folder.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QCH_FILE               = 
+QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
@@ -1366,7 +1366,7 @@ QHP_VIRTUAL_FOLDER     = doc
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_NAME   = 
+QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
@@ -1374,21 +1374,21 @@ QHP_CUST_FILTER_NAME   =
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_ATTRS  = 
+QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
 # http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_SECT_FILTER_ATTRS  = 
+QHP_SECT_FILTER_ATTRS  =
 
 # The QHG_LOCATION tag can be used to specify the location of Qt's
 # qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
 # generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHG_LOCATION           = 
+QHG_LOCATION           =
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To
@@ -1521,7 +1521,7 @@ MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     = 
+MATHJAX_EXTENSIONS     =
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
@@ -1529,7 +1529,7 @@ MATHJAX_EXTENSIONS     =
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_CODEFILE       = 
+MATHJAX_CODEFILE       =
 
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box for
 # the HTML output. The underlying search engine uses javascript and DHTML and
@@ -1589,7 +1589,7 @@ EXTERNAL_SEARCH        = NO
 # Searching" for details.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-SEARCHENGINE_URL       = 
+SEARCHENGINE_URL       =
 
 # When SERVER_BASED_SEARCH and EXTERNAL_SEARCH are both enabled the unindexed
 # search data is written to a file for indexing by an external tool. With the
@@ -1605,7 +1605,7 @@ SEARCHDATA_FILE        = searchdata.xml
 # projects and redirect the results back to the right project.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTERNAL_SEARCH_ID     = 
+EXTERNAL_SEARCH_ID     =
 
 # The EXTRA_SEARCH_MAPPINGS tag can be used to enable searching through doxygen
 # projects other than the one defined by this configuration file, but that are
@@ -1615,7 +1615,7 @@ EXTERNAL_SEARCH_ID     =
 # EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTRA_SEARCH_MAPPINGS  = 
+EXTRA_SEARCH_MAPPINGS  =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
@@ -1679,7 +1679,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = 
+EXTRA_PACKAGES         =
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1695,7 +1695,7 @@ EXTRA_PACKAGES         =
 # to HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_HEADER           = 
+LATEX_HEADER           =
 
 # The LATEX_FOOTER tag can be used to specify a personal LaTeX footer for the
 # generated LaTeX document. The footer should contain everything after the last
@@ -1706,7 +1706,7 @@ LATEX_HEADER           =
 # Note: Only use a user-defined footer if you know what you are doing!
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_FOOTER           = 
+LATEX_FOOTER           =
 
 # The LATEX_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # LaTeX style sheets that are included after the standard style sheets created
@@ -1717,7 +1717,7 @@ LATEX_FOOTER           =
 # list).
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_STYLESHEET = 
+LATEX_EXTRA_STYLESHEET =
 
 # The LATEX_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the LATEX_OUTPUT output
@@ -1725,7 +1725,7 @@ LATEX_EXTRA_STYLESHEET =
 # markers available.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_FILES      = 
+LATEX_EXTRA_FILES      =
 
 # If the PDF_HYPERLINKS tag is set to YES, the LaTeX that is generated is
 # prepared for conversion to PDF (using ps2pdf or pdflatex). The PDF file will
@@ -1833,14 +1833,14 @@ RTF_HYPERLINKS         = NO
 # default style sheet that doxygen normally uses.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_STYLESHEET_FILE    = 
+RTF_STYLESHEET_FILE    =
 
 # Set optional variables used in the generation of an RTF document. Syntax is
 # similar to doxygen's config file. A template extensions file can be generated
 # using doxygen -e rtf extensionFile.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_EXTENSIONS_FILE    = 
+RTF_EXTENSIONS_FILE    =
 
 # If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
 # with syntax highlighting in the RTF output.
@@ -1885,7 +1885,7 @@ MAN_EXTENSION          = .3
 # MAN_EXTENSION with the initial . removed.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_SUBDIR             = 
+MAN_SUBDIR             =
 
 # If the MAN_LINKS tag is set to YES and doxygen generates man output, then it
 # will generate one additional man file for each entity documented in the real
@@ -1998,7 +1998,7 @@ PERLMOD_PRETTY         = YES
 # overwrite each other's variables.
 # This tag requires that the tag GENERATE_PERLMOD is set to YES.
 
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
@@ -2039,7 +2039,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           =
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2047,7 +2047,7 @@ INCLUDE_PATH           =
 # used.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_FILE_PATTERNS  =
 
 # The PREDEFINED tag can be used to specify one or more macro names that are
 # defined before the preprocessor is started (similar to the -D option of e.g.
@@ -2057,7 +2057,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             =
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2066,7 +2066,7 @@ PREDEFINED             =
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = 
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2095,13 +2095,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = 
+TAGFILES               =
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       =
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be
@@ -2150,14 +2150,14 @@ CLASS_DIAGRAMS         = YES
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
 
-MSCGEN_PATH            = 
+MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
 # If left empty dia is assumed to be found in the default search path.
 
-DIA_PATH               = 
+DIA_PATH               =
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2206,7 +2206,7 @@ DOT_FONTSIZE           = 10
 # the path where dot can find it using this tag.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTPATH           = 
+DOT_FONTPATH           =
 
 # If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
 # each documented class showing the direct and indirect inheritance relations.
@@ -2350,26 +2350,26 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = 
+DOT_PATH               =
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile
 # command).
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOTFILE_DIRS           = 
+DOTFILE_DIRS           =
 
 # The MSCFILE_DIRS tag can be used to specify one or more directories that
 # contain msc files that are included in the documentation (see the \mscfile
 # command).
 
-MSCFILE_DIRS           = 
+MSCFILE_DIRS           =
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
 # command).
 
-DIAFILE_DIRS           = 
+DIAFILE_DIRS           =
 
 # When using plantuml, the PLANTUML_JAR_PATH tag should be used to specify the
 # path where java can find the plantuml.jar file. If left blank, it is assumed
@@ -2377,17 +2377,17 @@ DIAFILE_DIRS           =
 # generate a warning when it encounters a \startuml command in this case and
 # will not generate output for the diagram.
 
-PLANTUML_JAR_PATH      = 
+PLANTUML_JAR_PATH      =
 
 # When using plantuml, the PLANTUML_CFG_FILE tag can be used to specify a
 # configuration file for plantuml.
 
-PLANTUML_CFG_FILE      = 
+PLANTUML_CFG_FILE      =
 
 # When using plantuml, the specified paths are searched for files specified by
 # the !include statement in a plantuml block.
 
-PLANTUML_INCLUDE_PATH  = 
+PLANTUML_INCLUDE_PATH  =
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -603,19 +603,19 @@ inline Symbol::Symbol(napi_env env, napi_value value) : Name(env, value) {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename Key>
-inline PropertyLValue<Key>::operator Value() const {
-  return _object.Get(_key);
+inline Object::PropertyLValue<Key>::operator Value() const {
+  return Object(_env, _object).Get(_key);
 }
 
 template <typename Key> template <typename ValueType>
-inline PropertyLValue<Key>& PropertyLValue<Key>::operator =(ValueType value) {
-  _object.Set(_key, value);
+inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(ValueType value) {
+  Object(_env, _object).Set(_key, value);
   return *this;
 }
 
 template <typename Key>
-inline PropertyLValue<Key>::PropertyLValue(Object object, Key key)
-  : _object(object), _key(key) {}
+inline Object::PropertyLValue<Key>::PropertyLValue(Object object, Key key)
+  : _env(object.Env()), _object(object), _key(key) {}
 
 inline Object Object::New(napi_env env) {
   napi_value value;
@@ -630,40 +630,40 @@ inline Object::Object() : Value() {
 inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
 }
 
-inline PropertyLValue<std::string> Object::operator [](const char* name) {
-  return PropertyLValue<std::string>(*this, name);
+inline Object::PropertyLValue<std::string> Object::operator [](const char* utf8name) {
+  return PropertyLValue<std::string>(*this, utf8name);
 }
 
-inline PropertyLValue<std::string> Object::operator [](const std::string& name) {
-  return PropertyLValue<std::string>(*this, name);
+inline Object::PropertyLValue<std::string> Object::operator [](const std::string& utf8name) {
+  return PropertyLValue<std::string>(*this, utf8name);
 }
 
-inline PropertyLValue<uint32_t> Object::operator [](uint32_t index) {
+inline Object::PropertyLValue<uint32_t> Object::operator [](uint32_t index) {
   return PropertyLValue<uint32_t>(*this, index);
 }
 
-inline Value Object::operator [](const char* name) const {
-  return Get(name);
+inline Value Object::operator [](const char* utf8name) const {
+  return Get(utf8name);
 }
 
-inline Value Object::operator [](const std::string& name) const {
-  return Get(name);
+inline Value Object::operator [](const std::string& utf8name) const {
+  return Get(utf8name);
 }
 
 inline Value Object::operator [](uint32_t index) const {
   return Get(index);
 }
 
-inline bool Object::Has(napi_value name) const {
+inline bool Object::Has(napi_value key) const {
   bool result;
-  napi_status status = napi_has_property(_env, _value, name, &result);
+  napi_status status = napi_has_property(_env, _value, key, &result);
   NAPI_THROW_IF_FAILED(_env, status, false);
   return result;
 }
 
-inline bool Object::Has(Value name) const {
+inline bool Object::Has(Value key) const {
   bool result;
-  napi_status status = napi_has_property(_env, _value, name, &result);
+  napi_status status = napi_has_property(_env, _value, key, &result);
   NAPI_THROW_IF_FAILED(_env, status, false);
   return result;
 }
@@ -679,16 +679,16 @@ inline bool Object::Has(const std::string& utf8name) const {
   return Has(utf8name.c_str());
 }
 
-inline Value Object::Get(napi_value name) const {
+inline Value Object::Get(napi_value key) const {
   napi_value result;
-  napi_status status = napi_get_property(_env, _value, name, &result);
+  napi_status status = napi_get_property(_env, _value, key, &result);
   NAPI_THROW_IF_FAILED(_env, status, Value());
   return Value(_env, result);
 }
 
-inline Value Object::Get(Value name) const {
+inline Value Object::Get(Value key) const {
   napi_value result;
-  napi_status status = napi_get_property(_env, _value, name, &result);
+  napi_status status = napi_get_property(_env, _value, key, &result);
   NAPI_THROW_IF_FAILED(_env, status, Value());
   return Value(_env, result);
 }
@@ -704,8 +704,13 @@ inline Value Object::Get(const std::string& utf8name) const {
   return Get(utf8name.c_str());
 }
 
-inline void Object::Set(napi_value name, napi_value value) {
-  napi_status status = napi_set_property(_env, _value, name, value);
+inline void Object::Set(napi_value key, napi_value value) {
+  napi_status status = napi_set_property(_env, _value, key, value);
+  NAPI_THROW_IF_FAILED(_env, status);
+}
+
+inline void Object::Set(Value key, Value value) {
+  napi_status status = napi_set_property(_env, _value, key, value);
   NAPI_THROW_IF_FAILED(_env, status);
 }
 

--- a/napi.h
+++ b/napi.h
@@ -47,7 +47,6 @@ namespace Napi {
   class PropertyDescriptor;
   class CallbackInfo;
   template <typename T> class Reference;
-  template <typename Key> class PropertyLValue;
   class TypedArray;
   template <typename T> class TypedArrayOf;
 
@@ -104,7 +103,7 @@ namespace Napi {
   ///     bool isTruthy = anotherValue.ToBoolean(); // Coerce to a boolean value
   class Value {
   public:
-    Value(); ///< Creates a new _empty_ Value instance.
+    Value();                               ///< Creates a new _empty_ Value instance.
     Value(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
     /// Converts to a N-API value primitive.
@@ -168,42 +167,49 @@ namespace Napi {
     /// !endcond
   };
 
+  /// A JavaScript boolean value.
   class Boolean : public Value {
   public:
-    static Boolean New(napi_env env, bool val);
+    static Boolean New(
+      napi_env env, ///< N-API environment
+      bool value    ///< Boolean value
+    );
 
-    Boolean();
-    Boolean(napi_env env, napi_value value);
+    Boolean();                               ///< Creates a new _empty_ Boolean instance.
+    Boolean(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
-    operator bool() const;
-
-    bool Value() const;
+    operator bool() const; ///< Converts a Boolean value to a boolean primitive.
+    bool Value() const;    ///< Converts a Boolean value to a boolean primitive.
   };
 
+  /// A JavaScript number value.
   class Number : public Value {
   public:
-    static Number New(napi_env env, double val);
+    static Number New(
+      napi_env env, ///< N-API environment
+      double value  ///< Number value
+    );
 
-    Number();
-    Number(napi_env env, napi_value value);
+    Number();                               ///< Creates a new _empty_ Number instance.
+    Number(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
-    operator int32_t() const;
-    operator uint32_t() const;
-    operator int64_t() const;
-    operator float() const;
-    operator double() const;
+    operator int32_t() const;  ///< Converts a Number value to a 32-bit signed integer value.
+    operator uint32_t() const; ///< Converts a Number value to a 32-bit unsigned integer value.
+    operator int64_t() const;  ///< Converts a Number value to a 64-bit signed integer value.
+    operator float() const;    ///< Converts a Number value to a 32-bit floating-point value.
+    operator double() const;   ///< Converts a Number value to a 64-bit floating-point value.
 
-    int32_t Int32Value() const;
-    uint32_t Uint32Value() const;
-    int64_t Int64Value() const;
-    float FloatValue() const;
-    double DoubleValue() const;
+    int32_t Int32Value() const;   ///< Converts a Number value to a 32-bit signed integer value.
+    uint32_t Uint32Value() const; ///< Converts a Number value to a 32-bit unsigned integer value.
+    int64_t Int64Value() const;   ///< Converts a Number value to a 64-bit signed integer value.
+    float FloatValue() const;     ///< Converts a Number value to a 32-bit floating-point value.
+    double DoubleValue() const;   ///< Converts a Number value to a 64-bit floating-point value.
   };
 
   /// A JavaScript string or symbol value (that can be used as a property name).
   class Name : public Value {
   public:
-    Name(); ///< Creates a new _empty_ Name instance.
+    Name();                               ///< Creates a new _empty_ Name instance.
     Name(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
   };
 
@@ -248,7 +254,7 @@ namespace Napi {
       size_t length          ///< Length of the string in 2-byte code units
     );
 
-    String(); ///< Creates a new _empty_ String instance.
+    String();                               ///< Creates a new _empty_ String instance.
     String(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
     operator std::string() const;      ///< Converts a String value to a UTF-8 encoded C++ string.
@@ -257,82 +263,289 @@ namespace Napi {
     std::u16string Utf16Value() const; ///< Converts a String value to a UTF-16 encoded C++ string.
   };
 
+  /// A JavaScript symbol value.
   class Symbol : public Name {
   public:
-    static Symbol New(napi_env env, const char* description = nullptr);
-    static Symbol New(napi_env env, const std::string& description);
-    static Symbol New(napi_env env, String description);
-    static Symbol New(napi_env env, napi_value description);
+    /// Creates a new Symbol value with an optional description.
+    static Symbol New(
+      napi_env env,                     ///< N-API environment
+      const char* description = nullptr ///< Optional UTF-8 encoded null-terminated C string
+                                        ///  describing the symbol
+    );
 
-    Symbol();
-    Symbol(napi_env env, napi_value value);
+    /// Creates a new Symbol value with a description.
+    static Symbol New(
+      napi_env env,                  ///< N-API environment
+      const std::string& description ///< UTF-8 encoded C++ string describing the symbol
+    );
+
+    /// Creates a new Symbol value with a description.
+    static Symbol New(
+      napi_env env,      ///< N-API environment
+      String description ///< String value describing the symbol
+    );
+
+    /// Creates a new Symbol value with a description.
+    static Symbol New(
+      napi_env env,          ///< N-API environment
+      napi_value description ///< String value describing the symbol
+    );
+
+    Symbol();                               ///< Creates a new _empty_ Symbol instance.
+    Symbol(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
   };
 
+  /// A JavaScript object value.
   class Object : public Value {
   public:
-    static Object New(napi_env env);
+    /// Enables property and element assignments using indexing syntax.
+    ///
+    /// Example:
+    ///
+    ///     Napi::Value propertyValue = object1['A'];
+    ///     object2['A'] = propertyValue;
+    ///     Napi::Value elementValue = array[0];
+    ///     array[1] = elementValue;
+    template <typename Key>
+    class PropertyLValue {
+    public:
+      /// Converts an L-value to a value.
+      operator Value() const;
 
-    Object();
-    Object(napi_env env, napi_value value);
+      /// Assigns a value to the property. The type of value can be
+      /// anything supported by `Object::Set`.
+      template <typename ValueType>
+      PropertyLValue& operator =(ValueType value);
 
-    PropertyLValue<std::string> operator [](const char* name);
-    PropertyLValue<std::string> operator [](const std::string& name);
-    PropertyLValue<uint32_t> operator [](uint32_t index);
+    private:
+      PropertyLValue() = delete;
+      PropertyLValue(Object object, Key key);
+      napi_env _env;
+      napi_value _object;
+      Key _key;
 
-    Value operator [](const char* name) const;
-    Value operator [](const std::string& name) const;
-    Value operator [](uint32_t index) const;
+      friend class Napi::Object;
+    };
 
-    bool Has(napi_value name) const;
-    bool Has(Value name) const;
-    bool Has(const char* utf8name) const;
-    bool Has(const std::string& utf8name) const;
-    Value Get(napi_value name) const;
-    Value Get(Value name) const;
-    Value Get(const char* utf8name) const;
-    Value Get(const std::string& utf8name) const;
-    void Set(napi_value name, napi_value value);
-    void Set(const char* utf8name, napi_value value);
-    void Set(const char* utf8name, Value value);
-    void Set(const char* utf8name, const char* utf8value);
-    void Set(const char* utf8name, bool boolValue);
-    void Set(const char* utf8name, double numberValue);
-    void Set(const std::string& utf8name, napi_value value);
-    void Set(const std::string& utf8name, Value value);
-    void Set(const std::string& utf8name, std::string& utf8value);
-    void Set(const std::string& utf8name, bool boolValue);
-    void Set(const std::string& utf8name, double numberValue);
+    /// Creates a new Object value.
+    static Object New(
+      napi_env env ///< N-API environment
+    );
 
-    bool Has(uint32_t index) const;
-    Value Get(uint32_t index) const;
-    void Set(uint32_t index, napi_value value);
-    void Set(uint32_t index, Value value);
-    void Set(uint32_t index, const char* utf8value);
-    void Set(uint32_t index, const std::string& utf8value);
-    void Set(uint32_t index, bool boolValue);
-    void Set(uint32_t index, double numberValue);
+    Object();                               ///< Creates a new _empty_ Object instance.
+    Object(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
-    void DefineProperty(const PropertyDescriptor& property);
-    void DefineProperties(const std::initializer_list<PropertyDescriptor>& properties);
-    void DefineProperties(const std::vector<PropertyDescriptor>& properties);
-    bool InstanceOf(const Function& constructor) const;
-  };
+    /// Gets or sets a named property.
+    PropertyLValue<std::string> operator [](
+      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    );
 
-  template <typename Key>
-  class PropertyLValue {
-  public:
-    operator Value() const;
+    /// Gets or sets a named property.
+    PropertyLValue<std::string> operator [](
+      const std::string& utf8name ///< UTF-8 encoded property name
+    );
 
-    // |ValueType| can be anything supported by Object::Set.
-    template <typename ValueType>
-    PropertyLValue& operator =(ValueType value);
-    PropertyLValue() = delete;
-  private:
-    PropertyLValue(Object object, Key key);
-    Object _object;
-    Key _key;
+    /// Gets or sets an indexed property or array element.
+    PropertyLValue<uint32_t> operator [](
+      uint32_t index /// Property / element index
+    );
 
-    friend class Napi::Object;
+    /// Gets a named property.
+    Value operator [](
+      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    ) const;
+
+    /// Gets a named property.
+    Value operator [](
+      const std::string& utf8name ///< UTF-8 encoded property name
+    ) const;
+
+    /// Gets an indexed property or array element.
+    Value operator [](
+      uint32_t index ///< Property / element index
+    ) const;
+
+    /// Checks whether a property is present.
+    bool Has(
+      napi_value key ///< Property key primitive
+    ) const;
+
+    /// Checks whether a property is present.
+    bool Has(
+      Value key ///< Property key
+    ) const;
+
+    /// Checks whether a named property is present.
+    bool Has(
+      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    ) const;
+
+    /// Checks whether a named property is present.
+    bool Has(
+      const std::string& utf8name ///< UTF-8 encoded property name
+    ) const;
+
+    /// Gets a property.
+    Value Get(
+      napi_value key ///< Property key primitive
+    ) const;
+
+    /// Gets a property.
+    Value Get(
+      Value key ///< Property key
+    ) const;
+
+    /// Gets a named property.
+    Value Get(
+      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    ) const;
+
+    /// Gets a named property.
+    Value Get(
+      const std::string& utf8name ///< UTF-8 encoded property name
+    ) const;
+
+    /// Sets a property.
+    void Set(
+      napi_value key,  ///< Property key primitive
+      napi_value value ///< Property value primitive
+    );
+
+    /// Sets a property.
+    void Set(
+      Value key,  ///< Property key
+      Value value ///< Property value
+    );
+
+    /// Sets a named property.
+    void Set(
+      const char* utf8name, ///< UTF-8 encoded null-terminated property name
+      napi_value value      ///< Property value primitive
+    );
+
+    /// Sets a named property.
+    void Set(
+      const char* utf8name, ///< UTF-8 encoded null-terminated property name
+      Value value           ///< Property value
+    );
+
+    /// Sets a named property to a string value.
+    void Set(
+      const char* utf8name, ///< UTF-8 encoded null-terminated property name
+      const char* utf8value ///< UTF-8 encoded null-terminated property value
+    );
+
+    /// Sets a named property to a boolean value.
+    void Set(
+      const char* utf8name, ///< UTF-8 encoded null-terminated property name
+      bool boolValue        ///< Property value
+    );
+
+    /// Sets a named property to a number value.
+    void Set(
+      const char* utf8name, ///< UTF-8 encoded null-terminated property name
+      double numberValue    ///< Property value
+    );
+
+    /// Sets a named property.
+    void Set(
+      const std::string& utf8name, ///< UTF-8 encoded property name
+      napi_value value             ///< Property value primitive
+    );
+
+    /// Sets a named property.
+    void Set(
+      const std::string& utf8name, ///< UTF-8 encoded property name
+      Value value                  ///< Property value
+    );
+
+    /// Sets a named property to a string value.
+    void Set(
+      const std::string& utf8name, ///< UTF-8 encoded property name
+      std::string& utf8value       ///< UTF-8 encoded property value
+    );
+
+    /// Sets a named property to a boolean value.
+    void Set(
+      const std::string& utf8name, ///< UTF-8 encoded property name
+      bool boolValue               ///< Property value
+    );
+
+    /// Sets a named property to a number value.
+    void Set(
+      const std::string& utf8name, ///< UTF-8 encoded property name
+      double numberValue           ///< Property value
+    );
+
+    /// Checks whether an indexed property is present.
+    bool Has(
+      uint32_t index ///< Property / element index
+    ) const;
+
+    /// Gets an indexed property or array element.
+    Value Get(
+      uint32_t index ///< Property / element index
+    ) const;
+
+    /// Sets an indexed property or array element.
+    void Set(
+      uint32_t index,  ///< Property / element index
+      napi_value value ///< Property value primitive
+    );
+
+    /// Sets an indexed property or array element.
+    void Set(
+      uint32_t index, ///< Property / element index
+      Value value     ///< Property value
+    );
+
+    /// Sets an indexed property or array element to a string value.
+    void Set(
+      uint32_t index,       ///< Property / element index
+      const char* utf8value ///< UTF-8 encoded null-terminated property value
+    );
+
+    /// Sets an indexed property or array element to a string value.
+    void Set(
+      uint32_t index,              ///< Property / element index
+      const std::string& utf8value ///< UTF-8 encoded property value
+    );
+
+    /// Sets an indexed property or array element to a boolean value.
+    void Set(
+      uint32_t index, ///< Property / element index
+      bool boolValue  ///< Property value
+    );
+
+    /// Sets an indexed property or array element to a number value.
+    void Set(
+      uint32_t index,    ///< Property / element index
+      double numberValue ///< Property value
+    );
+
+    /// Defines a property on the object.
+    void DefineProperty(
+      const PropertyDescriptor& property ///< Descriptor for the property to be defined
+    );
+
+    /// Defines properties on the object.
+    void DefineProperties(
+      const std::initializer_list<PropertyDescriptor>& properties
+        ///< List of descriptors for the properties to be defined
+    );
+
+    /// Defines properties on the object.
+    void DefineProperties(
+      const std::vector<PropertyDescriptor>& properties
+        ///< Vector of descriptors for the properties to be defined
+    );
+
+    /// Checks if an object is an instance created by a constructor function.
+    ///
+    /// This is equivalent to the JavaScript `instanceof` operator.
+    bool InstanceOf(
+      const Function& constructor ///< Constructor function
+    ) const;
   };
 
   template <typename T>
@@ -505,7 +718,7 @@ namespace Napi {
         ///< Type of array, if different from the default array type for the template parameter T.
     );
 
-    TypedArrayOf();                               ///< Creates a new _empty_ TypedArray instance.
+    TypedArrayOf();                               ///< Creates a new _empty_ TypedArrayOf instance.
     TypedArrayOf(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
     T& operator [](size_t index);             ///< Gets or sets an element in the array.

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "pretest": "node-gyp rebuild -C test",
     "test": "node test"
   },
-  "version": "0.3.2"
+  "version": "0.3.3"
 }


### PR DESCRIPTION
 - Add doc-comments to the `Boolean`, `Number`, `Symbol`, `Object`,
   and `PropertyLValue` classes.
 - Make `PropertyLValue` a nested class inside `Object`, because it
   is only ever used by `Object` and would almost never be referenced
   explicitly.
 - Make some `Object` method parameter names more consistent.
 - Add missing `Object::Set()` overload.