### PR TITLE
objectwrap: implement missing descriptor definitions for symbols

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2740,6 +2740,40 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
 }
 
 template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
+    Symbol name,
+    StaticVoidMethodCallback method,
+    napi_property_attributes attributes,
+    void* data) {
+  // TODO: Delete when the class is destroyed
+  StaticVoidMethodCallbackData* callbackData = new StaticVoidMethodCallbackData({ method, data });
+
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
+  desc.method = T::StaticVoidMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
+    Symbol name,
+    StaticMethodCallback method,
+    napi_property_attributes attributes,
+    void* data) {
+  // TODO: Delete when the class is destroyed
+  StaticMethodCallbackData* callbackData = new StaticMethodCallbackData({ method, data });
+
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
+  desc.method = T::StaticMethodCallbackWrapper;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
     const char* utf8name,
     StaticGetterCallback getter,
@@ -2752,6 +2786,26 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
+  desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
+  desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
+  desc.data = callbackData;
+  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
+    Symbol name,
+    StaticGetterCallback getter,
+    StaticSetterCallback setter,
+    napi_property_attributes attributes,
+    void* data) {
+  // TODO: Delete when the class is destroyed
+  StaticAccessorCallbackData* callbackData =
+    new StaticAccessorCallbackData({ getter, setter, data });
+
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
   desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
   desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
   desc.data = callbackData;
@@ -2850,10 +2904,40 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceAccessor(
 }
 
 template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceAccessor(
+    Symbol name,
+    InstanceGetterCallback getter,
+    InstanceSetterCallback setter,
+    napi_property_attributes attributes,
+    void* data) {
+  // TODO: Delete when the class is destroyed
+  InstanceAccessorCallbackData* callbackData =
+    new InstanceAccessorCallbackData({ getter, setter, data });
+
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
+  desc.getter = getter != nullptr ? T::InstanceGetterCallbackWrapper : nullptr;
+  desc.setter = setter != nullptr ? T::InstanceSetterCallbackWrapper : nullptr;
+  desc.data = callbackData;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(const char* utf8name,
     Napi::Value value, napi_property_attributes attributes) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
+  desc.value = value;
+  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(Symbol name,
+    Napi::Value value, napi_property_attributes attributes) {
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
   desc.value = value;
   desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
@@ -2866,6 +2950,18 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
     napi_property_attributes attributes) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
+  desc.value = value;
+  desc.attributes = attributes;
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
+    Symbol name,
+    Napi::Value value,
+    napi_property_attributes attributes) {
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
   desc.value = value;
   desc.attributes = attributes;
   return desc;

--- a/napi.h
+++ b/napi.h
@@ -1395,7 +1395,20 @@ namespace Napi {
                                            StaticMethodCallback method,
                                            napi_property_attributes attributes = napi_default,
                                            void* data = nullptr);
+    static PropertyDescriptor StaticMethod(Symbol name,
+                                           StaticVoidMethodCallback method,
+                                           napi_property_attributes attributes = napi_default,
+                                           void* data = nullptr);
+    static PropertyDescriptor StaticMethod(Symbol name,
+                                           StaticMethodCallback method,
+                                           napi_property_attributes attributes = napi_default,
+                                           void* data = nullptr);
     static PropertyDescriptor StaticAccessor(const char* utf8name,
+                                             StaticGetterCallback getter,
+                                             StaticSetterCallback setter,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor StaticAccessor(Symbol name,
                                              StaticGetterCallback getter,
                                              StaticSetterCallback setter,
                                              napi_property_attributes attributes = napi_default,
@@ -1421,10 +1434,21 @@ namespace Napi {
                                                InstanceSetterCallback setter,
                                                napi_property_attributes attributes = napi_default,
                                                void* data = nullptr);
+    static PropertyDescriptor InstanceAccessor(Symbol name,
+                                               InstanceGetterCallback getter,
+                                               InstanceSetterCallback setter,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
     static PropertyDescriptor StaticValue(const char* utf8name,
                                           Napi::Value value,
                                           napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor StaticValue(Symbol name,
+                                          Napi::Value value,
+                                          napi_property_attributes attributes = napi_default);
     static PropertyDescriptor InstanceValue(const char* utf8name,
+                                            Napi::Value value,
+                                            napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor InstanceValue(Symbol name,
                                             Napi::Value value,
                                             napi_property_attributes attributes = napi_default);
 

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -1,66 +1,118 @@
 #include <napi.h>
 
-class TestIter : public Napi::ObjectWrap<TestIter> {
-public:
-  TestIter(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TestIter>(info) {}
+Napi::ObjectReference testStaticContextRef;
 
-  Napi::Value Next(const Napi::CallbackInfo& info) {
-    auto object = Napi::Object::New(info.Env());
-    object.Set("done", Napi::Boolean::New(info.Env(), true));
-    return object;
-  }
+Napi::Value StaticGetter(const Napi::CallbackInfo& info) {
+  return testStaticContextRef.Value().Get("value");
+}
 
-  static Napi::FunctionReference Initialize(Napi::Env env) {
-    return Napi::Persistent(DefineClass(env, "TestIter", {
-      InstanceMethod("next", &TestIter::Next),
-    }));
-  }
-};
+void StaticSetter(const Napi::CallbackInfo& info, const Napi::Value& value) {
+  testStaticContextRef.Value().Set("value", value);
+}
+
+Napi::Value TestStaticMethod(const Napi::CallbackInfo& info) {
+  std::string str = info[0].ToString();
+  return Napi::String::New(info.Env(), str + " static");
+}
+
+Napi::Value TestStaticMethodInternal(const Napi::CallbackInfo& info) {
+  std::string str = info[0].ToString();
+  return Napi::String::New(info.Env(), str + " static internal");
+}
 
 class Test : public Napi::ObjectWrap<Test> {
 public:
   Test(const Napi::CallbackInfo& info) :
-    Napi::ObjectWrap<Test>(info),
-    Constructor(TestIter::Initialize(info.Env())) {
+    Napi::ObjectWrap<Test>(info) {
   }
 
-  void SetMethod(const Napi::CallbackInfo& info) {
-    value = info[0].As<Napi::Number>();
-  }
-
-  Napi::Value GetMethod(const Napi::CallbackInfo& info) {
-    return Napi::Number::New(info.Env(), value);
-  }
-
-  Napi::Value Iter(const Napi::CallbackInfo& info) {
-    return Constructor.New({});
-  }
-
-  void Setter(const Napi::CallbackInfo& info, const Napi::Value& new_value) {
-    value = new_value.As<Napi::Number>();
+  void Setter(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    value_ = value.ToString();
   }
 
   Napi::Value Getter(const Napi::CallbackInfo& info) {
-    return Napi::Number::New(info.Env(), value);
+    return Napi::String::New(info.Env(), value_);
+  }
+
+  Napi::Value TestMethod(const Napi::CallbackInfo& info) {
+    std::string str = info[0].ToString();
+    return Napi::String::New(info.Env(), str + " instance");
+  }
+
+  Napi::Value TestMethodInternal(const Napi::CallbackInfo& info) {
+    std::string str = info[0].ToString();
+    return Napi::String::New(info.Env(), str + " instance internal");
+  }
+
+  Napi::Value ToStringTag(const Napi::CallbackInfo& info) {
+    return Napi::String::From(info.Env(), "TestTag");
+  }
+
+  // creates dummy array, returns `([value])[Symbol.iterator]()`
+  Napi::Value Iterator(const Napi::CallbackInfo& info) {
+    Napi::Array array = Napi::Array::New(info.Env());
+    array.Set(array.Length(), Napi::String::From(info.Env(), value_));
+    return array.Get(Napi::Symbol::WellKnown(info.Env(), "iterator")).As<Napi::Function>().Call(array, {});
   }
 
   static void Initialize(Napi::Env env, Napi::Object exports) {
+    
+    Napi::Symbol kTestStaticValueInternal = Napi::Symbol::New(env, "kTestStaticValueInternal");
+    Napi::Symbol kTestStaticAccessorInternal = Napi::Symbol::New(env, "kTestStaticAccessorInternal");
+    Napi::Symbol kTestStaticMethodInternal = Napi::Symbol::New(env, "kTestStaticMethodInternal");
+
+    Napi::Symbol kTestValueInternal = Napi::Symbol::New(env, "kTestValueInternal");
+    Napi::Symbol kTestAccessorInternal = Napi::Symbol::New(env, "kTestAccessorInternal");
+    Napi::Symbol kTestMethodInternal = Napi::Symbol::New(env, "kTestMethodInternal");
+    
     exports.Set("Test", DefineClass(env, "Test", {
-      InstanceMethod("test_set_method", &Test::SetMethod),
-      InstanceMethod("test_get_method", &Test::GetMethod),
-      InstanceMethod(Napi::Symbol::WellKnown(env, "iterator"), &Test::Iter),
-      InstanceAccessor("test_getter_only", &Test::Getter, nullptr),
-      InstanceAccessor("test_setter_only", nullptr, &Test::Setter),
-      InstanceAccessor("test_getter_setter", &Test::Getter, &Test::Setter),
+
+      // expose symbols for testing
+      StaticValue("kTestStaticValueInternal", kTestStaticValueInternal),
+      StaticValue("kTestStaticAccessorInternal", kTestStaticAccessorInternal),
+      StaticValue("kTestStaticMethodInternal", kTestStaticMethodInternal),
+      StaticValue("kTestValueInternal", kTestValueInternal),
+      StaticValue("kTestAccessorInternal", kTestAccessorInternal),
+      StaticValue("kTestMethodInternal", kTestMethodInternal),
+
+      // test data
+      StaticValue("testStaticValue", Napi::String::New(env, "value"), napi_enumerable),
+      StaticValue(kTestStaticValueInternal, Napi::Number::New(env, 5), napi_default),
+
+      StaticAccessor("testStaticGetter", &StaticGetter, nullptr, napi_enumerable),
+      StaticAccessor("testStaticSetter", nullptr, &StaticSetter, napi_default),
+      StaticAccessor("testStaticGetSet", &StaticGetter, &StaticSetter, napi_enumerable),
+      StaticAccessor(kTestStaticAccessorInternal, &StaticGetter, &StaticSetter, napi_enumerable),
+
+      StaticMethod("testStaticMethod", &TestStaticMethod, napi_enumerable),
+      StaticMethod(kTestStaticMethodInternal, &TestStaticMethodInternal, napi_default),
+
+      InstanceValue("testValue", Napi::Boolean::New(env, true), napi_enumerable),
+      InstanceValue(kTestValueInternal, Napi::Boolean::New(env, false), napi_enumerable),
+
+      InstanceAccessor("testGetter", &Test::Getter, nullptr, napi_enumerable),
+      InstanceAccessor("testSetter", nullptr, &Test::Setter, napi_default),
+      InstanceAccessor("testGetSet", &Test::Getter, &Test::Setter, napi_enumerable),
+      InstanceAccessor(kTestAccessorInternal, &Test::Getter, &Test::Setter, napi_enumerable),
+
+      InstanceMethod("testMethod", &Test::TestMethod, napi_enumerable),
+      InstanceMethod(kTestMethodInternal, &Test::TestMethodInternal, napi_default),
+
+      // conventions
+      InstanceAccessor(Napi::Symbol::WellKnown(env, "toStringTag"), &Test::ToStringTag, nullptr, napi_enumerable),
+      InstanceMethod(Napi::Symbol::WellKnown(env, "iterator"), &Test::Iterator, napi_default),
+
     }));
   }
 
 private:
-  uint32_t value;
-  Napi::FunctionReference Constructor;
+  std::string value_;
 };
 
 Napi::Object InitObjectWrap(Napi::Env env) {
+  testStaticContextRef = Napi::Persistent(Napi::Object::New(env));
+  testStaticContextRef.SuppressDestruct();
+
   Napi::Object exports = Napi::Object::New(env);
   Test::Initialize(env, exports);
   return exports;

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -2,61 +2,209 @@
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+const test = (binding) => {
+  const Test = binding.objectwrap.Test;
 
-function test(binding) {
-  var Test = binding.objectwrap.Test;
+  const testValue = (obj, clazz) => {
+    assert.strictEqual(obj.testValue, true);
+    assert.strictEqual(obj[clazz.kTestValueInternal], false);
+  };
 
-  function testSetGetMethod(obj) {
-    obj.test_set_method(90);
-    assert.strictEqual(obj.test_get_method(), 90);
-  }
+  const testAccessor = (obj, clazz) => {
+    // read-only, write-only
+    {
+      obj.testSetter = 'instance getter';
+      assert.strictEqual(obj.testGetter, 'instance getter');
 
-  function testIter(obj) {
-    for (const value of obj) {
+      obj.testSetter = 'instance getter 2';
+      assert.strictEqual(obj.testGetter, 'instance getter 2');
     }
-  }
 
-  function testGetterOnly(obj) {
-    obj.test_set_method(91);
-    assert.strictEqual(obj.test_getter_only, 91);
+    // read write-only
+    {
+      let error;
+      try { const read = obj.testSetter; } catch (e) { error = e; }
+      // no error
+      assert.strictEqual(error, undefined);
 
-    let error;
-    try {
-      // Can not assign to read only property.
-      obj.test_getter_only = 92;
-    } catch(e) {
-      error = e;
-    } finally {
+      // read is undefined
+      assert.strictEqual(obj.testSetter, undefined);
+    }
+
+    // write read-only
+    {
+      let error;
+      try { obj.testGetter = 'write'; } catch (e) { error = e; }
       assert.strictEqual(error.name, 'TypeError');
     }
+
+    // rw
+    {
+      obj.testGetSet = 'instance getset';
+      assert.strictEqual(obj.testGetSet, 'instance getset');
+
+      obj.testGetSet = 'instance getset 2';
+      assert.strictEqual(obj.testGetSet, 'instance getset 2');
+    }
+
+    // rw symbol
+    {
+      obj[clazz.kTestAccessorInternal] = 'instance internal getset';
+      assert.strictEqual(obj[clazz.kTestAccessorInternal], 'instance internal getset');
+
+      obj[clazz.kTestAccessorInternal] = 'instance internal getset 2';
+      assert.strictEqual(obj[clazz.kTestAccessorInternal], 'instance internal getset 2');
+    }
+  };
+
+  const testMethod = (obj, clazz) => {
+    assert.strictEqual(obj.testMethod('method'), 'method instance');
+    assert.strictEqual(obj[clazz.kTestMethodInternal]('method'), 'method instance internal');
+  };
+
+  const testEnumerables = (obj, clazz) => {
+    // Object.keys: only object
+    assert.deepEqual(Object.keys(obj), []);
+
+    // for..in: object + prototype
+    {
+      const keys = [];
+      for (let key in obj) {
+        keys.push(key);
+      }
+
+      assert.deepEqual(keys, [
+        'testGetSet',
+        'testGetter',
+        'testValue',
+        'testMethod'
+      ]);
+    }
+  };
+
+  const testConventions = (obj, clazz) => {
+    // test @@toStringTag
+    {
+      assert.strictEqual(obj[Symbol.toStringTag], 'TestTag');
+      assert.strictEqual('' + obj, '[object TestTag]');
+    }
+
+    // test @@iterator
+    {
+      obj.testSetter = 'iterator';
+      const values = [];
+
+      for (let item of obj) {
+        values.push(item);
+      }
+
+      assert.deepEqual(values, ['iterator']);
+    }
+  };
+
+  const testStaticValue = (clazz) => {
+    assert.strictEqual(clazz.testStaticValue, 'value');
+    assert.strictEqual(clazz[clazz.kTestStaticValueInternal], 5);
   }
 
-  function testSetterOnly(obj) {
-    obj.test_setter_only = 93;
-    assert.strictEqual(obj.test_setter_only, undefined);
-    assert.strictEqual(obj.test_getter_only, 93);
+  const testStaticAccessor = (clazz) => {
+    // read-only, write-only
+    {
+      const tempObj = {};
+      clazz.testStaticSetter = tempObj;
+      assert.strictEqual(clazz.testStaticGetter, tempObj);
+
+      const tempArray = [];
+      clazz.testStaticSetter = tempArray;
+      assert.strictEqual(clazz.testStaticGetter, tempArray);
+    }
+
+    // read write-only
+    {
+      let error;
+      try { const read = clazz.testStaticSetter; } catch (e) { error = e; }
+      // no error
+      assert.strictEqual(error, undefined);
+
+      // read is undefined
+      assert.strictEqual(clazz.testStaticSetter, undefined);
+    }
+
+    // write-read-only
+    {
+      let error;
+      try { clazz.testStaticGetter = 'write'; } catch (e) { error = e; }
+      assert.strictEqual(error.name, 'TypeError');
+    }
+
+    // rw
+    {
+      clazz.testStaticGetSet = 9;
+      assert.strictEqual(clazz.testStaticGetSet, 9);
+
+      clazz.testStaticGetSet = 4;
+      assert.strictEqual(clazz.testStaticGetSet, 4);
+    }
+
+    // rw symbol
+    {
+      clazz[clazz.kTestStaticAccessorInternal] = 'static internal getset';
+      assert.strictEqual(clazz[clazz.kTestStaticAccessorInternal], 'static internal getset');
+    }
+  };
+
+  const testStaticMethod = (clazz) => {
+    assert.strictEqual(clazz.testStaticMethod('method'), 'method static');
+    assert.strictEqual(clazz[clazz.kTestStaticMethodInternal]('method'), 'method static internal');
+  };
+
+  const testStaticEnumerables = (clazz) => {
+    // Object.keys
+    assert.deepEqual(Object.keys(clazz), [
+      'testStaticValue',
+      'testStaticGetter',
+      'testStaticGetSet',
+      'testStaticMethod'
+    ]);
+
+    // for..in
+    {
+      const keys = [];
+      for (let key in clazz) {
+        keys.push(key);
+      }
+
+      assert.deepEqual(keys, [
+        'testStaticValue',
+        'testStaticGetter',
+        'testStaticGetSet',
+        'testStaticMethod'
+      ]);
+    }
+  };
+
+  const testObj = (obj, clazz) => {
+    testValue(obj, clazz);
+    testAccessor(obj, clazz);
+    testMethod(obj, clazz);
+
+    testEnumerables(obj, clazz);
+
+    testConventions(obj, clazz);
   }
 
-  function testGetterSetter(obj) {
-    obj.test_getter_setter = 94;
-    assert.strictEqual(obj.test_getter_setter, 94);
+  const testClass = (clazz) => {
+    testStaticValue(clazz);
+    testStaticAccessor(clazz);
+    testStaticMethod(clazz);
 
-    obj.test_getter_setter = 95;
-    assert.strictEqual(obj.test_getter_setter, 95);
-  }
+    testStaticEnumerables(clazz);
+  };
 
-  function testObj(obj) {
-    testSetGetMethod(obj);
-    testIter(obj);
-    testGetterOnly(obj);
-    testSetterOnly(obj);
-    testGetterSetter(obj);
-  }
-
-  testObj(new Test());
-  testObj(new Test(1));
-  testObj(new Test(1, 2, 3, 4, 5, 6));
-  testObj(new Test(1, 2, 3, 4, 5, 6, 7));
+  // `Test` is needed for accessing exposed symbols
+  testObj(new Test(), Test);
+  testClass(Test);
 }
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));


### PR DESCRIPTION
Implements descriptor definitions with symbols for `StaticMethod`,
`StaticAccessor`, `InstanceAccessor`, `StaticValue`, `InstanceValue`.

Ref: https://github.com/nodejs/node-addon-api/issues/279