### PR TITLE
Fix test errors

### DIFF
--- a/src/node_api.gyp
+++ b/src/node_api.gyp
@@ -13,6 +13,7 @@
       'defines': [
          'EXTERNAL_NAPI',
       ],
+      'cflags_cc': ['-fvisibility=hidden']
     }
   ]
 }

--- a/src/node_internals.cc
+++ b/src/node_internals.cc
@@ -10,7 +10,7 @@
 #include <unistd.h>  // getpid
 #endif
 
-#if NODE_MAJOR_VERSION < 8
+#if NODE_MAJOR_VERSION < 8 || NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION < 6
 CallbackScope::CallbackScope(void *work) {
 }
 #endif // NODE_MAJOR_VERSION < 8
@@ -30,6 +30,15 @@ void EmitAsyncDestroy(v8::Isolate* isolate,
                       async_context asyncContext) {
 }
 
+AsyncResource::AsyncResource(v8::Isolate* isolate,
+                             v8::Local<v8::Object> object,
+                             const char *name) {
+}
+
+#endif // NODE_MAJOR_VERSION < 8
+
+#if NODE_MAJOR_VERSION < 8 || NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION < 6
+
 v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        v8::Local<v8::Object> recv,
                                        v8::Local<v8::Function> callback,
@@ -39,12 +48,7 @@ v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
   return node::MakeCallback(isolate, recv, callback, argc, argv);
 }
 
-AsyncResource::AsyncResource(v8::Isolate* isolate,
-                             v8::Local<v8::Object> object,
-                             const char *name) {
-}
-
-#endif // NODE_MAJOR_VERSION < 8
+#endif // NODE_MAJOR_VERSION < 8 || NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION < 6
 
 static void PrintErrorString(const char* format, ...) {
   va_list ap;

--- a/test/function.js
+++ b/test/function.js
@@ -46,7 +46,7 @@ function test(binding) {
 
   assert.throws(() => {
     binding.function.callWithInvalidReceiver();
-  }, /Invalid pointer/);
+  }, /Invalid (pointer passed as )?argument/);
 
   obj = binding.function.callConstructorWithArgs(testConstructor, 5, 6, 7);
   assert(obj instanceof testConstructor);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -66,5 +66,5 @@ function test(binding) {
 
   assert.throws(() => {
     binding.typedarray.createInvalidTypedArray();
-  }, /Invalid pointer/);
+  }, /Invalid (pointer passed as )?argument/);
 }


### PR DESCRIPTION
* Implement node::MakeCallback between 8.0.0 and 8.6.0 to fix
  unresolved symbol
* Fix error message expectation (was: "Invalid pointer", is: "Invalid
  argument")