### PR TITLE
Fixed missing void*data usage in PropertyDescriptors

### DIFF
--- a/napi-inl.deprecated.h
+++ b/napi-inl.deprecated.h
@@ -73,7 +73,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(const char* utf8name,
                                                        void* /*data*/) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, setter });
+  auto callbackData = new CbData({ getter, setter, nullptr });
 
   return PropertyDescriptor({
     utf8name,
@@ -104,7 +104,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(napi_value name,
                                                        void* /*data*/) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, setter });
+  auto callbackData = new CbData({ getter, setter, nullptr });
 
   return PropertyDescriptor({
     nullptr,

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2608,8 +2608,7 @@ PropertyDescriptor::Accessor(Napi::Env env,
                              napi_property_attributes attributes,
                              void* data) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
-  auto callbackData = new CbData({ getter, nullptr });
-  callbackData->data = data;
+  auto callbackData = new CbData({ getter, data });
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2644,8 +2643,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        napi_property_attributes attributes,
                                                        void* data) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
-  auto callbackData = new CbData({ getter, nullptr });
-  callbackData->data = data;
+  auto callbackData = new CbData({ getter, data });
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2671,8 +2669,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        napi_property_attributes attributes,
                                                        void* data) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
-  auto callbackData = new CbData({ getter, setter });
-  callbackData->data = data;
+  auto callbackData = new CbData({ getter, setter, data });
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2709,8 +2706,7 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        napi_property_attributes attributes,
                                                        void* data) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
-  auto callbackData = new CbData({ getter, setter });
-  callbackData->data = data;
+  auto callbackData = new CbData({ getter, setter, data });
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -176,6 +176,7 @@ struct AccessorCallbackData {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
         static_cast<AccessorCallbackData*>(callbackInfo.Data());
+      callbackInfo.SetData(callbackData->data);
       return callbackData->getterCallback(callbackInfo);
     });
   }
@@ -186,6 +187,7 @@ struct AccessorCallbackData {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
         static_cast<AccessorCallbackData*>(callbackInfo.Data());
+      callbackInfo.SetData(callbackData->data);
       callbackData->setterCallback(callbackInfo);
       return nullptr;
     });
@@ -193,6 +195,7 @@ struct AccessorCallbackData {
 
   Getter getterCallback;
   Setter setterCallback;
+  void* data;
 };
 
 }  // namespace details
@@ -2603,9 +2606,10 @@ PropertyDescriptor::Accessor(Napi::Env env,
                              const char* utf8name,
                              Getter getter,
                              napi_property_attributes attributes,
-                             void* /*data*/) {
+                             void* data) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
   auto callbackData = new CbData({ getter, nullptr });
+  callbackData->data = data;
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2638,9 +2642,10 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        Name name,
                                                        Getter getter,
                                                        napi_property_attributes attributes,
-                                                       void* /*data*/) {
+                                                       void* data) {
   typedef details::CallbackData<Getter, Napi::Value> CbData;
   auto callbackData = new CbData({ getter, nullptr });
+  callbackData->data = data;
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2664,9 +2669,10 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        Getter getter,
                                                        Setter setter,
                                                        napi_property_attributes attributes,
-                                                       void* /*data*/) {
+                                                       void* data) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   auto callbackData = new CbData({ getter, setter });
+  callbackData->data = data;
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
@@ -2701,9 +2707,10 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
                                                        Getter getter,
                                                        Setter setter,
                                                        napi_property_attributes attributes,
