### PR TITLE
n-api: fix memory leak in napi_async_destroy()

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2855,6 +2855,8 @@ napi_status napi_async_destroy(napi_env env,
       reinterpret_cast<node::async_context*>(async_context);
   node::EmitAsyncDestroy(isolate, *node_async_context);
 
+  delete node_async_context;
+
   return napi_clear_last_error(env);
 }
 


### PR DESCRIPTION
This is a cherry-pick patch from upstream[1].

[1] https://github.com/nodejs/node/pull/17714/commits/87cb1f53a57797132ce7a61fe23c7fde5ea21cfd