### PR TITLE
test: create test objects in the stack instead of the heap

### DIFF
--- a/test/basic_types/boolean.cc
+++ b/test/basic_types/boolean.cc
@@ -12,8 +12,8 @@ Value CreateEmptyBoolean(const CallbackInfo& info) {
 }
 
 Value CreateBooleanFromExistingValue(const CallbackInfo& info) {
-  Boolean* boolean =  new Boolean(info.Env(), info[0].As<Boolean>());
-  return Boolean::New(info.Env(), boolean->Value());
+  Boolean boolean(info.Env(), info[0].As<Boolean>());
+  return Boolean::New(info.Env(), boolean.Value());
 }
 
 Value CreateBooleanFromPrimitive(const CallbackInfo& info) {

--- a/test/basic_types/number.cc
+++ b/test/basic_types/number.cc
@@ -67,8 +67,8 @@ Value OperatorDouble(const CallbackInfo& info) {
 }
 
 Value CreateEmptyNumber(const CallbackInfo& info) {
-  Number* number = new Number();
-  return Boolean::New(info.Env(), number->IsEmpty());
+  Number number;
+  return Boolean::New(info.Env(), number.IsEmpty());
 }
 
 Value CreateNumberFromExistingValue(const CallbackInfo& info) {


### PR DESCRIPTION
Hi, I guess most systems will free any memory related to the program when it  is terminated but I changed code to create object in the heap in tests to avoid small memory leak. :)