### PR TITLE
Add missing tests for Object::Has() methods

### DIFF
--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -12,6 +12,7 @@
         'object/delete_property.cc',
         'object/get_property.cc',
         'object/has_own_property.cc',
+        'object/has_property.cc',
         'object/object.cc',
         'object/set_property.cc',
         'promise.cc',

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ let testModules = [
   'object/delete_property',
   'object/get_property',
   'object/has_own_property',
+  'object/has_property',
   'object/object',
   'object/set_property',
   'promise',

--- a/test/object/has_property.cc
+++ b/test/object/has_property.cc
@@ -1,0 +1,27 @@
+#include "napi.h"
+
+using namespace Napi;
+
+Value HasPropertyWithNapiValue(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Name key = info[1].As<Name>();
+  return Boolean::New(info.Env(), obj.Has(static_cast<napi_value>(key)));
+}
+
+Value HasPropertyWithNapiWrapperValue(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Name key = info[1].As<Name>();
+  return Boolean::New(info.Env(), obj.Has(key));
+}
+
+Value HasPropertyWithCStyleString(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  String jsKey = info[1].As<String>();
+  return Boolean::New(info.Env(), obj.Has(jsKey.Utf8Value().c_str()));
+}
+
+Value HasPropertyWithCppStyleString(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  String jsKey = info[1].As<String>();
+  return Boolean::New(info.Env(), obj.Has(jsKey.Utf8Value()));
+}

--- a/test/object/has_property.js
+++ b/test/object/has_property.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+
+test(require(`../build/${buildType}/binding.node`));
+test(require(`../build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  function testHasProperty(nativeHasProperty) {
+    const obj = { one: 1 };
+
+    Object.defineProperty(obj, 'two', { value: 2 });
+
+    assert.strictEqual(nativeHasProperty(obj, 'one'), true);
+    assert.strictEqual(nativeHasProperty(obj, 'two'), true);
+    assert.strictEqual('toString' in obj, true);
+    assert.strictEqual(nativeHasProperty(obj, 'toString'), true);
+  }
+
+  function testShouldThrowErrorIfKeyIsInvalid(nativeHasProperty) {
+    assert.throws(() => {
+      nativeHasProperty(undefined, 'test');
+    }, /object was expected/);
+  }
+
+  testHasProperty(binding.object.hasPropertyWithNapiValue);
+  testHasProperty(binding.object.hasPropertyWithNapiWrapperValue);
+  testHasProperty(binding.object.hasPropertyWithCStyleString);
+  testHasProperty(binding.object.hasPropertyWithCppStyleString);
+
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithNapiValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithNapiWrapperValue);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithCStyleString);
+  testShouldThrowErrorIfKeyIsInvalid(binding.object.hasPropertyWithCppStyleString);
+}

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -26,6 +26,12 @@ Value HasOwnPropertyWithNapiWrapperValue(const CallbackInfo& info);
 Value HasOwnPropertyWithCStyleString(const CallbackInfo& info);
 Value HasOwnPropertyWithCppStyleString(const CallbackInfo& info);
 
+// Native wrappers for testing Object::Has()
+Value HasPropertyWithNapiValue(const CallbackInfo& info);
+Value HasPropertyWithNapiWrapperValue(const CallbackInfo& info);
+Value HasPropertyWithCStyleString(const CallbackInfo& info);
+Value HasPropertyWithCppStyleString(const CallbackInfo& info);
+
 static bool testValue = true;
 
 Value TestGetter(const CallbackInfo& info) {
@@ -160,6 +166,11 @@ Object InitObject(Env env) {
   exports["hasOwnPropertyWithNapiWrapperValue"] = Function::New(env, HasOwnPropertyWithNapiWrapperValue);
   exports["hasOwnPropertyWithCStyleString"] = Function::New(env, HasOwnPropertyWithCStyleString);
   exports["hasOwnPropertyWithCppStyleString"] = Function::New(env, HasOwnPropertyWithCppStyleString);
+
+  exports["hasPropertyWithNapiValue"] = Function::New(env, HasPropertyWithNapiValue);
+  exports["hasPropertyWithNapiWrapperValue"] = Function::New(env, HasPropertyWithNapiWrapperValue);
+  exports["hasPropertyWithCStyleString"] = Function::New(env, HasPropertyWithCStyleString);
+  exports["hasPropertyWithCppStyleString"] = Function::New(env, HasPropertyWithCppStyleString);
 
   exports["createObjectUsingMagic"] = Function::New(env, CreateObjectUsingMagic);
 


### PR DESCRIPTION
There is no test for Object::Has() in current source tree.