### PR TITLE
string.md: Document existing New(env, value, length) APIs

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -56,6 +56,8 @@ Napi::String::New(napi_env env, const std::string& value);
 Napi::String::New(napi_env env, const std::u16::string& value);
 Napi::String::New(napi_env env, const char* value);
 Napi::String::New(napi_env env, const char16_t* value);
+Napi::String::New(napi_env env, const char* value, size_t length);
+Napi::String::New(napi_env env, const char16_t* value, size_t length);
 ```
 
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Value` object.
@@ -64,6 +66,7 @@ Napi::String::New(napi_env env, const char16_t* value);
   - `std::u16string&` - represents a UTF16-LE string.
   - `const char*` - represents a UTF8 string.
   - `const char16_t*` - represents a UTF16-LE string.
+- `[in] length`: The length of the string (not necessarily null-terminated) in code units.
 
 Returns a new `Napi::String` that represents the passed in C++ string.
 


### PR DESCRIPTION
This is a drive-by PR to document the String::New functions that take non null-terminated strings.