### PR TITLE
Fix warnings when running npm test

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2434,7 +2434,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
   // TODO: Delete when the class is destroyed
   StaticVoidMethodCallbackData* callbackData = new StaticVoidMethodCallbackData({ method, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::StaticVoidMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2451,7 +2451,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
   // TODO: Delete when the class is destroyed
   StaticMethodCallbackData* callbackData = new StaticMethodCallbackData({ method, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::StaticMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2470,7 +2470,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
   StaticAccessorCallbackData* callbackData =
     new StaticAccessorCallbackData({ getter, setter, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
   desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
@@ -2489,7 +2489,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
   InstanceVoidMethodCallbackData* callbackData =
     new InstanceVoidMethodCallbackData({ method, data});
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::InstanceVoidMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2506,7 +2506,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
   // TODO: Delete when the class is destroyed
   InstanceMethodCallbackData* callbackData = new InstanceMethodCallbackData({ method, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::InstanceMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2524,7 +2524,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
   InstanceVoidMethodCallbackData* callbackData =
     new InstanceVoidMethodCallbackData({ method, data});
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = T::InstanceVoidMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2541,7 +2541,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceMethod(
   // TODO: Delete when the class is destroyed
   InstanceMethodCallbackData* callbackData = new InstanceMethodCallbackData({ method, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = T::InstanceMethodCallbackWrapper;
   desc.data = callbackData;
@@ -2560,7 +2560,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceAccessor(
   InstanceAccessorCallbackData* callbackData =
     new InstanceAccessorCallbackData({ getter, setter, data });
 
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.getter = getter != nullptr ? T::InstanceGetterCallbackWrapper : nullptr;
   desc.setter = setter != nullptr ? T::InstanceSetterCallbackWrapper : nullptr;
@@ -2572,7 +2572,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceAccessor(
 template <typename T>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(const char* utf8name,
     Napi::Value value, napi_property_attributes attributes) {
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.value = value;
   desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
@@ -2584,7 +2584,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
     const char* utf8name,
     Napi::Value value,
     napi_property_attributes attributes) {
-  napi_property_descriptor desc = {};
+  napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.value = value;
   desc.attributes = attributes;


### PR DESCRIPTION
The warnings occur due to a bug in gcc(<5.1.1)[1]. To fix this issue,
we can use constructor initializer instead of empty braces initializer.

This change is fixing #164 issue.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61489