### PR TITLE
Fix segmentation fault when using setters or getters that are not defined

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -28,5 +28,11 @@ if (typeof global.gc === 'function') {
   const child = require('./napi_child').spawnSync(process.argv[0], [ '--expose-gc', __filename ], {
     stdio: 'inherit',
   });
-  process.exitCode = child.status;
+
+  if (child.signal) {
+    console.log(`Tests aborted with ${child.signal}`);
+    process.exitCode = 1;
+  } else {
+    process.exitCode = child.status;
+  }
 }

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -14,6 +14,8 @@ public:
     Constructor = Napi::Persistent(DefineClass(env, "TestIter", {
       InstanceMethod("next", &TestIter::Next),
     }));
+
+    Constructor.SuppressDestruct();
   }
 
   static Napi::FunctionReference Constructor;


### PR DESCRIPTION
Currently the following scenario aborts with a segmentation fault:

```
exports.Set("Text", DefineClass(env, "Test", {
    InstanceAccessor("readonly_prop", &Test::GetReadonlyProp, nullptr),
}));
```

```
new Test().readonly_prop = 1;
```

This PR fixes that scenario by checking for a null getter/setter and setting the property descriptor accordingly. Includes a test case for readonly properties.

I had to modify the test runner to correctly report SIGSEGV in order for it to actually fail the tests.