### PR TITLE
Added cpp highlight for string.md

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -12,7 +12,7 @@ If an error occurs, a `Napi::Error` will get thrown. If C++ exceptions are not
 being used, callers should check the result of `Env::IsExceptionPending` before
 attempting to use the returned value.
 
-```
+```cpp
 String(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 ```
 - `[in] env` - The environment in which to create the string.


### PR DESCRIPTION
There is no cpp highlight for some function in string.md file.