### PR TITLE
Added package-lock.json file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+package-lock.json


### PR DESCRIPTION
```npm install``` creates a ```package-lock.json``` to lock the versions of dependencies that are installed.
They recommend to commit this file and that's what I usually do in other projects but I think we should gitignore it in CITGM.
This will allow us to always test the latest version of our dependencies (especially in CI).