### PR TITLE
Leave platform-specific type in operator def.n

### DIFF
--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -126,7 +126,7 @@ Value CreateObjectUsingMagic(const CallbackInfo& info) {
   obj[std::string("s_true")] = true;
   obj[std::string("s_false")] = false;
   obj["0"] = 0;
-  obj[42] = 120;
+  obj[(uint32_t)42] = 120;
   obj["0.0f"] = 0.0f;
   obj["0.0"] = 0.0;
   obj["-1"] = -1;


### PR DESCRIPTION
The property get/set sugar for numerical indices has to stay platform-
agnostic. That is, we cannot use `uint32_t`, but must instead use `int`
in the operator definition, because `int` resolves exactly on both
32-bit and 64-bit platforms.

Fixes: https://github.com/nodejs/node-addon-api/issues/337