### PR TITLE
C++ implementation of promise

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -176,6 +176,7 @@ namespace Napi {
     bool IsTypedArray() const;  ///< Tests if a value is a JavaScript typed array.
     bool IsObject() const;      ///< Tests if a value is a JavaScript object.
     bool IsFunction() const;    ///< Tests if a value is a JavaScript function.
+    bool IsPromise() const;     ///< Tests if a value is a JavaScript promise.
     bool IsBuffer() const;      ///< Tests if a value is a Node buffer.
 
     /// Casts to another type of `Napi::Value`, when the actual type is known or assumed.
@@ -790,6 +791,27 @@ namespace Napi {
     Object New(const std::initializer_list<napi_value>& args) const;
     Object New(const std::vector<napi_value>& args) const;
     Object New(size_t argc, const napi_value* args) const;
+  };
+
+  class Promise : public Object {
+  public:
+    class Deferred {
+    public:
+      static Deferred New(napi_env env);
+      Deferred(napi_env env);
+
+      Napi::Promise Promise() const;
+
+      void Resolve(napi_value value) const;
+      void Reject(napi_value value) const;
+
+    private:
+      napi_env _env;
+      napi_deferred _deferred;
+      napi_value _promise;
+    };
+
+    Promise(napi_env env, napi_value value);
   };
 
   template <typename T>

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -10,6 +10,7 @@ Object InitExternal(Env env);
 Object InitFunction(Env env);
 Object InitName(Env env);
 Object InitObject(Env env);
+Object InitPromise(Env env);
 Object InitTypedArray(Env env);
 Object InitObjectWrap(Env env);
 
@@ -22,6 +23,7 @@ Object Init(Env env, Object exports) {
   exports.Set("function", InitFunction(env));
   exports.Set("name", InitName(env));
   exports.Set("object", InitObject(env));
+  exports.Set("promise", InitPromise(env));
   exports.Set("typedarray", InitTypedArray(env));
   exports.Set("objectwrap", InitObjectWrap(env));
   return exports;

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -10,6 +10,7 @@
         'function.cc',
         'name.cc',
         'object.cc',
+        'promise.cc',
         'typedarray.cc',
         'objectwrap.cc',
       ],

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -1,0 +1,70 @@
+/* Test helpers ported from test/common/index.js in Node.js project. */
+'use strict';
+const assert = require('assert');
+
+const noop = () => {};
+
+const mustCallChecks = [];
+
+function runCallChecks(exitCode) {
+  if (exitCode !== 0) return;
+
+  const failed = mustCallChecks.filter(function(context) {
+    if ('minimum' in context) {
+      context.messageSegment = `at least ${context.minimum}`;
+      return context.actual < context.minimum;
+    } else {
+      context.messageSegment = `exactly ${context.exact}`;
+      return context.actual !== context.exact;
+    }
+  });
+
+  failed.forEach(function(context) {
+    console.log('Mismatched %s function calls. Expected %s, actual %d.',
+                context.name,
+                context.messageSegment,
+                context.actual);
+    console.log(context.stack.split('\n').slice(2).join('\n'));
+  });
+
+  if (failed.length) process.exit(1);
+}
+
+exports.mustCall = function(fn, exact) {
+  return _mustCallInner(fn, exact, 'exact');
+};
+
+function _mustCallInner(fn, criteria = 1, field) {
+  if (typeof fn === 'number') {
+    criteria = fn;
+    fn = noop;
+  } else if (fn === undefined) {
+    fn = noop;
+  }
+
+  if (typeof criteria !== 'number')
+    throw new TypeError(`Invalid ${field} value: ${criteria}`);
+
+  const context = {
+    [field]: criteria,
+    actual: 0,
+    stack: (new Error()).stack,
+    name: fn.name || '<anonymous>'
+  };
+
+  // add the exit listener only once to avoid listener leak warnings
+  if (mustCallChecks.length === 0) process.on('exit', runCallChecks);
+
+  mustCallChecks.push(context);
+
+  return function() {
+    context.actual++;
+    return fn.apply(this, arguments);
+  };
+}
+
+exports.mustNotCall = function(msg) {
+  return function mustNotCall() {
+    assert.fail(msg || 'function should not have been called');
+  };
+};

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ let testModules = [
   'function',
   'name',
   'object',
+  'promise',
   'typedarray',
   'objectwrap'
 ];

--- a/test/promise.cc
+++ b/test/promise.cc
@@ -1,0 +1,29 @@
+#include "napi.h"
+
+using namespace Napi;
+
+Value IsPromise(const CallbackInfo& info) {
+  return Boolean::New(info.Env(), info[0].IsPromise());
+}
+
+Value ResolvePromise(const CallbackInfo& info) {
+  auto deferred = Promise::Deferred::New(info.Env());
+  deferred.Resolve(info[0]);
+  return deferred.Promise();
+}
+
+Value RejectPromise(const CallbackInfo& info) {
+  auto deferred = Promise::Deferred::New(info.Env());
+  deferred.Reject(info[0]);
+  return deferred.Promise();
+}
+
+Object InitPromise(Env env) {
+  Object exports = Object::New(env);
+
+  exports["isPromise"] = Function::New(env, IsPromise);
+  exports["resolvePromise"] = Function::New(env, ResolvePromise);
+  exports["rejectPromise"] = Function::New(env, RejectPromise);
+
+  return exports;
+}

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,19 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+const common = require('./common');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  assert.strictEqual(binding.promise.isPromise({}), false);
+
+  const resolving = binding.promise.resolvePromise('resolved');
+  assert.strictEqual(binding.promise.isPromise(resolving), true);
+  resolving.then(common.mustCall()).catch(common.mustNotCall());
+
+  const rejecting = binding.promise.rejectPromise('error');
+  assert.strictEqual(binding.promise.isPromise(rejecting), true);
+  rejecting.then(common.mustNotCall()).catch(common.mustCall());
+}


### PR DESCRIPTION
I noticed #126 was open and decided to implement it because I needed it for my experiments in converting an existing project to N-API. Especially an `AsyncWorker`-like class that I'd like to open a separate PR for once this is accepted. ([Implementation is already done](https://github.com/rolftimmermans/node-addon-api/commit/5dddef4c99d0dcf061d30faa04f50e45c4d7d487))

I don't know what the policy is for syncing `node_api.h`/`node_api.cc` etc, but they are also updated to a more recent version.

The API allows you to create a ~`Promise::Resolver`~ `Promise::Deferred` that you can use to retrieve the associated `Promise`; as well as resolve/reject that promise.