### PR TITLE
Introduce flag check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,25 @@
 var path = require('path');
 
-// We know which version of Node.js first shipped the incarnation of the API
-// available in *this* package. So, if we find that the Node.js version is below
-// that, we indicate that the API is missing from Node.js.
-function getNodeApiBuiltin() {
-  var versionArray = process.version
-    .substr(1)
-    .split('.')
-    .map(function(item) {
-      return +item;
-    });
-  return versionArray[0] >= 8 && versionArray[1] >= 4 && versionArray[2] >= 0;
-}
+var versionArray = process.version
+  .substr(1)
+  .replace(/-.*$/, '')
+  .split('.')
+  .map(function(item) {
+    return +item;
+  });
 
 // TODO: Check if the main node semantic version is within multiple ranges,
 // or detect presence of built-in N-API by some other mechanism TBD.
-var isNodeApiBuiltin = getNodeApiBuiltin();
+
+// We know which version of Node.js first shipped the incarnation of the API
+// available in *this* package. So, if we find that the Node.js version is below
+// that, we indicate that the API is missing from Node.js.
+var isNodeApiBuiltin =
+  (versionArray[0] >= 8 && versionArray[1] >= 4 && versionArray[2] >= 0);
+
+// So far it looks like even version 9 will need the flag. We need to adjust
+// this for the version where the flag is dropped whenever that version lands.
+var needsFlag = (versionArray[0] >= 8);
 
 var include = path.join(__dirname, 'src');
 var gyp = path.join(__dirname, 'src', 'node_api.gyp');
@@ -31,4 +35,5 @@ module.exports = {
    include: [ '"' + include + '"', '"' + __dirname + '"' ].join(' '),
    gyp: gyp,
    isNodeApiBuiltin: isNodeApiBuiltin,
+   needsFlag: needsFlag
 };

--- a/test/napi_child.js
+++ b/test/napi_child.js
@@ -1,6 +1,6 @@
 // Makes sure that child processes are spawned appropriately.
 exports.spawnSync = function(command, args, options) {
-  if (require('../index').isNodeApiBuiltin) {
+  if (require('../index').needsFlag) {
     args.splice(0, 0, '--napi-modules');
   }
   return require('child_process').spawnSync(command, args, options);


### PR DESCRIPTION
The version starting with which N-API is considered built-in is not the
same as the version starting with which the --napi-modules flag is
consisdered dropped. The latter needs a separate check.

Fixes: https://github.com/nodejs/node-addon-api/issues/119