-                                                       void* /*data*/) {
+                                                       void* data) {
   typedef details::AccessorCallbackData<Getter, Setter> CbData;
   auto callbackData = new CbData({ getter, setter });
+  callbackData->data = data;
 
   napi_status status = AttachData(env, object, callbackData);
   NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -46,12 +46,12 @@ void TestSetter(const CallbackInfo& info) {
    testValue = info[0].As<Boolean>();
 }
 
-Value TestGetterWithUd(const CallbackInfo& info) {
+Value TestGetterWithUserData(const CallbackInfo& info) {
   const UserDataHolder* holder = reinterpret_cast<UserDataHolder*>(info.Data());
   return Number::New(info.Env(), holder->value);
 }
 
-void TestSetterWithUd(const CallbackInfo& info) {
+void TestSetterWithUserData(const CallbackInfo& info) {
   UserDataHolder* holder = reinterpret_cast<UserDataHolder*>(info.Data());
   holder->value = info[0].As<Number>().Int32Value();
 }
@@ -79,8 +79,8 @@ void DefineProperties(const CallbackInfo& info) {
     obj.DefineProperties({
       PropertyDescriptor::Accessor(env, obj, "readonlyAccessor", TestGetter),
       PropertyDescriptor::Accessor(env, obj, "readwriteAccessor", TestGetter, TestSetter),
-      PropertyDescriptor::Accessor(env, obj, "readonlyAccessorWithUd", TestGetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor(env, obj, "readwriteAccessorWithUd", TestGetterWithUd, TestSetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+      PropertyDescriptor::Accessor(env, obj, "readonlyAccessorWithUserData", TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+      PropertyDescriptor::Accessor(env, obj, "readwriteAccessorWithUserData", TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
       PropertyDescriptor::Value("readonlyValue", trueValue),
       PropertyDescriptor::Value("readwriteValue", trueValue, napi_writable),
       PropertyDescriptor::Value("enumerableValue", trueValue, napi_enumerable),
@@ -94,8 +94,8 @@ void DefineProperties(const CallbackInfo& info) {
     // work around the issue.
     std::string str1("readonlyAccessor");
     std::string str2("readwriteAccessor");
-    std::string str1a("readonlyAccessorWithUd");
-    std::string str2a("readwriteAccessorWithUd");
+    std::string str1a("readonlyAccessorWithUserData");
+    std::string str2a("readwriteAccessorWithUserData");
     std::string str3("readonlyValue");
     std::string str4("readwriteValue");
     std::string str5("enumerableValue");
@@ -105,8 +105,8 @@ void DefineProperties(const CallbackInfo& info) {
     obj.DefineProperties({
       PropertyDescriptor::Accessor(env, obj, str1, TestGetter),
       PropertyDescriptor::Accessor(env, obj, str2, TestGetter, TestSetter),
-      PropertyDescriptor::Accessor(env, obj, str1a, TestGetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor(env, obj, str2a, TestGetterWithUd, TestSetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+      PropertyDescriptor::Accessor(env, obj, str1a, TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+      PropertyDescriptor::Accessor(env, obj, str2a, TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
       PropertyDescriptor::Value(str3, trueValue),
       PropertyDescriptor::Value(str4, trueValue, napi_writable),
       PropertyDescriptor::Value(str5, trueValue, napi_enumerable),
@@ -120,9 +120,9 @@ void DefineProperties(const CallbackInfo& info) {
       PropertyDescriptor::Accessor(env, obj,
         Napi::String::New(env, "readwriteAccessor"), TestGetter, TestSetter),
       PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readonlyAccessorWithUd"), TestGetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        Napi::String::New(env, "readonlyAccessorWithUserData"), TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
       PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readwriteAccessorWithUd"), TestGetterWithUd, TestSetterWithUd, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        Napi::String::New(env, "readwriteAccessorWithUserData"), TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
       PropertyDescriptor::Value(
         Napi::String::New(env, "readonlyValue"), trueValue),
       PropertyDescriptor::Value(

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -12,11 +12,11 @@ function test(binding) {
     assert.ok(propDesc[attribute]);
   }
 
-    function assertPropertyIsNot(obj, key, attribute) {
-      const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+  function assertPropertyIsNot(obj, key, attribute) {
+    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(!propDesc[attribute]);
-    }
+  }
 
   function testDefineProperties(nameType) {
     const obj = {};
@@ -26,9 +26,9 @@ function test(binding) {
     assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
     assert.strictEqual(obj.readonlyAccessor, true);
 
-    assertPropertyIsNot(obj, 'readonlyAccessorWithUd', 'enumerable');
-    assertPropertyIsNot(obj, 'readonlyAccessorWithUd', 'configurable');
-    assert.strictEqual(obj.readonlyAccessorWithUd, 1234, nameType);
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUserData', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUserData', 'configurable');
+    assert.strictEqual(obj.readonlyAccessorWithUserData, 1234, nameType);
 
     assertPropertyIsNot(obj, 'readwriteAccessor', 'enumerable');
     assertPropertyIsNot(obj, 'readwriteAccessor', 'configurable');
@@ -37,12 +37,12 @@ function test(binding) {
     obj.readwriteAccessor = true;
     assert.strictEqual(obj.readwriteAccessor, true);
 
-    assertPropertyIsNot(obj, 'readwriteAccessorWithUd', 'enumerable');
-    assertPropertyIsNot(obj, 'readwriteAccessorWithUd', 'configurable');
-    obj.readwriteAccessorWithUd = 2;
-    assert.strictEqual(obj.readwriteAccessorWithUd, 2);
-    obj.readwriteAccessorWithUd = -14;
-    assert.strictEqual(obj.readwriteAccessorWithUd, -14);
+    assertPropertyIsNot(obj, 'readwriteAccessorWithUserData', 'enumerable');
+    assertPropertyIsNot(obj, 'readwriteAccessorWithUserData', 'configurable');
+    obj.readwriteAccessorWithUserData = 2;
+    assert.strictEqual(obj.readwriteAccessorWithUserData, 2);
+    obj.readwriteAccessorWithUserData = -14;
+    assert.strictEqual(obj.readwriteAccessorWithUserData, -14);
 
     assertPropertyIsNot(obj, 'readonlyValue', 'writable');
     assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -12,11 +12,11 @@ function test(binding) {
     assert.ok(propDesc[attribute]);
   }
 
-  function assertPropertyIsNot(obj, key, attribute) {
-    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+    function assertPropertyIsNot(obj, key, attribute) {
+      const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(!propDesc[attribute]);
-  }
+    }
 
   function testDefineProperties(nameType) {
     const obj = {};
@@ -26,12 +26,23 @@ function test(binding) {
     assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
     assert.strictEqual(obj.readonlyAccessor, true);
 
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUd', 'enumerable');
+    assertPropertyIsNot(obj, 'readonlyAccessorWithUd', 'configurable');
+    assert.strictEqual(obj.readonlyAccessorWithUd, 1234, nameType);
+
     assertPropertyIsNot(obj, 'readwriteAccessor', 'enumerable');
     assertPropertyIsNot(obj, 'readwriteAccessor', 'configurable');
     obj.readwriteAccessor = false;
     assert.strictEqual(obj.readwriteAccessor, false);
     obj.readwriteAccessor = true;
     assert.strictEqual(obj.readwriteAccessor, true);
+
+    assertPropertyIsNot(obj, 'readwriteAccessorWithUd', 'enumerable');
+    assertPropertyIsNot(obj, 'readwriteAccessorWithUd', 'configurable');
+    obj.readwriteAccessorWithUd = 2;
+    assert.strictEqual(obj.readwriteAccessorWithUd, 2);
+    obj.readwriteAccessorWithUd = -14;
+    assert.strictEqual(obj.readwriteAccessorWithUd, -14);
 
     assertPropertyIsNot(obj, 'readonlyValue', 'writable');
     assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');


### PR DESCRIPTION
Currently the "data" argument in all PropertyDescriptor::Accessor overload is not taken in account in any code path, and hence not retrievable in the callback function from CbData.
Added the right implementation and some test.
Thanks! 
 Luciano