### PR TITLE
Correct return type of Int32Value to int32_t

### DIFF
--- a/doc/number.md
+++ b/doc/number.md
@@ -43,7 +43,7 @@ Creates a new instance of a `Napi::Number` object.
 
 ### Int32Value
 
-Converts a `Napi::Number` value to a `uint32_t` primitive type.
+Converts a `Napi::Number` value to a `int32_t` primitive type.
 
 ```cpp
 Napi::Number::Int32Value() const;


### PR DESCRIPTION
It currently reads uint32_t, which would be very strange, and is also untrue (I checked napi.h) ;)