### PR TITLE
Fix/nullptr error message

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1729,7 +1729,7 @@ inline NAPI_NO_RETURN void Error::Fatal(const char* location, const char* messag
   napi_fatal_error(location, NAPI_AUTO_LENGTH, message, NAPI_AUTO_LENGTH);
 }
 
-inline Error::Error() : ObjectReference(), _message(nullptr) {
+inline Error::Error() : ObjectReference() {
 }
 
 inline Error::Error(napi_env env, napi_value value) : ObjectReference(env, nullptr) {

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -32,7 +32,10 @@
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
       'msvs_settings': {
-        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+        'VCCLCompilerTool': { 
+          'ExceptionHandling': 1,
+          'EnablePREfast': 'true',
+        },
       },
       'xcode_settings': {
         'CLANG_CXX_LIBRARY': 'libc++',
@@ -46,7 +49,10 @@
       'cflags': [ '-fno-exceptions' ],
       'cflags_cc': [ '-fno-exceptions' ],
       'msvs_settings': {
-        'VCCLCompilerTool': { 'ExceptionHandling': 0 },
+        'VCCLCompilerTool': { 
+          'ExceptionHandling': 0,
+          'EnablePREfast': 'true',
+        },
       },
       'xcode_settings': {
         'CLANG_CXX_LIBRARY': 'libc++',


### PR DESCRIPTION
Fixes #224.

The Napi::Error constructor was initializing the `std::string _message` private member variable to `nullptr`. As a class, std::string automatically initializes to the equivalent of a blank string. `_message` isn't a pointer; assigning a pointer literal (nullptr) to it causes static analysis warnings.

I've also enabled Visual C++ Static Analysis (Prefast) in the test suite to detect these sorts of problems. If that isn't desirable let me know and I'll back out that part of the PR.