### PR TITLE
Make TypedArrayOf take both types as template parameters

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1123,73 +1123,68 @@ inline Napi::ArrayBuffer TypedArray::ArrayBuffer() const {
 // TypedArrayOf<T> class
 ////////////////////////////////////////////////////////////////////////////////
 
-template <typename T>
-inline TypedArrayOf<T> TypedArrayOf<T>::New(napi_env env,
-                                            size_t elementLength,
-                                            napi_typedarray_type type) {
-  Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(env, elementLength * sizeof (T));
-  return New(env, elementLength, arrayBuffer, 0, type);
+template <typename U, napi_typedarray_type V>
+inline TypedArrayOf<U, V> TypedArrayOf<U, V>::New(napi_env env,
+                                            size_t elementLength) {
+  Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(env, elementLength * sizeof (U));
+  return New(env, elementLength, arrayBuffer, 0);
 }
 
-template <typename T>
-inline TypedArrayOf<T> TypedArrayOf<T>::New(napi_env env,
+template <typename U, napi_typedarray_type V>
+inline TypedArrayOf<U, V> TypedArrayOf<U, V>::New(napi_env env,
                                             size_t elementLength,
                                             Napi::ArrayBuffer arrayBuffer,
-                                            size_t bufferOffset,
-                                            napi_typedarray_type type) {
+                                            size_t bufferOffset) {
   napi_value value;
   napi_status status = napi_create_typedarray(
-    env, type, elementLength, arrayBuffer, bufferOffset, &value);
-  NAPI_THROW_IF_FAILED(env, status, TypedArrayOf<T>());
+    env, V, elementLength, arrayBuffer, bufferOffset, &value);
+  NAPI_THROW_IF_FAILED(env, status, TypedArrayOf<U, V>());
 
-  return TypedArrayOf<T>(
-    env, value, type, elementLength,
-    reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(arrayBuffer.Data()) + bufferOffset));
+  return TypedArrayOf<U, V>(
+    env, value, elementLength,
+    reinterpret_cast<U*>(reinterpret_cast<uint8_t*>(arrayBuffer.Data()) + bufferOffset));
 }
 
-template <typename T>
-inline TypedArrayOf<T>::TypedArrayOf() : TypedArray(), _data(nullptr) {
+template <typename U, napi_typedarray_type V>
+inline TypedArrayOf<U, V>::TypedArrayOf() : TypedArray(), _data(nullptr) {
 }
 
-template <typename T>
-inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
+template <typename U, napi_typedarray_type V>
+inline TypedArrayOf<U, V>::TypedArrayOf(napi_env env, napi_value value)
   : TypedArray(env, value), _data(nullptr) {
   napi_status status = napi_get_typedarray_info(
     _env, _value, &_type, &_length, reinterpret_cast<void**>(&_data), nullptr, nullptr);
   NAPI_THROW_IF_FAILED(_env, status);
 }
 
-template <typename T>
-inline TypedArrayOf<T>::TypedArrayOf(napi_env env,
-                                     napi_value value,
-                                     napi_typedarray_type type,
-                                     size_t length,
-                                     T* data)
-  : TypedArray(env, value, type, length), _data(data) {
-  if (!(type == TypedArrayTypeForPrimitiveType<T>() ||
-      (type == napi_uint8_clamped_array && std::is_same<T, uint8_t>::value))) {
-    NAPI_THROW(TypeError::New(env, "Array type must match the template parameter. "
-      "(Uint8 arrays may optionally have the \"clamped\" array type.)"));
-  }
+template <typename U, napi_typedarray_type V>
+inline TypedArrayOf<U, V>::TypedArrayOf(napi_env env, napi_value value,
+                                        size_t length, U *data)
+    : TypedArray(env, value, V, length), _data(data) {
+  static_assert(
+      V == TypedArrayTypeForPrimitiveType<U>() ||
+          (V == napi_uint8_clamped_array && std::is_same<U, uint8_t>::value),
+      "Array type must match the template parameter. "
+      "(Uint8 arrays may optionally have the \"clamped\" array type.)");
 }
 
-template <typename T>
-inline T& TypedArrayOf<T>::operator [](size_t index) {
+template <typename U, napi_typedarray_type V>
+inline U& TypedArrayOf<U, V>::operator [](size_t index) {
   return _data[index];
 }
 
-template <typename T>
-inline const T& TypedArrayOf<T>::operator [](size_t index) const {
+template <typename U, napi_typedarray_type V>
+inline const U& TypedArrayOf<U, V>::operator [](size_t index) const {
   return _data[index];
 }
 
-template <typename T>
-inline T* TypedArrayOf<T>::Data() {
+template <typename U, napi_typedarray_type V>
+inline U* TypedArrayOf<U, V>::Data() {
   return _data;
 }
 
-template <typename T>
-inline const T* TypedArrayOf<T>::Data() const {
+template <typename U, napi_typedarray_type V>
+inline const U* TypedArrayOf<U, V>::Data() const {
   return _data;
 }
 

--- a/napi.h
+++ b/napi.h
@@ -62,16 +62,26 @@ namespace Napi {
   class CallbackInfo;
   template <typename T> class Reference;
   class TypedArray;
-  template <typename T> class TypedArrayOf;
+  template <typename U, napi_typedarray_type V> class TypedArrayOf;
 
-  typedef TypedArrayOf<int8_t> Int8Array;     ///< Typed-array of signed 8-bit integers
-  typedef TypedArrayOf<uint8_t> Uint8Array;   ///< Typed-array of unsigned 8-bit integers
-  typedef TypedArrayOf<int16_t> Int16Array;   ///< Typed-array of signed 16-bit integers
-  typedef TypedArrayOf<uint16_t> Uint16Array; ///< Typed-array of unsigned 16-bit integers
-  typedef TypedArrayOf<int32_t> Int32Array;   ///< Typed-array of signed 32-bit integers
-  typedef TypedArrayOf<uint32_t> Uint32Array; ///< Typed-array of unsigned 32-bit integers
-  typedef TypedArrayOf<float> Float32Array;   ///< Typed-array of 32-bit floating-point values
-  typedef TypedArrayOf<double> Float64Array;  ///< Typed-array of 64-bit floating-point values
+  ///< Typed-array of signed 8-bit integers
+  using Int8Array = TypedArrayOf<int8_t, napi_int8_array>;
+  ///< Typed-array of unsigned 8-bit integers
+  using Uint8Array = TypedArrayOf<uint8_t, napi_uint8_array>;
+  ///< Typed-array of unsigned 8-bit clamped integers
+  using Uint8ClampedArray = TypedArrayOf<uint8_t, napi_uint8_clamped_array>;
+  ///< Typed-array of signed 16-bit integers
+  using Int16Array = TypedArrayOf<int16_t, napi_int16_array>;
+  ///< Typed-array of unsigned 16-bit integers
+  using Uint16Array = TypedArrayOf<uint16_t, napi_uint16_array>;
+  ///< Typed-array of signed 32-bit integers
+  using Int32Array = TypedArrayOf<int32_t, napi_int32_array>;
+  ///< Typed-array of unsigned 32-bit integers
+  using Uint32Array = TypedArrayOf<uint32_t, napi_uint32_array>;
+  ///< Typed-array of 32-bit floating-point values
+  using Float32Array = TypedArrayOf<float, napi_float32_array>;
+  ///< Typed-array of 64-bit floating-point values
+  using Float64Array = TypedArrayOf<double, napi_float64_array>;
 
   /// Defines the signature of a N-API C++ module's registration callback (init) function.
   typedef void (*ModuleRegisterCallback)(Env env, Object exports, Object module);
@@ -707,7 +717,7 @@ namespace Napi {
   ///
   /// Note while it is possible to create and access Uint8 "clamped" arrays using this class,
   /// the _clamping_ behavior is only applied in JavaScript.
-  template <typename T>
+  template <typename U, napi_typedarray_type V>
   class TypedArrayOf : public TypedArray {
   public:
     /// Creates a new TypedArray instance over a new automatically-allocated array buffer.
@@ -718,13 +728,7 @@ namespace Napi {
     ///     Uint8Array::New(env, length, napi_uint8_clamped_array)
     static TypedArrayOf New(
       napi_env env,         ///< N-API environment
-      size_t elementLength, ///< Length of the created array, as a number of elements
-#if defined(NAPI_HAS_CONSTEXPR)
-      napi_typedarray_type type = TypedArray::TypedArrayTypeForPrimitiveType<T>()
-#else
-      napi_typedarray_type type
-#endif
-        ///< Type of array, if different from the default array type for the template parameter T.
+      size_t elementLength  ///< Length of the created array, as a number of elements
     );
 
     /// Creates a new TypedArray instance over a provided array buffer.
@@ -737,41 +741,34 @@ namespace Napi {
       napi_env env,                  ///< N-API environment
       size_t elementLength,          ///< Length of the created array, as a number of elements
       Napi::ArrayBuffer arrayBuffer, ///< Backing array buffer instance to use
-      size_t bufferOffset,           ///< Offset into the array buffer where the typed-array starts
-#if defined(NAPI_HAS_CONSTEXPR)
-      napi_typedarray_type type = TypedArray::TypedArrayTypeForPrimitiveType<T>()
-#else
-      napi_typedarray_type type
-#endif
-        ///< Type of array, if different from the default array type for the template parameter T.
+      size_t bufferOffset            ///< Offset into the array buffer where the typed-array starts
     );
 
     TypedArrayOf();                               ///< Creates a new _empty_ TypedArrayOf instance.
     TypedArrayOf(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
-    T& operator [](size_t index);             ///< Gets or sets an element in the array.
-    const T& operator [](size_t index) const; ///< Gets an element in the array.
+    U& operator [](size_t index);             ///< Gets or sets an element in the array.
+    const U& operator [](size_t index) const; ///< Gets an element in the array.
 
     /// Gets a pointer to the array's backing buffer.
     ///
     /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer, because the
     /// typed-array may have a non-zero `ByteOffset()` into the `ArrayBuffer`.
-    T* Data();
+    U* Data();
 
     /// Gets a pointer to the array's backing buffer.
     ///
     /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer, because the
     /// typed-array may have a non-zero `ByteOffset()` into the `ArrayBuffer`.
-    const T* Data() const;
+    const U* Data() const;
 
   private:
-    T* _data;
+    U* _data;
 
     TypedArrayOf(napi_env env,
                  napi_value value,
-                 napi_typedarray_type type,
                  size_t length,
-                 T* data);
+                 U* data);
   };
 
   class Function : public Object {

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -2,15 +2,9 @@
 
 using namespace Napi;
 
-#if defined(NAPI_HAS_CONSTEXPR)
-#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length)
-#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
+#define NAPI_TYPEDARRAY_NEW(className, env, length) className::New(env, length)
+#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset) \
   className::New(env, length, buffer, bufferOffset)
-#else
-#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length, type)
-#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
-  className::New(env, length, buffer, bufferOffset, type)
-#endif
 
 namespace {
 
@@ -21,57 +15,59 @@ Value CreateTypedArray(const CallbackInfo& info) {
   size_t bufferOffset = info[3].IsUndefined() ? 0 : info[3].As<Number>().Uint32Value();
 
   if (arrayType == "int8") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int8Array, info.Env(), length, napi_int8_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int8_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Int8Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "uint8") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint8Array, info.Env(), length, napi_uint8_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint8Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint8_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Uint8Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint8Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "uint8_clamped") {
-    return buffer.IsUndefined() ?
-      Uint8Array::New(info.Env(), length, napi_uint8_clamped_array) :
-      Uint8Array::New(info.Env(), length, buffer, bufferOffset, napi_uint8_clamped_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Uint8ClampedArray, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint8ClampedArray, info.Env(),
+                                            length, buffer, bufferOffset);
   } else if (arrayType == "int16") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int16Array, info.Env(), length, napi_int16_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int16Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int16_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Int16Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int16Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "uint16") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint16Array, info.Env(), length, napi_uint16_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint16Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint16_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Uint16Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint16Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "int32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int32Array, info.Env(), length, napi_int32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Int32Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int32Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "uint32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint32Array, info.Env(), length, napi_uint32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Uint32Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint32Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "float32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Float32Array, info.Env(), length, napi_float32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Float32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_float32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Float32Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Float32Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else if (arrayType == "float64") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length, napi_float64_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_float64_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length,
+                                            buffer, bufferOffset);
   } else {
-    Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Invalid typed-array type.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 }
 
 Value CreateInvalidTypedArray(const CallbackInfo& info) {
-  return NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), 1, ArrayBuffer(), 0, napi_int8_array);
+  return NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), 1, ArrayBuffer(), 0);
 }
 
 Value GetTypedArrayType(const CallbackInfo& info) {


### PR DESCRIPTION
This allows a compile-time check for matching array types.