### PR TITLE
docs: minor typos

### DIFF
--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -1,5 +1,5 @@
 # Array buffer
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/async_operations.md
+++ b/doc/async_operations.md
@@ -1,5 +1,5 @@
 # Asynchronous operations
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -1,5 +1,5 @@
 # Async worker
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/basic_types.md
+++ b/doc/basic_types.md
@@ -1,5 +1,5 @@
 # Basic Types
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/buffer.md
+++ b/doc/buffer.md
@@ -1,5 +1,5 @@
 # Buffer
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/callbackinfo.md
+++ b/doc/callbackinfo.md
@@ -52,7 +52,7 @@ Returns a `bool` indicating if the function that was invoked (and for which the 
 size_t Length() const;
 ```
 
-Returns the number of arguments passed in the Callabckinfo object.
+Returns the number of arguments passed in the CallbackInfo object.
 
 ### operator []
 

--- a/doc/class_property_descriptor.md
+++ b/doc/class_property_descriptor.md
@@ -1,5 +1,5 @@
 # Class propertry and descriptior
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/creating_a_release.md
+++ b/doc/creating_a_release.md
@@ -16,8 +16,8 @@ These are the steps to follow to create a new release:
 
 * Use https://ci.nodejs.org/view/x%20-%20Abi%20stable%20module%20API/job/node-test-node-addon-api/
   to validate tests pass for latest 9, 8, 6, 4 releases
-  (note there are still some issues on smartos and
-   windows in the testing).
+  (note there are still some issues on SmartOS and
+   Windows in the testing).
 
 * Update the version in package.json appropriately.
 
@@ -30,7 +30,7 @@ These are the steps to follow to create a new release:
 
 * Login and then run `npm publish`.
 
-* Create a release in github (look at existing releases for an example).
+* Create a release in Github (look at existing releases for an example).
 
 * Validate that you can run `npm install node-addon-api` successfully
   and that the correct version is installed.

--- a/doc/error.md
+++ b/doc/error.md
@@ -1,5 +1,5 @@
 # Error
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -1,5 +1,5 @@
 # Error handling
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/escapable_handle_sope.md
+++ b/doc/escapable_handle_sope.md
@@ -1,5 +1,5 @@
 # Escapable handle scope
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/function.md
+++ b/doc/function.md
@@ -1,5 +1,5 @@
 # Function
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -1,5 +1,5 @@
 # Function reference
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -1,5 +1,5 @@
 # Handle scope
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/name.md
+++ b/doc/name.md
@@ -1,5 +1,5 @@
 # Name
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/node-gyp.md
+++ b/doc/node-gyp.md
@@ -4,8 +4,8 @@ C++ code needs to be compiled into executable form whether it be as an object
 file to linked with others, a shared library, or a standalone executable.
 
 The main reason for this is that we need to link to the Node.js dependencies and
-headers correcrtly, another reason is that we need a cross platform way to build
-C++ soucre into binary for the target platform,
+headers correctly, another reason is that we need a cross platform way to build
+C++ source into binary for the target platform.
 
 Until now **node-gyp** is the **de-facto** standard build tool for writing
 Node.js addons. It's based on Google's **gyp** build tool, which abstract away

--- a/doc/object.md
+++ b/doc/object.md
@@ -1,5 +1,5 @@
 # Object
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/object_lifetime_management.md
+++ b/doc/object_lifetime_management.md
@@ -1,4 +1,4 @@
-# Array
+# Object lifetime management
 
 You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:

--- a/doc/object_reference.md
+++ b/doc/object_reference.md
@@ -1,5 +1,5 @@
 # Object reference
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -8,6 +8,6 @@ Classes extending ```ObjectWrap``` can be instantiated from JavaScript using the
 The **wrap** word refers to a way to group methods and state of your class because it
 will be your responsibility write custom code to bridge each of your C++ class methods.
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/onject_lifetime_management.md
+++ b/doc/onject_lifetime_management.md
@@ -1,5 +1,0 @@
-# Object lifetime management
-
-You are reading a draft of the next documentation and it's in continuos update so
-if you don't find what you need please refer to:
-[C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/promises.md
+++ b/doc/promises.md
@@ -1,5 +1,5 @@
 # Promise
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/property_descriptor.md
+++ b/doc/property_descriptor.md
@@ -1,5 +1,5 @@
 # property descriptor
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1,5 +1,5 @@
 # Reference
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -1,5 +1,5 @@
 # Symbol
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/typed_array.md
+++ b/doc/typed_array.md
@@ -1,5 +1,5 @@
 # Typed array
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/typed_array_of.md
+++ b/doc/typed_array_of.md
@@ -1,5 +1,5 @@
 # Typed array of
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)

--- a/doc/value.md
+++ b/doc/value.md
@@ -4,7 +4,7 @@
 
 Value is the C++ manifestation of a JavaScript value.
 
-Value is a the base class upon which other JavaScipt values such as Number, Boolean, String, and Object are based.
+Value is a the base class upon which other JavaScript values such as Number, Boolean, String, and Object are based.
 
 The following classes inherit, either directly or indirectly, from Value:
 

--- a/doc/working_with_javascript_values.md
+++ b/doc/working_with_javascript_values.md
@@ -1,5 +1,5 @@
 # Working with JavaScript Values
 
-You are reading a draft of the next documentation and it's in continuos update so
+You are reading a draft of the next documentation and it's in continuous update so
 if you don't find what you need please refer to:
 [C++ wrapper classes for the ABI-stable C APIs for Node.js](https://nodejs.github.io/node-addon-api/)


### PR DESCRIPTION
just some small typos in the docs
renamed `doc/onject_lifetime_management.md` to `doc/object_lifetime_management.md`