### PR TITLE
Make 'nothing' target a static library

### DIFF
--- a/src/node_api.gyp
+++ b/src/node_api.gyp
@@ -1,7 +1,8 @@
 {
   'targets': [
     {
-      'target_name': 'nothing'
+      'target_name': 'nothing',
+      'type': 'static_library'
     },
     {
       'target_name': 'node-api',

--- a/src/node_api.gyp
+++ b/src/node_api.gyp
@@ -2,7 +2,8 @@
   'targets': [
     {
       'target_name': 'nothing',
-      'type': 'static_library'
+      'type': 'static_library',
+      'sources': [ 'nothing.c' ]
     },
     {
       'target_name': 'node-api',


### PR DESCRIPTION
This avoids the creation of `nothing.node` files in other projects.
These files will otherwise be identified as non-N-API modules, even
though they are empty.