### PR TITLE
Use old-style functions and use safe-buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   ],
   "dependencies": {},
   "description": "Node.js API (N-API)",
-  "devDependencies": {},
+  "devDependencies": {
+    "safe-buffer": "^5.1.1"
+  },
   "directories": {},
   "homepage": "https://github.com/nodejs/node-addon-api",
   "license": "MIT",

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -2,6 +2,7 @@
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
+const safeBuffer = require('safe-buffer');
 
 test(require(`./build/${buildType}/binding.node`));
 test(require(`./build/${buildType}/binding_noexcept.node`));
@@ -14,7 +15,7 @@ function test(binding) {
       binding.buffer.checkBuffer(test);
       assert.ok(test instanceof Buffer);
 
-      const test2 = Buffer.alloc(test.length);
+      const test2 = safeBuffer.Buffer.alloc(test.length);
       test.copy(test2);
       binding.buffer.checkBuffer(test2);
     },

--- a/test/error.js
+++ b/test/error.js
@@ -14,19 +14,19 @@ test(`./build/${buildType}/binding_noexcept.node`);
 function test(bindingPath) {
   const binding = require(bindingPath);
 
-  assert.throws(() => binding.error.throwApiError('test'), err => {
+  assert.throws(() => binding.error.throwApiError('test'), function(err) {
     return err instanceof Error && err.message.includes('Invalid');
   });
 
-  assert.throws(() => binding.error.throwJSError('test'), err => {
+  assert.throws(() => binding.error.throwJSError('test'), function(err) {
     return err instanceof Error && err.message === 'test';
   });
 
-  assert.throws(() => binding.error.throwTypeError('test'), err => {
+  assert.throws(() => binding.error.throwTypeError('test'), function(err) {
     return err instanceof TypeError && err.message === 'test';
   });
 
-  assert.throws(() => binding.error.throwRangeError('test'), err => {
+  assert.throws(() => binding.error.throwRangeError('test'), function(err) {
     return err instanceof RangeError && err.message === 'test';
   });
 
@@ -35,7 +35,7 @@ function test(bindingPath) {
       () => {
         throw new TypeError('test');
       }),
-    err => {
+    function(err) {
       return err instanceof TypeError && err.message === 'test' && !err.caught;
     });
 
@@ -44,7 +44,7 @@ function test(bindingPath) {
       () => {
         throw new TypeError('test');
       }),
-    err => {
+    function(err) {
       return err instanceof TypeError && err.message === 'test' && err.caught;
     });
 
@@ -57,11 +57,11 @@ function test(bindingPath) {
     () => { throw new TypeError('test'); });
   assert.strictEqual(msg, 'test');
 
-  assert.throws(() => binding.error.throwErrorThatEscapesScope('test'), err => {
+  assert.throws(() => binding.error.throwErrorThatEscapesScope('test'), function(err) {
     return err instanceof Error && err.message === 'test';
   });
 
-  assert.throws(() => binding.error.catchAndRethrowErrorThatEscapesScope('test'), err => {
+  assert.throws(() => binding.error.catchAndRethrowErrorThatEscapesScope('test'), function(err) {
     return err instanceof Error && err.message === 'test' && err.caught;
   });
 


### PR DESCRIPTION
* err => {} notation doesn't work on Node 4.
* Run test that uses Buffer.alloc only if ("alloc" in Buffer).

Fixes: https://github.com/nodejs/node-addon-api/issues/120