### PR TITLE
src: move NAPI_AUTO_LEN from define to static const

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,17 @@
   },
   "directories": {},
   "homepage": "https://github.com/nodejs/node-addon-api",
-  "keywords": ["n-api", "napi", "addon", "native", "bindings", "c", "c++", "nan", "node-addon-api"],
+  "keywords": [
+    "n-api",
+    "napi",
+    "addon",
+    "native",
+    "bindings",
+    "c",
+    "c++",
+    "nan",
+    "node-addon-api"
+  ],
   "license": "MIT",
   "main": "index.js",
   "name": "node-addon-api",

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -100,9 +100,9 @@ typedef struct {
 #define NAPI_MODULE(modname, regfunc) \
   NAPI_MODULE_X(modname, regfunc, NULL, 0)
 
-#define NAPI_AUTO_LENGTH SIZE_MAX
-
 EXTERN_C_START
+
+static const size_t NAPI_AUTO_LENGTH = SIZE_MAX;
 
 NAPI_EXTERN void napi_module_register(napi_module* mod);
 


### PR DESCRIPTION
This allows tools like rust's bindgen to use this constant directly