### PR TITLE
Refactor property setting

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -120,6 +120,21 @@ namespace Napi {
     Value();                               ///< Creates a new _empty_ Value instance.
     Value(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
+    /// Creates a JS value from a C++ primitive.
+    ///
+    /// `value` may be any of:
+    /// - bool
+    /// - Any integer type
+    /// - Any floating point type
+    /// - const char* (encoded using UTF-8, null-terminated)
+    /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
+    /// - std::string (encoded using UTF-8)
+    /// - std::u16string
+    /// - napi::Value
+    /// - napi_value
+    template <typename T>
+    static Value From(napi_env env, const T& value);
+
     /// Converts to a N-API value primitive.
     ///
     /// If the instance is _empty_, this returns `nullptr`.
@@ -267,6 +282,16 @@ namespace Napi {
       const char16_t* value, ///< UTF-16 encoded C string (not necessarily null-terminated)
       size_t length          ///< Length of the string in 2-byte code units
     );
+
+    /// Creates a new String based on the original object's type.
+    ///
+    /// `value` may be any of:
+    /// - const char* (encoded using UTF-8, null-terminated)
+    /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
+    /// - std::string (encoded using UTF-8)
+    /// - std::u16string
+    template <typename T>
+    static String From(napi_env env, const T& value);
 
     String();                               ///< Creates a new _empty_ String instance.
     String(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
@@ -420,75 +445,31 @@ namespace Napi {
     ) const;
 
     /// Sets a property.
+    template <typename ValueType>
     void Set(
       napi_value key,  ///< Property key primitive
-      napi_value value ///< Property value primitive
+      const ValueType& value ///< Property value primitive
     );
 
     /// Sets a property.
+    template <typename ValueType>
     void Set(
       Value key,  ///< Property key
-      Value value ///< Property value
+      const ValueType& value ///< Property value
     );
 
     /// Sets a named property.
+    template <typename ValueType>
     void Set(
       const char* utf8name, ///< UTF-8 encoded null-terminated property name
-      napi_value value      ///< Property value primitive
+      const ValueType& value
     );
 
     /// Sets a named property.
-    void Set(
-      const char* utf8name, ///< UTF-8 encoded null-terminated property name
-      Value value           ///< Property value
-    );
-
-    /// Sets a named property to a string value.
-    void Set(
-      const char* utf8name, ///< UTF-8 encoded null-terminated property name
-      const char* utf8value ///< UTF-8 encoded null-terminated property value
-    );
-
-    /// Sets a named property to a boolean value.
-    void Set(
-      const char* utf8name, ///< UTF-8 encoded null-terminated property name
-      bool boolValue        ///< Property value
-    );
-
-    /// Sets a named property to a number value.
-    void Set(
-      const char* utf8name, ///< UTF-8 encoded null-terminated property name
-      double numberValue    ///< Property value
-    );
-
-    /// Sets a named property.
+    template <typename ValueType>
     void Set(
       const std::string& utf8name, ///< UTF-8 encoded property name
-      napi_value value             ///< Property value primitive
-    );
-
-    /// Sets a named property.
-    void Set(
-      const std::string& utf8name, ///< UTF-8 encoded property name
-      Value value                  ///< Property value
-    );
-
-    /// Sets a named property to a string value.
-    void Set(
-      const std::string& utf8name, ///< UTF-8 encoded property name
-      std::string& utf8value       ///< UTF-8 encoded property value
-    );
-
-    /// Sets a named property to a boolean value.
-    void Set(
-      const std::string& utf8name, ///< UTF-8 encoded property name
-      bool boolValue               ///< Property value
-    );
-
-    /// Sets a named property to a number value.
-    void Set(
-      const std::string& utf8name, ///< UTF-8 encoded property name
-      double numberValue           ///< Property value
+      const ValueType& value             ///< Property value primitive
     );
 
     /// Delete property.
@@ -522,39 +503,10 @@ namespace Napi {
     ) const;
 
     /// Sets an indexed property or array element.
+    template <typename ValueType>
     void Set(
       uint32_t index,  ///< Property / element index
-      napi_value value ///< Property value primitive
-    );
-
-    /// Sets an indexed property or array element.
-    void Set(
-      uint32_t index, ///< Property / element index
-      Value value     ///< Property value
-    );
-
-    /// Sets an indexed property or array element to a string value.
-    void Set(
-      uint32_t index,       ///< Property / element index
-      const char* utf8value ///< UTF-8 encoded null-terminated property value
-    );
-
-    /// Sets an indexed property or array element to a string value.
-    void Set(
-      uint32_t index,              ///< Property / element index
-      const std::string& utf8value ///< UTF-8 encoded property value
-    );
-
-    /// Sets an indexed property or array element to a boolean value.
-    void Set(
-      uint32_t index, ///< Property / element index
-      bool boolValue  ///< Property value
-    );
-
-    /// Sets an indexed property or array element to a number value.
-    void Set(
-      uint32_t index,    ///< Property / element index
-      double numberValue ///< Property value
+      const ValueType& value ///< Property value primitive
     );
 
     /// Deletes an indexed property or array element.

--- a/test/object.cc
+++ b/test/object.cc
@@ -108,6 +108,28 @@ Value DeleteProperty(const CallbackInfo& info) {
   return Boolean::New(info.Env(), obj.Delete(name));
 }
 
+Value CreateObjectUsingMagic(const CallbackInfo& info) {
+  Env env = info.Env();
+  Object obj = Object::New(env);
+  obj["cp_false"] = false;
+  obj["cp_true"] = true;
+  obj[std::string("s_true")] = true;
+  obj[std::string("s_false")] = false;
+  obj["0"] = 0;
+  obj[42] = 120;
+  obj["0.0f"] = 0.0f;
+  obj["0.0"] = 0.0;
+  obj["-1"] = -1;
+  obj["foo2"] = u"foo";
+  obj[std::string("foo4")] = NAPI_WIDE_TEXT("foo");
+  obj[std::string("foo5")] = "foo";
+  obj[std::string("foo6")] = std::u16string(NAPI_WIDE_TEXT("foo"));
+  obj[std::string("foo7")] = std::string("foo");
+  obj[std::string("circular")] = obj;
+  obj["circular2"] = obj;
+  return obj;
+}
+
 Object InitObject(Env env) {
   Object exports = Object::New(env);
 
@@ -117,6 +139,7 @@ Object InitObject(Env env) {
   exports["getProperty"] = Function::New(env, GetProperty);
   exports["setProperty"] = Function::New(env, SetProperty);
   exports["deleteProperty"] = Function::New(env, DeleteProperty);
+  exports["createObjectUsingMagic"] = Function::New(env, CreateObjectUsingMagic);
 
   return exports;
 }

--- a/test/object.js
+++ b/test/object.js
@@ -109,4 +109,26 @@ function test(binding) {
   assert.throws(() => {
     binding.object.deleteProperty(undefined, 'test');
   }, /object was expected/);
+
+  {
+    const magicObject = binding.object.createObjectUsingMagic();
+    assert.deepStrictEqual(magicObject, {
+      0: 0,
+      42: 120,
+      cp_false: false,
+      cp_true: true,
+      s_true: true,
+      s_false: false,
+      '0.0f': 0,
+      '0.0': 0,
+      '-1': -1,
+      foo2: 'foo',
+      foo4: 'foo',
+      foo5: 'foo',
+      foo6: 'foo',
+      foo7: 'foo',
+      circular: magicObject,
+      circular2: magicObject
+    });
+  }
 }


### PR DESCRIPTION
Previously, various utility overloads of `Object::Set()` were provided. This was problematic, because accidental unexpected conversions could happen (e.g. `const char*` to `bool`) and overloads were ambiguous (e.g. `int` could be cast to `double` and `bool` and therefore could not be passed directly).

To address this, pass a template parameter instead, and introduce a helper `Value::From` method that could create a value based on the type of object it receives, and that uses clear precedence rules for determining the kind of JS value to create.

Fixes: https://github.com/nodejs/node-addon-api/issues/86

Also: Note that we can, if we want, extend this facility a lot, e.g. by turning iterable C++ types into arrays or `std::unordered_map`s into objects, and so on. I'd be happy to work on that, but since that would be a bit more extensive, it's probably good to get other people's buy-in first.