### PR TITLE
test: add ability to control experimental tests

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -298,7 +298,9 @@ inline bool Value::IsNumber() const {
   return Type() == napi_number;
 }
 
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
 inline bool Value::IsBigInt() const {
   return Type() == napi_bigint;
 }
@@ -520,7 +522,9 @@ inline double Number::DoubleValue() const {
   return result;
 }
 
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
 ////////////////////////////////////////////////////////////////////////////////
 // BigInt Class
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi.h
+++ b/napi.h
@@ -52,7 +52,9 @@ namespace Napi {
   class Value;
   class Boolean;
   class Number;
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
   class BigInt;
 #endif  // NAPI_EXPERIMENTAL
   class String;
@@ -75,7 +77,9 @@ namespace Napi {
   typedef TypedArrayOf<uint32_t> Uint32Array; ///< Typed-array of unsigned 32-bit integers
   typedef TypedArrayOf<float> Float32Array;   ///< Typed-array of 32-bit floating-point values
   typedef TypedArrayOf<double> Float64Array;  ///< Typed-array of 64-bit floating-point values
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
   typedef TypedArrayOf<int64_t> BigInt64Array;   ///< Typed array of signed 64-bit integers
   typedef TypedArrayOf<uint64_t> BigUint64Array; ///< Typed array of unsigned 64-bit integers
 #endif  // NAPI_EXPERIMENTAL
@@ -178,7 +182,9 @@ namespace Napi {
     bool IsNull() const;        ///< Tests if a value is a null JavaScript value.
     bool IsBoolean() const;     ///< Tests if a value is a JavaScript boolean.
     bool IsNumber() const;      ///< Tests if a value is a JavaScript number.
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
     bool IsBigInt() const;      ///< Tests if a value is a JavaScript bigint.
 #endif  // NAPI_EXPERIMENTAL
     bool IsString() const;      ///< Tests if a value is a JavaScript string.
@@ -250,7 +256,9 @@ namespace Napi {
     double DoubleValue() const;   ///< Converts a Number value to a 64-bit floating-point value.
   };
 
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
   /// A JavaScript bigint value.
   class BigInt : public Value {
   public:
@@ -754,7 +762,9 @@ namespace Napi {
         : std::is_same<T, uint32_t>::value ? napi_uint32_array
         : std::is_same<T, float>::value ? napi_float32_array
         : std::is_same<T, double>::value ? napi_float64_array
-#ifdef NAPI_EXPERIMENTAL
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
         : std::is_same<T, int64_t>::value ? napi_bigint64_array
         : std::is_same<T, uint64_t>::value ? napi_biguint64_array
 #endif  // NAPI_EXPERIMENTAL

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "pretest": "node-gyp rebuild -C test",
-    "test": "node test",
+    "test": "NAPI_VERSION=$NODE_VERSION node test",
     "doc": "doxygen doc/Doxyfile"
   },
   "version": "1.4.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "pretest": "node-gyp rebuild -C test",
-    "test": "NAPI_VERSION=$NODE_VERSION node test",
+    "test": "node test",
     "doc": "doxygen doc/Doxyfile"
   },
   "version": "1.4.0"

--- a/test/bigint.cc
+++ b/test/bigint.cc
@@ -3,6 +3,9 @@
 
 using namespace Napi;
 
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
 namespace {
 
 Value IsLossless(const CallbackInfo& info) {
@@ -74,3 +77,5 @@ Object InitBigInt(Env env) {
 
   return exports;
 }
+
+#endif

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -30,7 +30,11 @@ Object Init(Env env, Object exports) {
   exports.Set("basic_types_boolean", InitBasicTypesBoolean(env));
   exports.Set("basic_types_number", InitBasicTypesNumber(env));
   exports.Set("basic_types_value", InitBasicTypesValue(env));
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
   exports.Set("bigint", InitBigInt(env));
+#endif
   exports.Set("buffer", InitBuffer(env));
   exports.Set("dataview", InitDataView(env));
   exports.Set("dataview_read_write", InitDataView(env));

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -1,3 +1,4 @@
+#define NAPI_EXPERIMENTAL
 #include "napi.h"
 
 using namespace Napi;
@@ -7,7 +8,11 @@ Object InitAsyncWorker(Env env);
 Object InitBasicTypesBoolean(Env env);
 Object InitBasicTypesNumber(Env env);
 Object InitBasicTypesValue(Env env);
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
 Object InitBigInt(Env env);
+#endif
 Object InitBuffer(Env env);
 Object InitDataView(Env env);
 Object InitDataViewReadWrite(Env env);

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'NAPI_VERSION%': ""
+  },
   'target_defaults': {
     'sources': [
         'arraybuffer.cc',
@@ -28,6 +31,9 @@
         'objectwrap.cc',
         'objectreference.cc',
         'version_management.cc'
+      ],
+      'conditions': [
+        ['NAPI_VERSION!=""', { 'defines': ['NAPI_VERSION=<@(NAPI_VERSION)'] } ]
       ],
       'include_dirs': ["<!@(node -p \"require('../').include\")"],
       'dependencies': ["<!(node -p \"require('../').gyp\")"],

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,15 @@ let testModules = [
   'version_management'
 ];
 
+if(process.env.NAPI_VERSION < 2147483647 ){
+  // currently experimental only test if NAPI_VERSION
+  // is set to experimental
+  // once bigint is in a release this should be guarged
+  // on the napi version  supported by the current
+  // node being tested
+  testModules.splice(testModules.indexOf('bigint'), 1);
+}
+
 if (typeof global.gc === 'function') {
   console.log('Starting test suite\n');
 

--- a/test/index.js
+++ b/test/index.js
@@ -39,7 +39,7 @@ let testModules = [
 if(process.env.NAPI_VERSION < 2147483647 ){
   // currently experimental only test if NAPI_VERSION
   // is set to experimental
-  // once bigint is in a release this should be guarged
+  // once bigint is in a release this should be guarded
   // on the napi version  supported by the current
   // node being tested
   testModules.splice(testModules.indexOf('bigint'), 1);

--- a/test/index.js
+++ b/test/index.js
@@ -36,12 +36,14 @@ let testModules = [
   'version_management'
 ];
 
-if(process.env.NAPI_VERSION < 2147483647 ){
+if((process.env.npm_config_NAPI_VERSION !== undefined) &&
+   (process.env.npm_config_NAPI_VERSION < 50000)) {
   // currently experimental only test if NAPI_VERSION
-  // is set to experimental
-  // once bigint is in a release this should be guarded
-  // on the napi version supported by the current
-  // node being tested
+  // is set to experimental. We can't use C max int 
+  // as that is not supported as a number on earlier
+  // Node.js versions.  Oonce bigint is in a release
+  // this should be guarded on the napi version
+  // in which bigint was added.
   testModules.splice(testModules.indexOf('bigint'), 1);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -37,12 +37,12 @@ let testModules = [
   'version_management'
 ];
 
-if((process.env.npm_config_NAPI_VERSION !== undefined) &&
-   (process.env.npm_config_NAPI_VERSION < 50000)) {
+if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
+    (process.env.npm_config_NAPI_VERSION < 50000)) {
   // currently experimental only test if NAPI_VERSION
   // is set to experimental. We can't use C max int 
   // as that is not supported as a number on earlier
-  // Node.js versions.  Oonce bigint is in a release
+  // Node.js versions. Once bigint is in a release
   // this should be guarded on the napi version
   // in which bigint was added.
   testModules.splice(testModules.indexOf('bigint'), 1);

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,7 @@ let testModules = [
   'object/set_property',
   'promise',
   'typedarray',
+  'typedarray-bigint',
   'objectwrap',
   'objectreference',
   'version_management'
@@ -45,6 +46,7 @@ if((process.env.npm_config_NAPI_VERSION !== undefined) &&
   // this should be guarded on the napi version
   // in which bigint was added.
   testModules.splice(testModules.indexOf('bigint'), 1);
+  testModules.splice(testModules.indexOf('typedarray-bigint'), 1);
 }
 
 if (typeof global.gc === 'function') {

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ if(process.env.NAPI_VERSION < 2147483647 ){
   // currently experimental only test if NAPI_VERSION
   // is set to experimental
   // once bigint is in a release this should be guarded
-  // on the napi version  supported by the current
+  // on the napi version supported by the current
   // node being tested
   testModules.splice(testModules.indexOf('bigint'), 1);
 }

--- a/test/typedarray-bigint.js
+++ b/test/typedarray-bigint.js
@@ -1,0 +1,59 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  [
+    ['bigint64', BigInt64Array],
+    ['biguint64', BigUint64Array],
+  ].forEach(([type, Constructor]) => {
+    try {
+      const length = 4;
+      const t = binding.typedarray.createTypedArray(type, length);
+      assert.ok(t instanceof Constructor);
+      assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
+      assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
+
+      t[3] = 11n;
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
+      binding.typedarray.setTypedArrayElement(t, 3, 22n);
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
+      assert.strictEqual(t[3], 22n);
+
+      const b = binding.typedarray.getTypedArrayBuffer(t);
+      assert.ok(b instanceof ArrayBuffer);
+    } catch (e) {
+      console.log(type, Constructor);
+      throw e;
+    }
+
+    try {
+      const length = 4;
+      const offset = 8;
+      const b = new ArrayBuffer(offset + 64 * 4);
+
+      const t = binding.typedarray.createTypedArray(type, length, b, offset);
+      assert.ok(t instanceof Constructor);
+      assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
+      assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
+
+      t[3] = 11n;
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
+      binding.typedarray.setTypedArrayElement(t, 3, 22n);
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
+      assert.strictEqual(t[3], 22n);
+
+      assert.strictEqual(binding.typedarray.getTypedArrayBuffer(t), b);
+    } catch (e) {
+      console.log(type, Constructor);
+      throw e;
+    }
+  });
+
+  assert.throws(() => {
+    binding.typedarray.createInvalidTypedArray();
+  }, /Invalid (pointer passed as )?argument/);
+}

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -65,6 +65,9 @@ Value CreateTypedArray(const CallbackInfo& info) {
       NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length, napi_float64_array) :
       NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length, buffer, bufferOffset,
                                  napi_float64_array);
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
   } else if (arrayType == "bigint64") {
     return buffer.IsUndefined() ?
       NAPI_TYPEDARRAY_NEW(BigInt64Array, info.Env(), length, napi_bigint64_array) :
@@ -75,6 +78,7 @@ Value CreateTypedArray(const CallbackInfo& info) {
       NAPI_TYPEDARRAY_NEW(BigUint64Array, info.Env(), length, napi_biguint64_array) :
       NAPI_TYPEDARRAY_NEW_BUFFER(BigUint64Array, info.Env(), length, buffer, bufferOffset,
                                  napi_biguint64_array);
+#endif
   } else {
     Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
     return Value();
@@ -97,8 +101,12 @@ Value GetTypedArrayType(const CallbackInfo& info) {
     case napi_uint32_array: return String::New(info.Env(), "uint32");
     case napi_float32_array: return String::New(info.Env(), "float32");
     case napi_float64_array: return String::New(info.Env(), "float64");
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
     case napi_bigint64_array: return String::New(info.Env(), "bigint64");
     case napi_biguint64_array: return String::New(info.Env(), "biguint64");
+#endif
     default: return String::New(info.Env(), "invalid");
   }
 }
@@ -135,10 +143,14 @@ Value GetTypedArrayElement(const CallbackInfo& info) {
       return Number::New(info.Env(), array.As<Float32Array>()[index]);
     case napi_float64_array:
       return Number::New(info.Env(), array.As<Float64Array>()[index]);
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
     case napi_bigint64_array:
       return BigInt::New(info.Env(), array.As<BigInt64Array>()[index]);
     case napi_biguint64_array:
       return BigInt::New(info.Env(), array.As<BigUint64Array>()[index]);
+#endif
     default:
       Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
       return Value();
@@ -177,6 +189,9 @@ void SetTypedArrayElement(const CallbackInfo& info) {
     case napi_float64_array:
       array.As<Float64Array>()[index] = value.DoubleValue();
       break;
+// currently experimental guard with version of NAPI_VERSION that it is 
+// released in once it is no longer experimental
+#if (NAPI_VERSION > 2147483646) 
     case napi_bigint64_array: {
       bool lossless;
       array.As<BigInt64Array>()[index] = value.As<BigInt>().Int64Value(&lossless);
@@ -187,6 +202,7 @@ void SetTypedArrayElement(const CallbackInfo& info) {
       array.As<BigUint64Array>()[index] = value.As<BigInt>().Uint64Value(&lossless);
       break;
     }
+#endif
     default:
       Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
   }

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -64,9 +64,14 @@ function test(binding) {
     }
   });
 
-// currently experimental, guard qurg NAPI_VERSION it
-// is related in once no longer experimntal
-if(process.env.NAPI_VERSION > 2147483646 ){
+  // currently experimental only test if NAPI_VERSION
+  // is set to experimental. We can't use C max int 
+  // as that is not supported as a number on earlier
+  // Node.js versions.  Oonce bigint is in a release
+  // this should be guarded on the napi version
+  // in which bigint was added.
+if((process.env.npm_config_NAPI_VERSION === undefined) ||
+   (process.env.npm_config_NAPI_VERSION >= 50000)) {
   [
     ['bigint64', BigInt64Array],
     ['biguint64', BigUint64Array],

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -64,6 +64,9 @@ function test(binding) {
     }
   });
 
+// currently experimental, guard qurg NAPI_VERSION it
+// is related in once no longer experimntal
+if(process.env.NAPI_VERSION > 2147483646 ){
   [
     ['bigint64', BigInt64Array],
     ['biguint64', BigUint64Array],
@@ -110,6 +113,7 @@ function test(binding) {
       throw e;
     }
   });
+}
 
   assert.throws(() => {
     binding.typedarray.createInvalidTypedArray();

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -64,62 +64,6 @@ function test(binding) {
     }
   });
 
-  // currently experimental only test if NAPI_VERSION
-  // is set to experimental. We can't use C max int 
-  // as that is not supported as a number on earlier
-  // Node.js versions.  Oonce bigint is in a release
-  // this should be guarded on the napi version
-  // in which bigint was added.
-if((process.env.npm_config_NAPI_VERSION === undefined) ||
-   (process.env.npm_config_NAPI_VERSION >= 50000)) {
-  [
-    ['bigint64', BigInt64Array],
-    ['biguint64', BigUint64Array],
-  ].forEach(([type, Constructor]) => {
-    try {
-      const length = 4;
-      const t = binding.typedarray.createTypedArray(type, length);
-      assert.ok(t instanceof Constructor);
-      assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
-      assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
-
-      t[3] = 11n;
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
-      binding.typedarray.setTypedArrayElement(t, 3, 22n);
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
-      assert.strictEqual(t[3], 22n);
-
-      const b = binding.typedarray.getTypedArrayBuffer(t);
-      assert.ok(b instanceof ArrayBuffer);
-    } catch (e) {
-      console.log(type, Constructor);
-      throw e;
-    }
-
-    try {
-      const length = 4;
-      const offset = 8;
-      const b = new ArrayBuffer(offset + 64 * 4);
-
-      const t = binding.typedarray.createTypedArray(type, length, b, offset);
-      assert.ok(t instanceof Constructor);
-      assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
-      assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
-
-      t[3] = 11n;
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
-      binding.typedarray.setTypedArrayElement(t, 3, 22n);
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
-      assert.strictEqual(t[3], 22n);
-
-      assert.strictEqual(binding.typedarray.getTypedArrayBuffer(t), b);
-    } catch (e) {
-      console.log(type, Constructor);
-      throw e;
-    }
-  });
-}
-
   assert.throws(() => {
     binding.typedarray.createInvalidTypedArray();
   }, /Invalid (pointer passed as )?argument/);


### PR DESCRIPTION
Add the ability to specify a NAPI_VERSION which
limits the tests executed to those supported by that
version.

As an example tests can be built/run as:
  npm test --NAPI_VERSION=3

Fixes: https://github.com/nodejs/node-addon-api/issues/349