### PR TITLE
test: Fix a syntax error in test

### DIFF
--- a/test/bigint.js
+++ b/test/bigint.js
@@ -15,7 +15,7 @@ function test(binding) {
     TestTooBigBigInt,
   } = binding.bigint;
 
-  [
+  eval(`[
     0n,
     -0n,
     1n,
@@ -27,15 +27,15 @@ function test(binding) {
     -976675n,
     98765432213456789876546896323445679887645323232436587988766545658n,
     -4350987086545760976737453646576078997096876957864353245245769809n,
-  ].forEach((num) => {
-    if (num > -(2n ** 63n) && num < 2n ** 63n) {
+  ]`).forEach((num) => {
+    if (num > eval(`-(2n ** 63n)`) && num < eval(`2n ** 63n`)) {
       assert.strictEqual(TestInt64(num), num);
       assert.strictEqual(IsLossless(num, true), true);
     } else {
       assert.strictEqual(IsLossless(num, true), false);
     }
 
-    if (num >= 0 && num < 2n ** 64n) {
+    if (num >= 0 && num < eval(`2n ** 64n`)) {
       assert.strictEqual(TestUint64(num), num);
       assert.strictEqual(IsLossless(num, false), true);
     } else {

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -75,11 +75,11 @@ function test(binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
 
-      t[3] = 11n;
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
-      binding.typedarray.setTypedArrayElement(t, 3, 22n);
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
-      assert.strictEqual(t[3], 22n);
+      t[3] = eval(`11n`);
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), eval(`11n`));
+      binding.typedarray.setTypedArrayElement(t, 3, eval(`22n`));
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), eval(`22n`));
+      assert.strictEqual(t[3], eval(`22n`));
 
       const b = binding.typedarray.getTypedArrayBuffer(t);
       assert.ok(b instanceof ArrayBuffer);
@@ -98,11 +98,11 @@ function test(binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), type);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
 
-      t[3] = 11n;
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11n);
-      binding.typedarray.setTypedArrayElement(t, 3, 22n);
-      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 22n);
-      assert.strictEqual(t[3], 22n);
+      t[3] = eval(`11n`);
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), eval(`11n`));
+      binding.typedarray.setTypedArrayElement(t, 3, eval(`22n`));
+      assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), eval(`22n`));
+      assert.strictEqual(t[3], eval(`22n`));
 
       assert.strictEqual(binding.typedarray.getTypedArrayBuffer(t), b);
     } catch (e) {


### PR DESCRIPTION
`npm test` command has been failed in old version node.js since
introducing `bitint` tests. The problem is caused that old version V8
doesn't support the bigint syntax(e.g. 11n, 22n). So, we just wrap the
syntax using `eval()` method to avoid the problem.

/home/jinho_bang/up/test/typedarray.js:81
      t[3] = 11n;
             ^^

SyntaxError: Invalid or unexpected token
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:607:28)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at testModules.forEach.name (/home/jinho_bang/up/test/index.js:54:5)

Fixes: #349