### PR TITLE
n-api: throw RangeError in napi_create_dataview() with invalid range

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -3253,6 +3253,14 @@ napi_status napi_create_dataview(napi_env env,
   RETURN_STATUS_IF_FALSE(env, value->IsArrayBuffer(), napi_invalid_arg);
 
   v8::Local<v8::ArrayBuffer> buffer = value.As<v8::ArrayBuffer>();
+  if (byte_length + byte_offset > buffer->ByteLength()) {
+    napi_throw_range_error(
+        env,
+        "ERR_NAPI_INVALID_DATAVIEW_ARGS",
+        "byte_offset + byte_length should be less than or "
+        "equal to the size in bytes of the array passed in");
+    return napi_set_last_error(env, napi_generic_failure);
+  }
   v8::Local<v8::DataView> DataView = v8::DataView::New(buffer, byte_offset,
                                                        byte_length);
 


### PR DESCRIPTION
The API is required that `byte_length + byte_offset` is less than or
equal to the size in bytes of the array passed in. If not, a RangeError
exception is raised[1].

This is a partial cherry-pick from upstream[2].

[1] https://nodejs.org/api/n-api.html#n_api_napi_create_dataview
[2] https://github.com/nodejs/node/pull/17869/commits/2e329e9b776e0bea5e045a370858fb908dbdea5d