### PR TITLE
Make IsObject() allow functions

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -329,7 +329,7 @@ inline bool Value::IsTypedArray() const {
 }
 
 inline bool Value::IsObject() const {
-  return Type() == napi_object;
+  return Type() == napi_object || IsFunction();
 }
 
 inline bool Value::IsFunction() const {

--- a/test/basic_types/value.js
+++ b/test/basic_types/value.js
@@ -7,6 +7,10 @@ test(require(`../build/${buildType}/binding.node`));
 test(require(`../build/${buildType}/binding_noexcept.node`));
 
 function test(binding) {
+  function isObject(value) {
+    return typeof value === 'object' || typeof value === 'function';
+  }
+
   function detailedTypeOf(value) {
     const type = typeof value;
     if (type !== 'object')
@@ -57,7 +61,7 @@ function test(binding) {
 
     testValueList.forEach((testValue) => {
       if (testValue !== null && expectedType === 'object') {
-        assert.strictEqual(typeChecker(testValue), typeof testValue === expectedType);
+        assert.strictEqual(typeChecker(testValue), isObject(testValue));
       } else {
         assert.strictEqual(typeChecker(testValue), detailedTypeOf(testValue) === expectedType);
       }


### PR DESCRIPTION
As discussed in the issue[1], IsObject() should return true for a
function.

[1] https://github.com/nodejs/node-addon-api/issues/207