### PR TITLE
Fix HandleScope docs

### DIFF
--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -15,10 +15,10 @@ the section titled (Object lifetime management)[object_lifetime_management].
 Creates a new handle scope.
 
 ```cpp
-HandleScope HandleScope::New(Napi:Env env);
+HandleScope::HandleScope(Napi:Env env);
 ```
 
-- `[in] Env`: The environment in which to construct the HandleScope object.
+- `[in] env`: The environment in which to construct the HandleScope object.
 
 Returns a new HandleScope
 
@@ -28,11 +28,11 @@ Returns a new HandleScope
 Creates a new handle scope.
 
 ```cpp
-HandleScope HandleScope::New(napi_env env, napi_handle_scope scope);
+HandleScope::HandleScope(Napi::Env env, Napi::HandleScope scope);
 ```
 
-- `[in] env`: napi_env in which the scope passed in was created.
-- `[in] scope`: pre-existing napi_handle_scope.
+- `[in] env`: Napi::Env in which the scope passed in was created.
+- `[in] scope`: pre-existing Napi::HandleScope.
 
 Returns a new HandleScope instance which wraps the napi_handle_scope
 handle passed in.  This can be used to mix usage of the C N-API

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -41,7 +41,7 @@ and node-addon-api.
 operator HandleScope::napi_handle_scope
 
 ```cpp
-operator HandleScope::napi_handle_scope() const
+operator napi_handle_scope() const
 ```
 
 Returns the N-API napi_handle_scope wrapped by the EscapableHandleScope object.

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -12,10 +12,10 @@ the section titled (Object lifetime management)[object_lifetime_management].
 
 ### Constructor
 
-Creates a new handle scope.
+Creates a new handle scope on the stack.
 
 ```cpp
-HandleScope::HandleScope(Napi:Env env);
+HandleScope(Napi:Env env);
 ```
 
 - `[in] env`: The environment in which to construct the HandleScope object.
@@ -25,10 +25,10 @@ Returns a new HandleScope
 
 ### Constructor
 
-Creates a new handle scope.
+Creates a new handle scope on the stack.
 
 ```cpp
-HandleScope::HandleScope(Napi::Env env, Napi::HandleScope scope);
+HandleScope(Napi::Env env, Napi::HandleScope scope);
 ```
 
 - `[in] env`: Napi::Env in which the scope passed in was created.


### PR DESCRIPTION
It turns out `HandleScope::New` doesn't actually exist, so I'm not sure exactly how that happened.

Side note: Maybe it should, because I'm getting the error "Entering the V8 API without proper locking in place" when I just construct `HandleScope` so I think I'm missing something important that could be hidden using a factory function, but I don't know because I don't know why I'm running into this issue. =)