### PR TITLE
Minor doc fixes

### DIFF
--- a/doc/class_property_descriptor.md
+++ b/doc/class_property_descriptor.md
@@ -8,7 +8,7 @@ This prevents using descriptors from a different class when defining a new class
 
 ## Methods
 
-### Contructor
+### Constructor
 
 Creates new instance of `Napi::ClassPropertyDescriptor` descriptor object.
 

--- a/doc/number.md
+++ b/doc/number.md
@@ -24,7 +24,7 @@ Creates a new instance of a `Napi::Number` object.
 Napi::Number(napi_env env, napi_value value);
 ```
 
- - `[in] env`: The `napi_env` environment in which to construct the `Napi::Nuber` object.
+ - `[in] env`: The `napi_env` environment in which to construct the `Napi::Number` object.
  - `[in] value`: The `napi_value` which is a handle for a JavaScript `Number`.
 
  Returns a non-empty `Napi::Number` object.
@@ -36,7 +36,7 @@ Napi::Number(napi_env env, napi_value value);
 ```cpp
 Napi::Number Napi::Number::New(napi_env env, double value);
 ```
- - `[in] env`: The `napi_env` environment in which to construct the `Napi::Nuber` object.
+ - `[in] env`: The `napi_env` environment in which to construct the `Napi::Number` object.
  - `[in] value`: The `napi_value` which is a handle for a JavaScript `Number`.
 
 Creates a new instance of a `Napi::Number` object.

--- a/doc/object.md
+++ b/doc/object.md
@@ -108,7 +108,7 @@ Napi::Value Napi::Object::Get(____ key);
 ```
 - `[in] key`: The name of the property to return the value for.
 
-Returns the [`Napi::Value`](value.md) associated with the key property. Returns NULL if no such key exists.
+Returns the [`Napi::Value`](value.md) associated with the key property. Returns the value *undefined* if the key does not exist.
 
 The `key` can be any of the following types:
 - `napi_value`

--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -116,7 +116,7 @@ against the class constructor.
 
 ## Methods
 
-### Contructor
+### Constructor
 
 Creates a new instance of a JavaScript object that wraps native instance.
 

--- a/doc/property_descriptor.md
+++ b/doc/property_descriptor.md
@@ -192,7 +192,7 @@ static Napi::PropertyDescriptor Napi::PropertyDescriptor::Function (
 		            void *data = nullptr);
 ```
 
-* `[in] env`: The environemnt in which to create this accessor.
+* `[in] env`: The environment in which to create this accessor.
 * `[in] name`: The name of the Callable function.
 * `[in] cb`: The function
 * `[in] attributes`: Potential attributes for the getter function.

--- a/tools/README.md
+++ b/tools/README.md
@@ -25,7 +25,7 @@ Here is the list of things that can be fixed easily.
 
 
 ### Major Reconstructions
-The implementation of `Napi::ObjectWrap` is significantly different from NAN's. `Napi::ObjectWrap` takes a pointer to the wrapped object and creates a reference to the wrapped object inside ObjectWrap constructor. `Napi::ObjectWrap` also associated wrapped object's instance methods to Javascript module instead of static methods like NAN.
+The implementation of `Napi::ObjectWrap` is significantly different from NAN's. `Napi::ObjectWrap` takes a pointer to the wrapped object and creates a reference to the wrapped object inside ObjectWrap constructor. `Napi::ObjectWrap` also associates wrapped object's instance methods to Javascript module instead of static methods like NAN.
 
 So if you use Nan::ObjectWrap in your module, you will need to execute the following steps.
 
@@ -39,7 +39,7 @@ and define it as
   ...
 }
 ```
-This way, the `Napi::ObjectWrap` constructor will be invoked after the object has been instanciated and `Napi::ObjectWrap` can use the `this` pointer to create reference to the wrapped object.
+This way, the `Napi::ObjectWrap` constructor will be invoked after the object has been instantiated and `Napi::ObjectWrap` can use the `this` pointer to create a reference to the wrapped object.
 
   2. Move your original constructor code into the new constructor. Delete your original constructor.
   3. In your class initialization function, associate native methods in the following way. The `&` character before methods is required because they are not static methods but instance methods.


### PR DESCRIPTION
As I was working through the docs I made edits when I noticed typos, misspellings, or in the case of object.md, incorrect information.

I find myself doing a bit more research than I wanted to in a few cases and wondered what your thoughts were on expanding some of the docs to include examples as opposed to (mostly just) API.

Here's a list of items that I found myself experimenting with to get something working because I couldn't deduce from the docs alone what I needed to do.

- external data
- DefineClass examples for Instance/Static methods/properties
- property_descriptors
- how to use class_property_descriptors

(actually I didn't get the last two working and just found a way around the issue but those were my first approaches.)

If you're open to providing more examples for the first two let me know where you think they belong and I'll work on some.

Thanks for the excellent doc. When I compare this to trying to get Nan working over a year ago it's night and day.