### PR TITLE
src: fix noexcept control flow issues

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2045,7 +2045,7 @@ inline void Error::ThrowAsJavaScriptException() const {
   HandleScope scope(_env);
   if (!IsEmpty()) {
 
-    // We intentionally don't use `NAPI_THROW_*` macros here to point
+    // We intentionally don't use `NAPI_THROW_*` macros here to ensure
     // that there is no possible recursion as `ThrowAsJavaScriptException`
     // is part of `NAPI_THROW_*` macro definition for noexcept.
 


### PR DESCRIPTION
- adapt `NAPI_THROW`, create `NAPI_THROW_VOID`: either throw or
  return, never continue
- fix `Error::ThrowAsJavaScriptException`: if `napi_throw` fails, either
  explicitly throw or create fatal error

Closes: https://github.com/nodejs/node-addon-api/issues/419