### PR TITLE
Introduce new build targets for debugging purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ npm install
 npm test --disable-deprecated
 ```
 
+### **Debug**
+
+To run the **node-addon-api** tests with `--debug` option:
+
+```
+npm run-script dev
+```
+
+If you want faster build, you might use the following option:
+
+```
+npm run-script dev:incremental
+```
+
 Take a look and get inspired by our **[test suite](https://github.com/nodejs/node-addon-api/tree/master/test)**
 
 <a name="resources"></a>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
   "scripts": {
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
+    "predev": "node-gyp rebuild -C test --debug",
+    "dev": "node test",
+    "predev:incremental": "node-gyp configure build -C test --debug",
+    "dev:incremental": "node test",
     "doc": "doxygen doc/Doxyfile"
   },
   "version": "1.6.2"


### PR DESCRIPTION
In this project, we can use the following command to test examples.
`$ npm test`

It might be very inefficient, especially, if the number of files
increases. So, this patch introduces new build targets for debugging
purpose as follows:
```
$ npm run-script dev                # Build with --debug option
$ npm run-script dev:incremental    # Incremental dev build
```

This idea comes from @DaAitch.