### PR TITLE
[WIP]: src: implement `NodeThreadScheduler`

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -6,6 +6,7 @@
 #include <initializer_list>
 #include <string>
 #include <vector>
+#include <memory>
 
 // VS2015 RTM has bugs with constexpr, so require min of VS2015 Update 3 (known good version)
 #if !defined(_MSC_VER) || _MSC_FULL_VER >= 190024210
@@ -1759,6 +1760,40 @@ namespace Napi {
     FunctionReference _callback;
     std::string _error;
   };
+
+  // NodeThreadScheduler
+
+  #if (NAPI_VERSION > 2147483646)
+
+  class NodeThreadScheduler : public std::enable_shared_from_this<NodeThreadScheduler> {
+  public:
+    static std::shared_ptr<NodeThreadScheduler> Create(Env env);
+
+  public:
+
+    explicit NodeThreadScheduler(Env env);
+    explicit NodeThreadScheduler(Env env, String async_resource_name);
+    explicit NodeThreadScheduler(Env env, Object async_resource, String async_resource_name);
+
+    // noncopyable
+    NodeThreadScheduler(const NodeThreadScheduler&) = delete;
+    NodeThreadScheduler& operator=(const NodeThreadScheduler&) = delete;
+
+    // movable
+    NodeThreadScheduler(NodeThreadScheduler&&) = default;
+    NodeThreadScheduler& operator=(NodeThreadScheduler&&) = default;
+
+    ~NodeThreadScheduler() NAPI_NOEXCEPT;
+
+  public:
+    template<typename Callable>
+    bool RunInNodeThread(Callable&& callable);
+
+  private:
+    napi_threadsafe_function schedule_function = nullptr;
+  };
+
+#endif // NAPI_VERSION > 2147483646
 
   // Memory management.
   class MemoryManagement {

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -27,6 +27,9 @@ Object InitFunction(Env env);
 Object InitHandleScope(Env env);
 Object InitMemoryManagement(Env env);
 Object InitName(Env env);
+#if (NAPI_VERSION > 2147483646)
+Object InitNodeThreadScheduler(Env env);
+#endif
 Object InitObject(Env env);
 #ifndef NODE_ADDON_API_DISABLE_DEPRECATED
 Object InitObjectDeprecated(Env env);
@@ -62,6 +65,9 @@ Object Init(Env env, Object exports) {
   exports.Set("external", InitExternal(env));
   exports.Set("function", InitFunction(env));
   exports.Set("name", InitName(env));
+#if (NAPI_VERSION > 2147483646)
+  exports.Set("nodethreadscheduler", InitNodeThreadScheduler(env));
+#endif
   exports.Set("handlescope", InitHandleScope(env));
   exports.Set("memory_management", InitMemoryManagement(env));
   exports.Set("object", InitObject(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -24,6 +24,7 @@
         'handlescope.cc',
         'memory_management.cc',
         'name.cc',
+        'nodethreadscheduler.cc',
         'object/delete_property.cc',
         'object/get_property.cc',
         'object/has_own_property.cc',

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,7 @@ let testModules = [
   'handlescope',
   'memory_management',
   'name',
+  'nodethreadscheduler',
   'object/delete_property',
   'object/get_property',
   'object/has_own_property',
@@ -50,6 +51,7 @@ if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
   // this should be guarded on the napi version
   // in which bigint was added.
   testModules.splice(testModules.indexOf('bigint'), 1);
+  testModules.splice(testModules.indexOf('nodethreadscheduler'), 1);
   testModules.splice(testModules.indexOf('typedarray-bigint'), 1);
 }
 

--- a/test/nodethreadscheduler.cc
+++ b/test/nodethreadscheduler.cc
@@ -1,0 +1,44 @@
+#define NAPI_EXPERIMENTAL
+#include "napi.h"
+
+#if (NAPI_VERSION > 2147483646)
+#include <thread>
+#include <chrono>
+
+using namespace Napi;
+
+void MultithreadedCallback(const CallbackInfo& info) {
+  HandleScope scope(info.Env());
+
+  int32_t thread_count = info[0].ToNumber().Int32Value();
+  Function cb = info[1].As<Function>();
+
+  auto&& scheduler = NodeThreadScheduler::Create(info.Env());
+
+  for (int i = 0; i < thread_count; i++) {
+    // Reference is not copyable, this is a workaround
+    napi_ref ref;
+    napi_create_reference(info.Env(), cb, 1, &ref);
+
+    std::thread([scheduler, ref]() {
+      using namespace std::chrono_literals;
+
+      // bring in some execution chaos
+      std::this_thread::sleep_for(1ns);
+
+      scheduler->RunInNodeThread([ref](Env env) {
+        FunctionReference fn_ref(env, ref);
+        fn_ref.Call(env.Global(), {});
+      });
+    }).detach();
+  }
+}
+
+Object InitNodeThreadScheduler(Env env) {
+  Object exports = Object::New(env);
+
+  exports["multithreadedCallback"] = Function::New(env, MultithreadedCallback);
+  return exports;
+}
+
+#endif // (NAPI_VERSION > 2147483646)

--- a/test/nodethreadscheduler.js
+++ b/test/nodethreadscheduler.js
@@ -1,0 +1,17 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const {mustCall} = require('./common');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  const {nodethreadscheduler} = binding;
+
+  testCalls(50);
+
+  function testCalls(threadCount) {
+    nodethreadscheduler.multithreadedCallback(threadCount, mustCall(threadCount));
+  }
+
+};


### PR DESCRIPTION
## This is a WIP PR.

Did some verbose commenting in the code as I was fixing some potential bugs/leaks from https://github.com/DaAitch/napi-experimental/commit/412a466ced8b6f4587db01a263acc21054bffdc7 as `napi_tsfn_abort` mode was used.

This code should work, but I think we can do better.

I have a new idea of how we can get rid of heap allocation of `NodeThreadScheduler`, having it copyable, movable on the stack, thus feels more lightweight.
I'll work on it soon.