### PR TITLE
Fix Node n-api support check

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ var versionArray = process.version
 // We know which version of Node.js first shipped the incarnation of the API
 // available in *this* package. So, if we find that the Node.js version is below
 // that, we indicate that the API is missing from Node.js.
-var isNodeApiBuiltin =
-  (versionArray[0] >= 8 && versionArray[1] >= 4 && versionArray[2] >= 0);
+var isNodeApiBuiltin = 
+  (versionArray[0] > 8 || (versionArray[0] == 8 && versionArray[1] > 5));
 
 // So far it looks like even version 9 will need the flag. We need to adjust
 // this for the version where the flag is dropped whenever that version lands.


### PR DESCRIPTION
The current n-api capability check works only if Node's major version is 8. Switches this to check for unsupported versions instead and invert the result of that to determine whether `isNodeApiBuiltin` is `true`.

