### PR TITLE
Fix conversion tool that created two return statements after throwing error [conversion]

### DIFF
--- a/tools/conversion.js
+++ b/tools/conversion.js
@@ -148,7 +148,8 @@ var SourceFileOperations = [
 
   // Nan::ThrowError(error) to Napi::Error::New(env, error).ThrowAsJavaScriptException()
   [ /return Nan::Throw(\w*?)Error\((.+?)\);/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n  return env.Null();' ],
-  [ /Nan::Throw(\w*?)Error\((.+?)\);/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n  return env.Null();' ],
+  [ /Nan::Throw(\w*?)Error\((.+?)\);\n(\s*)return;/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n$3return env.Null();' ],
+  [ /Nan::Throw(\w*?)Error\((.+?)\);/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n' ],
   // Nan::RangeError(error) to Napi::RangeError::New(env, error)
   [ /Nan::(\w*?)Error\((.+)\)/g, 'Napi::$1Error::New(env, $2)' ],
 


### PR DESCRIPTION
The conversion tool didn't match a return statement but added one anyways when converting a ThrowAsJavaScriptException, which often resulted in two return statements.