### PR TITLE
tests: add operator overloading tests for Number class

### DIFF
--- a/test/basic_types/number.cc
+++ b/test/basic_types/number.cc
@@ -41,6 +41,31 @@ Value MaxDouble(const CallbackInfo& info) {
   return Number::New(info.Env(), DBL_MAX);
 }
 
+Value OperatorInt32(const CallbackInfo& info) {
+  Number jsValue = info[0].As<Number>();
+  return Boolean::New(info.Env(), jsValue.Int32Value() == static_cast<int32_t>(jsValue));
+}
+
+Value OperatorUint32(const CallbackInfo& info) {
+  Number jsValue = info[0].As<Number>();
+  return Boolean::New(info.Env(), jsValue.Uint32Value() == static_cast<uint32_t>(jsValue));
+}
+
+Value OperatorInt64(const CallbackInfo& info) {
+  Number jsValue = info[0].As<Number>();
+  return Boolean::New(info.Env(), jsValue.Int64Value() == static_cast<int64_t>(jsValue));
+}
+
+Value OperatorFloat(const CallbackInfo& info) {
+  Number jsValue = info[0].As<Number>();
+  return Boolean::New(info.Env(), jsValue.FloatValue() == static_cast<float>(jsValue));
+}
+
+Value OperatorDouble(const CallbackInfo& info) {
+  Number jsValue = info[0].As<Number>();
+  return Boolean::New(info.Env(), jsValue.DoubleValue() == static_cast<double>(jsValue));
+}
+
 Object InitBasicTypesNumber(Env env) {
   Object exports = Object::New(env);
 
@@ -53,6 +78,11 @@ Object InitBasicTypesNumber(Env env) {
   exports["maxFloat"] = Function::New(env, MaxFloat);
   exports["minDouble"] = Function::New(env, MinDouble);
   exports["maxDouble"] = Function::New(env, MaxDouble);
+  exports["operatorInt32"] = Function::New(env, OperatorInt32);
+  exports["operatorUint32"] = Function::New(env, OperatorUint32);
+  exports["operatorInt64"] = Function::New(env, OperatorInt64);
+  exports["operatorFloat"] = Function::New(env, OperatorFloat);
+  exports["operatorDouble"] = Function::New(env, OperatorDouble);
 
   return exports;
 }

--- a/test/basic_types/number.js
+++ b/test/basic_types/number.js
@@ -80,4 +80,20 @@ function test(binding) {
     assert.strictEqual(0, binding.basic_types_number.toDouble(MIN_DOUBLE * MIN_DOUBLE));
     assert.strictEqual(Infinity, binding.basic_types_number.toDouble(MAX_DOUBLE * MAX_DOUBLE));
   }
+
+  // Test for operator overloading
+  {
+    assert.strictEqual(binding.basic_types_number.operatorInt32(MIN_INT32), true);
+    assert.strictEqual(binding.basic_types_number.operatorInt32(MAX_INT32), true);
+    assert.strictEqual(binding.basic_types_number.operatorUint32(MIN_UINT32), true);
+    assert.strictEqual(binding.basic_types_number.operatorUint32(MAX_UINT32), true);
+    assert.strictEqual(binding.basic_types_number.operatorInt64(MIN_INT64), true);
+    assert.strictEqual(binding.basic_types_number.operatorInt64(MAX_INT64), true);
+    assert.strictEqual(binding.basic_types_number.operatorFloat(MIN_FLOAT), true);
+    assert.strictEqual(binding.basic_types_number.operatorFloat(MAX_FLOAT), true);
+    assert.strictEqual(binding.basic_types_number.operatorFloat(MAX_DOUBLE), true);
+    assert.strictEqual(binding.basic_types_number.operatorDouble(MIN_DOUBLE), true);
+    assert.strictEqual(binding.basic_types_number.operatorDouble(MAX_DOUBLE), true);
+  }
+
 }


### PR DESCRIPTION

Hi node-addon-api members,

in this PR, I added tests for checking operator overloading for Number class.

class | methods
-- | --
Number | operator int32_t() const
  | operator uint32_t() const
  | operator int64_t() const
  | operator float() const
  | operator double() const

Please review and suggest some other test cases. See the issue https://github.com/nodejs/node-addon-api/issues/332.