### PR TITLE
Set conversion from '->' to '.' for object dereference [conversion]

### DIFF
--- a/tools/conversion.js
+++ b/tools/conversion.js
@@ -162,6 +162,8 @@ var SourceFileOperations = [
   [ /Nan::Equals\(([^,]+),/g, '$1.StrictEquals(' ],
 
 
+  [ /(.+)->Set\(/g, '$1.Set\(' ],
+
 
   [ /Nan::Callback/g, 'Napi::FunctionReference' ],
 


### PR DESCRIPTION
Uncertain if searching for "->Set(" would over-match in some circumstances. Alternative is to search exclusively for "exports->Set(" and "module->Set(", which will under-match in some circumstances. 