### PR TITLE
Make Buffer extend Uint8Array instead of directly extending Object

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1524,17 +1524,17 @@ inline Buffer<T> Buffer<T>::Copy(napi_env env, const T* data, size_t length) {
 }
 
 template <typename T>
-inline Buffer<T>::Buffer() : Object(), _length(0), _data(nullptr) {
+inline Buffer<T>::Buffer() : Uint8Array(), _length(0), _data(nullptr) {
 }
 
 template <typename T>
 inline Buffer<T>::Buffer(napi_env env, napi_value value)
-  : Object(env, value), _length(0), _data(nullptr) {
+  : Uint8Array(env, value), _length(0), _data(nullptr) {
 }
 
 template <typename T>
 inline Buffer<T>::Buffer(napi_env env, napi_value value, size_t length, T* data)
-  : Object(env, value), _length(length), _data(data) {
+  : Uint8Array(env, value), _length(length), _data(data) {
 }
 
 template <typename T>

--- a/napi.h
+++ b/napi.h
@@ -835,7 +835,7 @@ namespace Napi {
   };
 
   template <typename T>
-  class Buffer : public Object {
+  class Buffer : public Uint8Array {
   public:
     static Buffer<T> New(napi_env env, size_t length);
     static Buffer<T> New(napi_env env, T* data, size_t length);


### PR DESCRIPTION
For issue: https://github.com/nodejs/node-addon-api/issues/109