### PR TITLE
Added Call and MakeCallback that accept cargs as agruments

### DIFF
--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -150,14 +150,14 @@ function.
 
 ### Call
 
-Calls a referenced Javascript function from a native add-on.
+Calls a referenced JavaScript function from a native add-on.
 
 ```cpp
 Napi::Value Napi::FunctionReference::Call(napi_value recv, size_t argc, const napi_value* args) const;
 ```
 
 - `[in] recv`: The `this` object passed to the referenced function when it's called.
-- `[in] argc`: The number of the arguments passed to the referenced function.
+- `[in] argc`: The number of arguments passed to the referenced function.
 - `[in] args`: Array of JavaScript values as `napi_value` representing the
 arguments of the referenced function.
 
@@ -199,7 +199,7 @@ function.
 
 ### MakeCallback
 
-Calls a referenced Javascript function from a native add-on after an asynchronous
+Calls a referenced JavaScript function from a native add-on after an asynchronous
 operation.
 
 ```cpp
@@ -207,7 +207,7 @@ Napi::Value Napi::FunctionReference::MakeCallback(napi_value recv, size_t argc, 
 ```
 
 - `[in] recv`: The `this` object passed to the referenced function when it's called.
-- `[in] argc`: The number of the arguments passed to the referenced function.
+- `[in] argc`: The number of arguments passed to the referenced function.
 - `[in] args`: Array of JavaScript values as `napi_value` representing the
 arguments of the referenced function.
 

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -148,6 +148,23 @@ arguments of the referenced function.
 Returns a `Napi::Value` representing the JavaScript object returned by the referenced
 function.
 
+### Call
+
+Calls a referenced Javascript function from a native add-on.
+
+```cpp
+Napi::Value Napi::FunctionReference::Call(napi_value recv, size_t argc, const napi_value* args) const;
+```
+
+- `[in] recv`: The `this` object passed to the referenced function when it's called.
+- `[in] argc`: The number of the arguments passed to the referenced function.
+- `[in] args`: Array of JavaScript values as `napi_value` representing the
+arguments of the referenced function.
+
+Returns a `Napi::Value` representing the JavaScript object returned by the referenced
+function.
+
+
 ### MakeCallback
 
 Calls a referenced Javascript function from a native add-on after an asynchronous
@@ -175,6 +192,23 @@ Napi::Value MakeCallback(napi_value recv, const std::vector<napi_value>& args) c
 
 - `[in] recv`: The `this` object passed to the referenced function when it's called.
 - `[in] args`: Vector of JavaScript values as `napi_value` representing the
+arguments of the referenced function.
+
+Returns a `Napi::Value` representing the JavaScript object returned by the referenced
+function.
+
+### MakeCallback
+
+Calls a referenced Javascript function from a native add-on after an asynchronous
+operation.
+
+```cpp
+Napi::Value Napi::FunctionReference::MakeCallback(napi_value recv, size_t argc, const napi_value* args) const;
+```
+
+- `[in] recv`: The `this` object passed to the referenced function when it's called.
+- `[in] argc`: The number of the arguments passed to the referenced function.
+- `[in] args`: Array of JavaScript values as `napi_value` representing the
 arguments of the referenced function.
 
 Returns a `Napi::Value` representing the JavaScript object returned by the referenced

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2336,6 +2336,16 @@ inline Napi::Value FunctionReference::Call(
   return scope.Escape(result);
 }
 
+inline Napi::Value FunctionReference::Call(
+    napi_value recv, size_t argc, const napi_value* args) const {
+  EscapableHandleScope scope(_env);
+  Napi::Value result = Value().Call(recv, argc, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+}
+
 inline Napi::Value FunctionReference::MakeCallback(
     napi_value recv, const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
@@ -2350,6 +2360,16 @@ inline Napi::Value FunctionReference::MakeCallback(
     napi_value recv, const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
   Napi::Value result = Value().MakeCallback(recv, args);
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+}
+
+inline Napi::Value FunctionReference::MakeCallback(
+    napi_value recv, size_t argc, const napi_value* args) const {
+  EscapableHandleScope scope(_env);
+  Napi::Value result = Value().MakeCallback(recv, argc, args);
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }

--- a/napi.h
+++ b/napi.h
@@ -1036,9 +1036,11 @@ namespace Napi {
     Napi::Value Call(const std::vector<napi_value>& args) const;
     Napi::Value Call(napi_value recv, const std::initializer_list<napi_value>& args) const;
     Napi::Value Call(napi_value recv, const std::vector<napi_value>& args) const;
+    Napi::Value Call(napi_value recv, size_t argc, const napi_value* args) const;
 
     Napi::Value MakeCallback(napi_value recv, const std::initializer_list<napi_value>& args) const;
     Napi::Value MakeCallback(napi_value recv, const std::vector<napi_value>& args) const;
+    Napi::Value MakeCallback(napi_value recv, size_t argc, const napi_value* args) const;
 
     Object New(const std::initializer_list<napi_value>& args) const;
     Object New(const std::vector<napi_value>& args) const;


### PR DESCRIPTION
Added methods to `Napi::FunctionReference` like requested and discussed on the issue **[https://github.com/nodejs/node-addon-api/issues/320](https://github.com/nodejs/node-addon-api/issues/320)**

Below I report the added methods:

```cpp
Napi::Value Call(napi_value recv, size_t argc, const napi_value* args) const;

Napi::Value MakeCallback(napi_value recv, size_t argc, const napi_value* args) const;
```