### PR TITLE
package: add npm search keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "directories": {},
   "homepage": "https://github.com/nodejs/node-addon-api",
+  "keywords": ["n-api", "napi", "addon", "native", "bindings", "c", "c++", "nan", "node-addon-api"],
   "license": "MIT",
   "main": "index.js",
   "name": "node-addon-api",


### PR DESCRIPTION
It was hard to find this package on npm, even though I knew it was there. With keywords, it should be possible to find it with, for example, https://www.npmjs.com/search?q=napi%20addon