### PR TITLE
src: guard CallbackScope with N-API v3

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3404,6 +3404,8 @@ inline Value EscapableHandleScope::Escape(napi_value escapee) {
   return Value(_env, result);
 }
 
+
+#if (NAPI_VERSION > 2)
 ////////////////////////////////////////////////////////////////////////////////
 // CallbackScope class
 ////////////////////////////////////////////////////////////////////////////////
@@ -3431,6 +3433,7 @@ inline CallbackScope::operator napi_callback_scope() const {
 inline Napi::Env CallbackScope::Env() const {
   return Napi::Env(_env);
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // AsyncContext class

--- a/napi.h
+++ b/napi.h
@@ -1671,6 +1671,7 @@ namespace Napi {
     napi_escapable_handle_scope _scope;
   };
 
+#if (NAPI_VERSION > 2)
   class CallbackScope {
   public:
     CallbackScope(napi_env env, napi_callback_scope scope);
@@ -1686,6 +1687,7 @@ namespace Napi {
     napi_async_context _async_context;
     napi_callback_scope _scope;
   };
+#endif
 
   class AsyncContext {
   public:

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -16,7 +16,9 @@ Object InitBasicTypesValue(Env env);
 Object InitBigInt(Env env);
 #endif
 Object InitBuffer(Env env);
+#if (NAPI_VERSION > 2)
 Object InitCallbackScope(Env env);
+#endif
 Object InitDataView(Env env);
 Object InitDataViewReadWrite(Env env);
 Object InitError(Env env);
@@ -50,7 +52,9 @@ Object Init(Env env, Object exports) {
   exports.Set("bigint", InitBigInt(env));
 #endif
   exports.Set("buffer", InitBuffer(env));
+#if (NAPI_VERSION > 2)
   exports.Set("callbackscope", InitCallbackScope(env));
+#endif
   exports.Set("dataview", InitDataView(env));
   exports.Set("dataview_read_write", InitDataView(env));
   exports.Set("dataview_read_write", InitDataViewReadWrite(env));

--- a/test/callbackscope.cc
+++ b/test/callbackscope.cc
@@ -2,6 +2,7 @@
 
 using namespace Napi;
 
+#if (NAPI_VERSION > 2)
 namespace {
 
 static void RunInCallbackScope(const CallbackInfo& info) {
@@ -18,3 +19,4 @@ Object InitCallbackScope(Env env) {
   exports["runInCallbackScope"] = Function::New(env, RunInCallbackScope);
   return exports;
 }
+#endif

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,12 @@ if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
   testModules.splice(testModules.indexOf('typedarray-bigint'), 1);
 }
 
+if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
+    (process.env.npm_config_NAPI_VERSION < 3)) {
+  testModules.splice(testModules.indexOf('callbackscope'), 1);
+  testModules.splice(testModules.indexOf('version_management'), 1);
+}
+
 if (typeof global.gc === 'function') {
   console.log('Starting test suite\n');
 


### PR DESCRIPTION
CallbackScope support needs to be guarded
with N-API version 3, otherwise older versions
of N-API that did not have CallbackScope
support will have compile failures.

Fixes: https://github.com/nodejs/node-addon-api/issues/387