### PR TITLE
Add support for VS2013

### DIFF
--- a/test/error.cc
+++ b/test/error.cc
@@ -11,7 +11,7 @@ void DoNotCatch(const CallbackInfo& info) {
 
 void ThrowApiError(const CallbackInfo& info) {
   // Attempting to call an empty function value will throw an API error.
-  Function(info.Env(), nullptr).Call({});
+  Function(info.Env(), nullptr).Call(std::initializer_list<napi_value>{});
 }
 
 #ifdef NAPI_CPP_EXCEPTIONS

--- a/test/function.cc
+++ b/test/function.cc
@@ -62,7 +62,7 @@ Value CallWithVector(const CallbackInfo& info) {
 Value CallWithReceiverAndArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
    Value receiver = info[1];
-   return func.Call(receiver, { info[2], info[3], info[4] });
+   return func.Call(receiver, std::initializer_list<napi_value>{ info[2], info[3], info[4] });
 }
 
 Value CallWithReceiverAndVector(const CallbackInfo& info) {
@@ -78,12 +78,12 @@ Value CallWithReceiverAndVector(const CallbackInfo& info) {
 
 Value CallWithInvalidReceiver(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return func.Call(Value(), {});
+   return func.Call(Value(), std::initializer_list<napi_value>{});
 }
 
 Value CallConstructorWithArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return func.New({ info[1], info[2], info[3] });
+   return func.New(std::initializer_list<napi_value>{ info[1], info[2], info[3] });
 }
 
 Value CallConstructorWithVector(const CallbackInfo& info) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,10 +13,15 @@ let testModules = [
 ];
 
 if (typeof global.gc === 'function') {
+  console.log('Starting test suite\n');
+
   // Requiring each module runs tests in the module.
   testModules.forEach(name => {
+    console.log(`Running test '${name}'`);
     require('./' + name);
   });
+
+  console.log('\nAll tests passed!');
 } else {
   // Make it easier to run with the correct (version-dependent) command-line args.
   const args = [ '--expose-gc', __filename ];

--- a/test/name.cc
+++ b/test/name.cc
@@ -3,7 +3,7 @@
 using namespace Napi;
 
 const char* testValueUtf8 = "123456789";
-const char16_t* testValueUtf16 = u"123456789";
+const char16_t* testValueUtf16 = NAPI_WIDE_TEXT("123456789");
 
 Value EchoString(const CallbackInfo& info) {
   String value = info[0].As<String>();

--- a/test/object.cc
+++ b/test/object.cc
@@ -39,14 +39,26 @@ void DefineProperties(const CallbackInfo& info) {
       PropertyDescriptor::Function("function", TestFunction),
     });
   } else if (nameType.Utf8Value() == "string") {
+    // VS2013 has lifetime issues when passing temporary objects into the constructor of another
+    // object. It generates code to destruct the object as soon as the constructor call returns.
+    // Since this isn't a common case for using std::string objects, I'm refactoring the test to
+    // work around the issue.
+    std::string str1("readonlyAccessor");
+    std::string str2("readwriteAccessor");
+    std::string str3("readonlyValue");
+    std::string str4("readwriteValue");
+    std::string str5("enumerableValue");
+    std::string str6("configurableValue");
+    std::string str7("function");
+
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(std::string("readonlyAccessor"), TestGetter),
-      PropertyDescriptor::Accessor(std::string("readwriteAccessor"), TestGetter, TestSetter),
-      PropertyDescriptor::Value(std::string("readonlyValue"), trueValue),
-      PropertyDescriptor::Value(std::string("readwriteValue"), trueValue, napi_writable),
-      PropertyDescriptor::Value(std::string("enumerableValue"), trueValue, napi_enumerable),
-      PropertyDescriptor::Value(std::string("configurableValue"), trueValue, napi_configurable),
-      PropertyDescriptor::Function(std::string("function"), TestFunction),
+      PropertyDescriptor::Accessor(str1, TestGetter),
+      PropertyDescriptor::Accessor(str2, TestGetter, TestSetter),
+      PropertyDescriptor::Value(str3, trueValue),
+      PropertyDescriptor::Value(str4, trueValue, napi_writable),
+      PropertyDescriptor::Value(str5, trueValue, napi_enumerable),
+      PropertyDescriptor::Value(str6, trueValue, napi_configurable),
+      PropertyDescriptor::Function(str7, TestFunction),
     });
   } else if (nameType.Utf8Value() == "value") {
     obj.DefineProperties({

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -2,6 +2,16 @@
 
 using namespace Napi;
 
+#if defined(NAPI_HAS_CONSTEXPR)
+#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length)
+#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
+  className::New(env, length, buffer, bufferOffset)
+#else
+#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length, type)
+#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
+  className::New(env, length, buffer, bufferOffset, type)
+#endif
+
 namespace {
 
 Value CreateTypedArray(const CallbackInfo& info) {
@@ -11,32 +21,49 @@ Value CreateTypedArray(const CallbackInfo& info) {
   size_t bufferOffset = info[3].IsUndefined() ? 0 : info[3].As<Number>().Uint32Value();
 
   if (arrayType == "int8") {
-    return buffer.IsUndefined() ? Int8Array::New(info.Env(), length)
-      : Int8Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Int8Array, info.Env(), length, napi_int8_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_int8_array);
   } else if (arrayType == "uint8") {
-    return buffer.IsUndefined() ? Uint8Array::New(info.Env(), length)
-      : Uint8Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Uint8Array, info.Env(), length, napi_uint8_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Uint8Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_uint8_array);
   } else if (arrayType == "uint8_clamped") {
-    return buffer.IsUndefined() ? Uint8Array::New(info.Env(), length, napi_uint8_clamped_array)
-      : Uint8Array::New(info.Env(), length, buffer, bufferOffset, napi_uint8_clamped_array);
+    return buffer.IsUndefined() ?
+      Uint8Array::New(info.Env(), length, napi_uint8_clamped_array) :
+      Uint8Array::New(info.Env(), length, buffer, bufferOffset, napi_uint8_clamped_array);
   } else if (arrayType == "int16") {
-    return buffer.IsUndefined() ? Int16Array::New(info.Env(), length)
-      : Int16Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Int16Array, info.Env(), length, napi_int16_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Int16Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_int16_array);
   } else if (arrayType == "uint16") {
-    return buffer.IsUndefined() ? Uint16Array::New(info.Env(), length)
-      : Uint16Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Uint16Array, info.Env(), length, napi_uint16_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Uint16Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_uint16_array);
   } else if (arrayType == "int32") {
-    return buffer.IsUndefined() ? Int32Array::New(info.Env(), length)
-      : Int32Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Int32Array, info.Env(), length, napi_int32_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Int32Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_int32_array);
   } else if (arrayType == "uint32") {
-    return buffer.IsUndefined() ? Uint32Array::New(info.Env(), length)
-      : Uint32Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Uint32Array, info.Env(), length, napi_uint32_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Uint32Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_uint32_array);
   } else if (arrayType == "float32") {
-    return buffer.IsUndefined() ? Float32Array::New(info.Env(), length)
-      : Float32Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Float32Array, info.Env(), length, napi_float32_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Float32Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_float32_array);
   } else if (arrayType == "float64") {
-    return buffer.IsUndefined() ? Float64Array::New(info.Env(), length)
-      : Float64Array::New(info.Env(), length, buffer, bufferOffset);
+    return buffer.IsUndefined() ?
+      NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length, napi_float64_array) :
+      NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length, buffer, bufferOffset,
+                                 napi_float64_array);
   } else {
     Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
     return Value();
@@ -44,7 +71,7 @@ Value CreateTypedArray(const CallbackInfo& info) {
 }
 
 Value CreateInvalidTypedArray(const CallbackInfo& info) {
-  return Int8Array::New(info.Env(), 1, ArrayBuffer(), 0);
+  return NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), 1, ArrayBuffer(), 0, napi_int8_array);
 }
 
 Value GetTypedArrayType(const CallbackInfo& info) {


### PR DESCRIPTION
VS2013 issues
* No constexpr support
  - Conditionally use constexpr if the compiler supports it
  - Updated tests to use a macro for this purpose
* Requires copy constructor support for base classes of thrown objects
  - Added a protected copy constructor to ObjectReference and
    Reference<T>
* Incorrect overload resolution for std::initializer_list
  - Used explicit types to invoke the correct overload
* No literal support for char16_t
  - Added macro to convert the text properly
* Lambdas are unable to capture function non-pointers
  - Updated the typedef to create a function pointer
* Short lifetime for temporary objects passed to constructors
  - Updated the tests to create the objects and pass them to the
    constructor. This is closer to how they would be used anyway
    
General improvements
* Added console.log output to the test runner to make it more clear
  when and where tests are failing

[![Build Status](https://travis-ci.org/kfarnung/node-addon-api.svg?branch=vs2013)](https://travis-ci.org/kfarnung/node-addon-api)