### PR TITLE
Tighten up warnings

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -171,7 +171,7 @@ struct AccessorCallbackData {
                                 napi_value exports) {     \
     return Napi::RegisterModule(env, exports, regfunc);   \
   }                                                       \
-  NAPI_MODULE(modname, __napi_ ## regfunc);
+  NAPI_MODULE(modname, __napi_ ## regfunc)
 
 // Adapt the NAPI_MODULE registration function:
 //  - Wrap the arguments in NAPI wrappers.

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2437,7 +2437,7 @@ inline PropertyDescriptor
 PropertyDescriptor::Accessor(const char* utf8name,
                              Getter getter,
                              napi_property_attributes attributes,
-                             void* data) {
+                             void* /*data*/) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
   // TODO: Delete when the function is destroyed
   auto callbackData = new CbData({ getter, nullptr });
@@ -2466,7 +2466,7 @@ template <typename Getter>
 inline PropertyDescriptor PropertyDescriptor::Accessor(napi_value name,
                                                        Getter getter,
                                                        napi_property_attributes attributes,
-                                                       void* data) {
+                                                       void* /*data*/) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
   // TODO: Delete when the function is destroyed
   auto callbackData = new CbData({ getter, nullptr });
@@ -2497,7 +2497,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(const char* utf8name,
                                                        Getter getter,
                                                        Setter setter,
                                                        napi_property_attributes attributes,
-                                                       void* data) {
+                                                       void* /*data*/) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   // TODO: Delete when the function is destroyed
   auto callbackData = new CbData({ getter, setter });
@@ -2528,7 +2528,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(napi_value name,
                                                        Getter getter,
                                                        Setter setter,
                                                        napi_property_attributes attributes,
-                                                       void* data) {
+                                                       void* /*data*/) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   // TODO: Delete when the function is destroyed
   auto callbackData = new CbData({ getter, setter });
@@ -2559,7 +2559,7 @@ template <typename Callable>
 inline PropertyDescriptor PropertyDescriptor::Function(const char* utf8name,
                                                        Callable cb,
                                                        napi_property_attributes attributes,
-                                                       void* data) {
+                                                       void* /*data*/) {
   typedef decltype(cb(CallbackInfo(nullptr, nullptr))) ReturnType;
   typedef details::CallbackData<Callable, ReturnType> CbData;
   // TODO: Delete when the function is destroyed
@@ -2589,7 +2589,7 @@ template <typename Callable>
 inline PropertyDescriptor PropertyDescriptor::Function(napi_value name,
                                                        Callable cb,
                                                        napi_property_attributes attributes,
-                                                       void* data) {
+                                                       void* /*data*/) {
   typedef decltype(cb(CallbackInfo(nullptr, nullptr))) ReturnType;
   typedef details::CallbackData<Callable, ReturnType> CbData;
   // TODO: Delete when the function is destroyed
@@ -3204,7 +3204,7 @@ inline void AsyncWorker::SetError(const std::string& error) {
   _error = error;
 }
 
-inline void AsyncWorker::OnExecute(napi_env env, void* this_pointer) {
+inline void AsyncWorker::OnExecute(napi_env /*env*/, void* this_pointer) {
   AsyncWorker* self = static_cast<AsyncWorker*>(this_pointer);
 #ifdef NAPI_CPP_EXCEPTIONS
   try {
@@ -3218,7 +3218,7 @@ inline void AsyncWorker::OnExecute(napi_env env, void* this_pointer) {
 }
 
 inline void AsyncWorker::OnWorkComplete(
-    napi_env env, napi_status status, void* this_pointer) {
+    napi_env /*env*/, napi_status status, void* this_pointer) {
   AsyncWorker* self = static_cast<AsyncWorker*>(this_pointer);
   if (status != napi_cancelled) {
     HandleScope scope(self->_env);

--- a/test/arraybuffer.cc
+++ b/test/arraybuffer.cc
@@ -63,7 +63,7 @@ Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
     info.Env(),
     data,
     testLength,
-    [](Env env, void* finalizeData) {
+    [](Env /*env*/, void* finalizeData) {
       delete[] static_cast<uint8_t*>(finalizeData);
       finalizeCount++;
     });
@@ -92,7 +92,7 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
     info.Env(),
     data,
     testLength,
-    [](Env env, void* finalizeData, char* finalizeHint) {
+    [](Env /*env*/, void* finalizeData, char* /*finalizeHint*/) {
       delete[] static_cast<uint8_t*>(finalizeData);
       finalizeCount++;
     },

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -28,6 +28,8 @@
       ],
       'include_dirs': ["<!@(node -p \"require('../').include\")"],
       'dependencies': ["<!(node -p \"require('../').gyp\")"],
+      'cflags': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ],
+      'cflags_cc': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ],
   },
   'targets': [
     {

--- a/test/buffer.cc
+++ b/test/buffer.cc
@@ -68,7 +68,7 @@ Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
     info.Env(),
     data,
     testLength,
-    [](Env env, uint16_t* finalizeData) {
+    [](Env /*env*/, uint16_t* finalizeData) {
       delete[] finalizeData;
       finalizeCount++;
     });
@@ -97,7 +97,7 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
     info.Env(),
     data,
     testLength,
-    [](Env env, uint16_t* finalizeData, char* finalizeHint) {
+    [](Env /*env*/, uint16_t* finalizeData, char* /*finalizeHint*/) {
       delete[] finalizeData;
       finalizeCount++;
     },

--- a/test/error.cc
+++ b/test/error.cc
@@ -154,7 +154,7 @@ void CatchAndRethrowErrorThatEscapesScope(const CallbackInfo& info) {
 
 #endif // NAPI_CPP_EXCEPTIONS
 
-void ThrowFatalError(const CallbackInfo& info) {
+void ThrowFatalError(const CallbackInfo& /*info*/) {
   Error::Fatal("Error::ThrowFatalError", "This is a fatal error");
 }
 

--- a/test/external.cc
+++ b/test/external.cc
@@ -15,7 +15,7 @@ Value CreateExternal(const CallbackInfo& info) {
 Value CreateExternalWithFinalize(const CallbackInfo& info) {
   finalizeCount = 0;
   return External<int>::New(info.Env(), new int(1),
-    [](Env env, int* data) {
+    [](Env /*env*/, int* data) {
       delete data;
       finalizeCount++;
     });
@@ -25,7 +25,7 @@ Value CreateExternalWithFinalizeHint(const CallbackInfo& info) {
   finalizeCount = 0;
   char* hint = nullptr;
   return External<int>::New(info.Env(), new int(1),
-    [](Env env, int* data, char* hint) {
+    [](Env /*env*/, int* data, char* /*hint*/) {
       delete data;
       finalizeCount++;
     },

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -32,11 +32,11 @@ public:
     return Napi::Number::New(info.Env(), value);
   }
 
-  Napi::Value Iter(const Napi::CallbackInfo& info) {
+  Napi::Value Iter(const Napi::CallbackInfo& /*info*/) {
     return Constructor.New({});
   }
 
-  void Setter(const Napi::CallbackInfo& info, const Napi::Value& new_value) {
+  void Setter(const Napi::CallbackInfo& /*info*/, const Napi::Value& new_value) {
     value = new_value.As<Napi::Number>();
   }
 


### PR DESCRIPTION
This PR enable more warnings in tests and mark them as errors, to ensure that headers would not interfere with build environment of project using this library.