### PR TITLE
Catch segfaults, fix a segfault, track build type

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
+process.config.target_defaults.default_configuration =
+  require('fs')
+    .readdirSync(require('path').join(__dirname, 'build'))
+    .filter((item) => (item === 'Debug' || item === 'Release'))[0];
+
 let testModules = [
   'arraybuffer',
   'asyncworker',
@@ -30,9 +35,10 @@ if (typeof global.gc === 'function') {
   });
 
   if (child.signal) {
-    console.log(`Tests aborted with ${child.signal}`);
+    console.error(`Tests aborted with ${child.signal}`);
     process.exitCode = 1;
   } else {
     process.exitCode = child.status;
   }
+  process.exit(process.exitCode);
 }

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -10,23 +10,18 @@ public:
     return object;
   }
 
-  static void Initialize(Napi::Env env, Napi::Object exports) {
-    Constructor = Napi::Persistent(DefineClass(env, "TestIter", {
+  static Napi::FunctionReference Initialize(Napi::Env env) {
+    return Napi::Persistent(DefineClass(env, "TestIter", {
       InstanceMethod("next", &TestIter::Next),
     }));
-
-    Constructor.SuppressDestruct();
   }
-
-  static Napi::FunctionReference Constructor;
 };
-
-Napi::FunctionReference TestIter::Constructor;
 
 class Test : public Napi::ObjectWrap<Test> {
 public:
   Test(const Napi::CallbackInfo& info) :
-    Napi::ObjectWrap<Test>(info) {
+    Napi::ObjectWrap<Test>(info),
+    Constructor(TestIter::Initialize(info.Env())) {
   }
 
   void SetMethod(const Napi::CallbackInfo& info) {
@@ -38,7 +33,7 @@ public:
   }
 
   Napi::Value Iter(const Napi::CallbackInfo& info) {
-    return TestIter::Constructor.New({});
+    return Constructor.New({});
   }
 
   void Setter(const Napi::CallbackInfo& info, const Napi::Value& new_value) {
@@ -62,11 +57,11 @@ public:
 
 private:
   uint32_t value;
+  Napi::FunctionReference Constructor;
 };
 
 Napi::Object InitObjectWrap(Napi::Env env) {
   Napi::Object exports = Napi::Object::New(env);
   Test::Initialize(env, exports);
-  TestIter::Initialize(env, exports);
   return exports;
 }


### PR DESCRIPTION
* Establish the build type by looking at whether test/build has a
subdirectory named "Release" or whether it has one named "Debug". Thus,
`npm test --debug` will also work.

* Correctly process the child exit status, examining both the exit code
*and* the signal it threw, if any.

* In `objectwrap` we must delete the reference to the constructor
sooner than the C++ library destructor for global data, because by the
time the library constructor gets called the V8 machinery has been
decommissioned and causes a segfault when attempting the belated
deletion of a reference.