### PR TITLE
Allow easy definition of iterators and other methods that are defined by (public) symbols

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -593,7 +593,7 @@ inline Symbol Symbol::New(napi_env env, napi_value description) {
   return Symbol(env, value);
 }
 
-inline Symbol Symbol::Public(napi_env env, const std::string& name) {
+inline Symbol Symbol::WellKnown(napi_env env, const std::string& name) {
   return Napi::Env(env).Global().Get("Symbol").As<Object>().Get(name).As<Symbol>();
 }
 

--- a/napi.h
+++ b/napi.h
@@ -305,6 +305,9 @@ namespace Napi {
       napi_value description ///< String value describing the symbol
     );
 
+    /// Get a public Symbol (e.g. Symbol.iterator).
+    static Symbol Public(napi_env, const std::string& name);
+
     Symbol();                               ///< Creates a new _empty_ Symbol instance.
     Symbol(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
   };
@@ -1325,6 +1328,14 @@ namespace Napi {
                                              napi_property_attributes attributes = napi_default,
                                              void* data = nullptr);
     static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             InstanceMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(Symbol name,
+                                             InstanceVoidMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(Symbol name,
                                              InstanceMethodCallback method,
                                              napi_property_attributes attributes = napi_default,
                                              void* data = nullptr);

--- a/napi.h
+++ b/napi.h
@@ -306,7 +306,7 @@ namespace Napi {
     );
 
     /// Get a public Symbol (e.g. Symbol.iterator).
-    static Symbol Public(napi_env, const std::string& name);
+    static Symbol WellKnown(napi_env, const std::string& name);
 
     Symbol();                               ///< Creates a new _empty_ Symbol instance.
     Symbol(napi_env env, napi_value value); ///< Wraps a N-API value primitive.

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -1,5 +1,26 @@
 #include <napi.h>
 
+class TestIter : public Napi::ObjectWrap<TestIter> {
+public:
+  TestIter(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TestIter>(info) {}
+
+  Napi::Value Next(const Napi::CallbackInfo& info) {
+    auto object = Napi::Object::New(info.Env());
+    object.Set("done", Napi::Boolean::New(info.Env(), true));
+    return object;
+  }
+
+  static void Initialize(Napi::Env env, Napi::Object exports) {
+    Constructor = Napi::Persistent(DefineClass(env, "TestIter", {
+      InstanceMethod("next", &TestIter::Next),
+    }));
+  }
+
+  static Napi::FunctionReference Constructor;
+};
+
+Napi::FunctionReference TestIter::Constructor;
+
 class Test : public Napi::ObjectWrap<Test> {
 public:
   Test(const Napi::CallbackInfo& info) :
@@ -14,10 +35,15 @@ public:
     return Napi::Number::New(info.Env(), value);
   }
 
+  Napi::Value Iter(const Napi::CallbackInfo& info) {
+    return TestIter::Constructor.New({});
+  }
+
   static void Initialize(Napi::Env env, Napi::Object exports) {
     exports.Set("Test", DefineClass(env, "Test", {
       InstanceMethod("test_set", &Test::Set),
-      InstanceMethod("test_get", &Test::Get)
+      InstanceMethod("test_get", &Test::Get),
+      InstanceMethod(Napi::Symbol::Public(env, "iterator"), &Test::Iter)
     }));
   }
 
@@ -28,5 +54,6 @@ private:
 Napi::Object InitObjectWrap(Napi::Env env) {
   Napi::Object exports = Napi::Object::New(env);
   Test::Initialize(env, exports);
+  TestIter::Initialize(env, exports);
   return exports;
 }

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -43,7 +43,7 @@ public:
     exports.Set("Test", DefineClass(env, "Test", {
       InstanceMethod("test_set", &Test::Set),
       InstanceMethod("test_get", &Test::Get),
-      InstanceMethod(Napi::Symbol::Public(env, "iterator"), &Test::Iter)
+      InstanceMethod(Napi::Symbol::WellKnown(env, "iterator"), &Test::Iter)
     }));
   }
 

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -13,8 +13,14 @@ function test(binding) {
     assert.strictEqual(obj.test_get(), 90);
   }
 
+  function testIter(obj) {
+    for (const value of obj) {
+    }
+  }
+
   function testObj(obj) {
     testSetGet(obj);
+    testIter(obj);
   }
 
   testObj(new Test());


### PR DESCRIPTION
This PR introduces two API additions that together makes it a lot easier to define iterator methods and other functions that are defined by public symbols.

The first addition is `Napi::Symbol::Public` which returns a public symbol defined by name on `Symbol`. For example: `Napi::Symbol::Public(env, "iterator")`.

The second addition is the addition of `InstanceMethod(Symbol name, ...)` which allows defining an instance method with a symbol key instead of a string key.

It is now possible to do:

```
DefineClass(env, "Test", {
    InstanceMethod(Napi::Symbol::Public(env, "iterator"), &Test::Iterator)
});
```

This defines the method `Test.prototype[Symbol.iterator]()`.