### PR TITLE
Provide alternative for v8::Private and backport NODE_RELEASE

### DIFF
--- a/src/node_internals.cc
+++ b/src/node_internals.cc
@@ -95,3 +95,10 @@ NO_RETURN void FatalError(const char* location, const char* message) {
 }
 
 }  // namespace node
+
+#if NODE_MAJOR_VERSION < 6
+v8::Local<v8::Name> v8::Private::ForApi(v8::Isolate* isolate,
+                                         v8::Local<v8::String> key) {
+  return v8::Symbol::ForApi(isolate, key);
+}
+#endif // NODE_MAJOR_VERSION < 6

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -52,6 +52,10 @@
 #define NO_RETURN
 #endif
 
+#ifndef NODE_RELEASE
+#define NODE_RELEASE "node"
+#endif
+
 namespace node {
 
 // The slightly odd function signature for Assert() is to ease
@@ -66,5 +70,19 @@ constexpr size_t arraysize(const T(&)[N]) { return N; }
 NO_RETURN void FatalError(const char* location, const char* message);
 
 }  // namespace node
+
+#if NODE_MAJOR_VERSION < 6
+namespace v8 {
+  namespace Private {
+    v8::Local<v8::Name> ForApi(v8::Isolate* isolate, v8::Local<v8::String> key);
+  }
+}
+#define GetPrivate(context, key) Get((context), (key))
+#define SetPrivate(context, key, value)                                 \
+  DefineOwnProperty((context), (key), (value),                          \
+                    static_cast<v8::PropertyAttribute>(v8::DontEnum |   \
+                                                       v8::DontDelete | \
+                                                       v8::ReadOnly))
+#endif // NODE_MAJOR_VERSION < 6
 
 #endif  // SRC_NODE_INTERNALS_H_


### PR DESCRIPTION
The current release of node-addon-api fails to build under versions of node less than 6.0.0, because `v8::Private` is missing (my bad). This replaces the `v8::Private` usage with that of a symbol-keyed property which is marked as non-deletable, non-enumerable, and read-only.

Additionally, this backports the conditional definition of `NODE_RELEASE` which was introduced along with `napi_get_node_version()`.