### PR TITLE
don't try to escape null

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2285,36 +2285,60 @@ inline Napi::Value FunctionReference::operator ()(
 
 inline Napi::Value FunctionReference::Call(const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Call(args));
+  Napi::Value result = Value().Call(args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Napi::Value FunctionReference::Call(const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Call(args));
+  Napi::Value result = Value().Call(args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Napi::Value FunctionReference::Call(
     napi_value recv, const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Call(recv, args));
+  Napi::Value result = Value().Call(recv, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Napi::Value FunctionReference::Call(
     napi_value recv, const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Call(recv, args));
+  Napi::Value result = Value().Call(recv, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Napi::Value FunctionReference::MakeCallback(
     napi_value recv, const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().MakeCallback(recv, args));
+  Napi::Value result = Value().MakeCallback(recv, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Napi::Value FunctionReference::MakeCallback(
     napi_value recv, const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().MakeCallback(recv, args));
+  Napi::Value result = Value().MakeCallback(recv, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value(); 
+  }
+  return scope.Escape(result);
 }
 
 inline Object FunctionReference::New(const std::initializer_list<napi_value>& args) const {


### PR DESCRIPTION
If an exception is pending from Call Or MakeCallback on
FunctionReference the return value may be nullptr.
Check for a pending exception and don't try to escape in these cases.

Refs:  https://github.com/nodejs/node-addon-api/issues/233

Next step after this would be to add support for throwing fatal exception with node-addon-api which can include a test that validates the exception is correct.