### PR TITLE
src : implement Cleanup class

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3705,6 +3705,28 @@ inline const napi_node_version* VersionManagement::GetNodeVersion(Env env) {
   return result;
 }
 
+#if (NAPI_VERSION > 2)
+////////////////////////////////////////////////////////////////////////////////
+// Cleanup class
+////////////////////////////////////////////////////////////////////////////////
+
+inline CleanupHook::CleanupHook(Env env) : _env(env) {
+  napi_status status = napi_add_env_cleanup_hook(_env, NapiHook, static_cast<void*>(this));
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
+
+inline CleanupHook::~CleanupHook() {
+  napi_status status = napi_remove_env_cleanup_hook(_env, NapiHook, static_cast<void*>(this));
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
+
+inline void CleanupHook::NapiHook(void* arg) {
+  CleanupHook* self = static_cast<CleanupHook*>(arg);
+  self->Cleanup();
+  delete self;
+}
+#endif
+
 // These macros shouldn't be useful in user code.
 #undef NAPI_THROW
 #undef NAPI_THROW_IF_FAILED

--- a/napi.h
+++ b/napi.h
@@ -1773,6 +1773,18 @@ namespace Napi {
       static const napi_node_version* GetNodeVersion(Env env);
   };
 
+#if (NAPI_VERSION > 2)
+  class CleanupHook {
+    public:
+      CleanupHook(Env env);
+      virtual ~CleanupHook();
+      virtual void Cleanup() = 0;
+    private:
+      napi_env _env;
+      static void NapiHook(void* arg);
+  };
+#endif
+
 } // namespace Napi
 
 // Inline implementations of all the above class methods are included here.

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -18,6 +18,7 @@ Object InitBigInt(Env env);
 Object InitBuffer(Env env);
 #if (NAPI_VERSION > 2)
 Object InitCallbackScope(Env env);
+Object InitCleanupHook(Env env);
 #endif
 Object InitDataView(Env env);
 Object InitDataViewReadWrite(Env env);
@@ -54,6 +55,7 @@ Object Init(Env env, Object exports) {
   exports.Set("buffer", InitBuffer(env));
 #if (NAPI_VERSION > 2)
   exports.Set("callbackscope", InitCallbackScope(env));
+  exports.Set("cleanuphook", InitCleanupHook(env));
 #endif
   exports.Set("dataview", InitDataView(env));
   exports.Set("dataview_read_write", InitDataView(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -16,6 +16,7 @@
         'binding.cc',
         'buffer.cc',
         'callbackscope.cc',
+        'cleanuphook.cc',
         'dataview/dataview.cc',
         'dataview/dataview_read_write.cc',
         'error.cc',

--- a/test/cleanuphook.cc
+++ b/test/cleanuphook.cc
@@ -7,16 +7,16 @@ using namespace Napi;
 class TestCleanupHook : public CleanupHook {
   public:
     static void DoCleanup(const CallbackInfo& info) {
-	  static int secret = 42;
-	  static int wrongSecret = 17;
-	  TestCleanupHook* testCleanupHook = new TestCleanupHook(info, wrongSecret);
-	  delete testCleanupHook;
+      static int secret = 42;
+      static int wrongSecret = 17;
+      TestCleanupHook* testCleanupHook = new TestCleanupHook(info, wrongSecret);
+      delete testCleanupHook;
 
       testCleanupHook = new TestCleanupHook(info, secret);
-	}
-	void Cleanup() {
-	  printf("cleanup(%d)\n", _secret);
-	};
+    }
+    void Cleanup() {
+      printf("cleanup(%d)\n", _secret);
+    };
   private:
     TestCleanupHook(const CallbackInfo& info, int secret) : CleanupHook(info.Env()), _secret(secret) {}
     int _secret;

--- a/test/cleanuphook.cc
+++ b/test/cleanuphook.cc
@@ -1,0 +1,31 @@
+#include "napi.h"
+
+using namespace Napi;
+
+#if (NAPI_VERSION > 2)
+
+class TestCleanupHook : public CleanupHook {
+  public:
+    static void DoCleanup(const CallbackInfo& info) {
+	  static int secret = 42;
+	  static int wrongSecret = 17;
+	  TestCleanupHook* testCleanupHook = new TestCleanupHook(info, wrongSecret);
+	  delete testCleanupHook;
+
+      testCleanupHook = new TestCleanupHook(info, secret);
+	}
+	void Cleanup() {
+	  printf("cleanup(%d)\n", _secret);
+	};
+  private:
+    TestCleanupHook(const CallbackInfo& info, int secret) : CleanupHook(info.Env()), _secret(secret) {}
+    int _secret;
+};
+
+Object InitCleanupHook(Env env) {
+  Object exports = Object::New(env);
+  exports["doCleanup"] = Function::New(env, TestCleanupHook::DoCleanup);
+  return exports;
+}
+
+#endif

--- a/test/cleanuphook.js
+++ b/test/cleanuphook.js
@@ -1,0 +1,34 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+const child_process = require('child_process');
+const bindingNode = `./build/${buildType}/binding.node`;
+const bindingNoexceptNode = `./build/${buildType}/binding_noexcept.node`;
+
+// we only check cleanup on 10.2 an higher were
+function checkNodeVersion() {
+  const nodeMajorVersion = process.versions.node.split('.')[0];
+  const nodeMinorVersion = process.versions.node.split('.')[1];
+  if (nodeMajorVersion >= 10 && nodeMinorVersion >= 2)
+    return true;
+  else
+    return false;
+}
+
+function test(bindingType) {
+  if (!checkNodeVersion())
+    return;
+  const { stdout } =
+          child_process.spawnSync(process.execPath, [__filename, bindingType]);
+  assert.strictEqual(stdout.toString().trim(), 'cleanup(42)');
+}
+
+if (process.argv[2] === bindingNode ||
+    process.argv[2] === bindingNoexceptNode) {
+  const binding = require(process.argv[2]);
+  binding.cleanuphook.doCleanup();
+}
+else {
+  test(bindingNode);
+  test(bindingNoexceptNode);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ let testModules = [
   'bigint',
   'buffer',
   'callbackscope',
+  'cleanuphook',
   'dataview/dataview',
   'dataview/dataview_read_write',
   'error',


### PR DESCRIPTION
This is a wrapper class to support the following N-APIs.

napi_add_env_cleanup_hook()
napi_remove_env_cleanup_hook()
Refs: https://nodejs.org/api/n-api.html#n_api_cleanup_on_exit_of_the_current_node_js_instance

I checked this pr with node v8.12.0 and v10.12.0.
The document for this class is not implemented yet.