### PR TITLE
Use a version check to determine if N-API is internal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,21 @@
 var path = require('path');
 
+// We know which version of Node.js first shipped the incarnation of the API
+// available in *this* package. So, if we find that the Node.js version is below
+// that, we indicate that the API is missing from Node.js.
+function getNodeApiBuiltin() {
+  var versionArray = process.version
+    .substr(1)
+    .split('.')
+    .map(function(item) {
+      return +item;
+    });
+  return versionArray[0] >= 8 && versionArray[1] >= 4 && versionArray[2] >= 0;
+}
+
 // TODO: Check if the main node semantic version is within multiple ranges,
 // or detect presence of built-in N-API by some other mechanism TBD.
-var isNodeApiBuiltin = process.versions.modules >= 52;  // Node 8.x
+var isNodeApiBuiltin = getNodeApiBuiltin();
 
 var include = path.join(__dirname, 'src');
 var gyp = path.join(__dirname, 'src', 'node_api.gyp');


### PR DESCRIPTION
We need to cover the breaks we've introduced since 8.0.0, so we must link statically when the Node.js version is less than 8.4.0.