### PR TITLE
Implement Value.isDataView()

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -347,6 +347,19 @@ inline bool Value::IsPromise() const {
   return result;
 }
 
+#if NAPI_DATA_VIEW_FEATURE
+inline bool Value::IsDataView() const {
+  if (_value == nullptr) {
+    return false;
+  }
+
+  bool result;
+  napi_status status = napi_is_dataview(_env, _value, &result);
+  NAPI_THROW_IF_FAILED(_env, status, false);
+  return result;
+}
+#endif
+
 inline bool Value::IsBuffer() const {
   if (_value == nullptr) {
     return false;

--- a/napi.h
+++ b/napi.h
@@ -177,6 +177,9 @@ namespace Napi {
     bool IsObject() const;      ///< Tests if a value is a JavaScript object.
     bool IsFunction() const;    ///< Tests if a value is a JavaScript function.
     bool IsPromise() const;     ///< Tests if a value is a JavaScript promise.
+#if NAPI_DATA_VIEW_FEATURE
+    bool IsDataView() const;    ///< Tests if a value is a JavaScript data view.
+#endif
     bool IsBuffer() const;      ///< Tests if a value is a Node buffer.
 
     /// Casts to another type of `Napi::Value`, when the actual type is known or assumed.

--- a/test/basic_types/value.cc
+++ b/test/basic_types/value.cc
@@ -55,6 +55,10 @@ static Value IsPromise(const CallbackInfo& info) {
   return Boolean::New(info.Env(), info[0].IsPromise());
 }
 
+static Value IsDataView(const CallbackInfo& info) {
+  return Boolean::New(info.Env(), info[0].IsDataView());
+}
+
 static Value ToBoolean(const CallbackInfo& info) {
   return info[0].ToBoolean();
 }
@@ -87,6 +91,7 @@ Object InitBasicTypesValue(Env env) {
   exports["isObject"] = Function::New(env, IsObject);
   exports["isFunction"] = Function::New(env, IsFunction);
   exports["isPromise"] = Function::New(env, IsPromise);
+  exports["isDataView"] = Function::New(env, IsDataView);
   exports["toBoolean"] = Function::New(env, ToBoolean);
   exports["toNumber"] = Function::New(env, ToNumber);
   exports["toString"] = Function::New(env, ToString);

--- a/test/basic_types/value.js
+++ b/test/basic_types/value.js
@@ -24,8 +24,13 @@ function test(binding) {
     if (value instanceof ArrayBuffer)
       return 'arraybuffer';
 
-    if (ArrayBuffer.isView(value))
-      return 'typedarray';
+    if (ArrayBuffer.isView(value)) {
+      if (value instanceof DataView) {
+        return 'dataview';
+      } else {
+        return 'typedarray';
+      }
+    }
 
     if (value instanceof Promise)
       return 'promise';
@@ -46,7 +51,8 @@ function test(binding) {
       new Int32Array(new ArrayBuffer(12)),
       {},
       function() {},
-      new Promise((resolve, reject) => {})
+      new Promise((resolve, reject) => {}),
+      new DataView(new ArrayBuffer(12))
     ];
 
     testValueList.forEach((testValue) => {
@@ -99,6 +105,7 @@ function test(binding) {
   typeCheckerTest(value.isObject, 'object');
   typeCheckerTest(value.isFunction, 'function');
   typeCheckerTest(value.isPromise, 'promise');
+  typeCheckerTest(value.isDataView, 'dataview');
 
   typeConverterTest(value.toBoolean, Boolean);
   assert.strictEqual(value.toBoolean(undefined), false);

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -27,7 +27,7 @@
   'targets': [
     {
       'target_name': 'binding',
-      'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+      'defines': [ 'NAPI_CPP_EXCEPTIONS', 'NAPI_DATA_VIEW_FEATURE' ],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'msvs_settings': {
@@ -41,7 +41,7 @@
     },
     {
       'target_name': 'binding_noexcept',
-      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+      'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_DATA_VIEW_FEATURE' ],
       'cflags': [ '-fno-exceptions' ],
       'cflags_cc': [ '-fno-exceptions' ],
       'msvs_settings': {


### PR DESCRIPTION
The method is to check if the given value is a data view object. This ia
an initial implementation of DataView feature(#196).

This change also adds the NAPI_DATA_VIEW_FEATURE flag to expose only to
test modules until all features are implemented.