### PR TITLE
test: fix MSVC warning C4244 in tests

### DIFF
--- a/test/basic_types/number.cc
+++ b/test/basic_types/number.cc
@@ -13,7 +13,8 @@ Value ToUint32(const CallbackInfo& info) {
 }
 
 Value ToInt64(const CallbackInfo& info) {
-  return Number::New(info.Env(), info[0].As<Number>().Int64Value());
+  return Number::New(info.Env(),
+                     static_cast<double>(info[0].As<Number>().Int64Value()));
 }
 
 Value ToFloat(const CallbackInfo& info) {

--- a/test/dataview/dataview.cc
+++ b/test/dataview/dataview.cc
@@ -25,11 +25,13 @@ static Value GetArrayBuffer(const CallbackInfo& info) {
 }
 
 static Value GetByteOffset(const CallbackInfo& info) {
-  return Number::New(info.Env(), info[0].As<DataView>().ByteOffset());
+  return Number::New(info.Env(),
+                     static_cast<double>(info[0].As<DataView>().ByteOffset()));
 }
 
 static Value GetByteLength(const CallbackInfo& info) {
-  return Number::New(info.Env(), info[0].As<DataView>().ByteLength());
+  return Number::New(info.Env(),
+                     static_cast<double>(info[0].As<DataView>().ByteLength()));
 }
 
 Object InitDataView(Env env) {


### PR DESCRIPTION
Fixes `warning C4244: 'argument': conversion from '::size_t' to
'double', possible loss of data` issues in `number` and `dataview`
tests.