### PR TITLE
Use Call() instead of MakeCallback() in AsyncWorker

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3444,11 +3444,11 @@ inline FunctionReference& AsyncWorker::Callback() {
 }
 
 inline void AsyncWorker::OnOK() {
-  _callback.MakeCallback(_receiver.Value(), std::initializer_list<napi_value>{});
+  _callback.Call(_receiver.Value(), std::initializer_list<napi_value>{});
 }
 
 inline void AsyncWorker::OnError(const Error& e) {
-  _callback.MakeCallback(_receiver.Value(), std::initializer_list<napi_value>{ e.Value() });
+  _callback.Call(_receiver.Value(), std::initializer_list<napi_value>{ e.Value() });
 }
 
 inline void AsyncWorker::SetError(const std::string& error) {


### PR DESCRIPTION
Change `AsyncWorker::OnOK()` and `AsyncWorker::OnError()` callbacks to
**NOT** use `MakeCallback()`. An ordinary function call
(`_callback::Call()`) is now correct.

Refs: https://nodejs.org/api/n-api.html#n_api_napi_make_callback