### PR TITLE
AsyncWorker: make callback optional

### DIFF
--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -105,8 +105,8 @@ virtual void Napi::AsyncWorker::Execute() = 0;
 
 ### OnOK
 
-This method is invoked when the computation in the `Excecute` method ends.
-The default implementation runs the Callback provided when the AsyncWorker class
+This method is invoked when the computation in the `Execute` method ends.
+The default implementation runs the Callback optionally provided when the AsyncWorker class
 was created.
 
 ```cpp
@@ -136,7 +136,7 @@ explicit Napi::AsyncWorker(const Napi::Function& callback);
 - `[in] callback`: The function which will be called when an asynchronous
 operations ends. The given function is called from the main event loop thread.
 
-Returns a`Napi::AsyncWork` instance which can later be queued for execution by calling
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by calling
 `Queue`.
 
 ### Constructor
@@ -153,7 +153,7 @@ operations ends. The given function is called from the main event loop thread.
 identifier for the kind of resource that is being provided for diagnostic
 information exposed by the async_hooks API.
 
-Returns a `Napi::AsyncWork` instance which can later be queued for execution by
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by
 calling `Napi::AsyncWork::Queue`.
 
 ### Constructor
@@ -172,7 +172,7 @@ information exposed by the async_hooks API.
 - `[in] resource`: Object associated with the asynchronous operation that
 will be passed to possible async_hooks.
 
-Returns a `Napi::AsyncWork` instance which can later be queued for execution by
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by
 calling `Napi::AsyncWork::Queue`.
 
 ### Constructor
@@ -187,7 +187,7 @@ explicit Napi::AsyncWorker(const Napi::Object& receiver, const Napi::Function& c
 - `[in] callback`: The function which will be called when an asynchronous
 operations ends. The given function is called from the main event loop thread.
 
-Returns a `Napi::AsyncWork` instance which can later be queued for execution by
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by
 calling `Napi::AsyncWork::Queue`.
 
 ### Constructor
@@ -227,6 +227,54 @@ will be passed to possible async_hooks.
 
 Returns a `Napi::AsyncWork` instance which can later be queued for execution by
 calling `Napi::AsyncWork::Queue`.
+
+
+### Constructor
+
+Creates a new `Napi::AsyncWorker`.
+
+```cpp
+explicit Napi::AsyncWorker(Napi::Env env);
+```
+
+- `[in] env`: The environment in which to create the `Napi::AsyncWorker`.
+
+Returns an `Napi::AsyncWorker` instance which can later be queued for execution by calling
+`Napi::AsyncWorker::Queue`.
+
+### Constructor
+
+Creates a new `Napi::AsyncWorker`.
+
+```cpp
+explicit Napi::AsyncWorker(Napi::Env env, const char* resource_name);
+```
+
+- `[in] env`: The environment in which to create the `Napi::AsyncWorker`.
+- `[in] resource_name`: Null-terminated strings that represents the
+identifier for the kind of resource that is being provided for diagnostic
+information exposed by the async_hooks API.
+
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by
+calling `Napi::AsyncWorker::Queue`.
+
+### Constructor
+
+Creates a new `Napi::AsyncWorker`.
+
+```cpp
+explicit Napi::AsyncWorker(Napi::Env env, const char* resource_name, const Napi::Object& resource);
+```
+
+- `[in] env`: The environment in which to create the `Napi::AsyncWorker`.
+- `[in] resource_name`:  Null-terminated strings that represents the
+identifier for the kind of resource that is being provided for diagnostic
+information exposed by the async_hooks API.
+- `[in] resource`: Object associated with the asynchronous operation that
+will be passed to possible async_hooks.
+
+Returns a `Napi::AsyncWorker` instance which can later be queued for execution by
+calling `Napi::AsyncWorker::Queue`.
 
 ### Destructor
 

--- a/napi.h
+++ b/napi.h
@@ -1800,6 +1800,13 @@ namespace Napi {
                          const char* resource_name,
                          const Object& resource);
 
+    explicit AsyncWorker(Napi::Env env);
+    explicit AsyncWorker(Napi::Env env,
+                         const char* resource_name);
+    explicit AsyncWorker(Napi::Env env,
+                         const char* resource_name,
+                         const Object& resource);
+
     virtual void Execute() = 0;
     virtual void OnOK();
     virtual void OnError(const Error& e);

--- a/test/asyncworker-nocallback.js
+++ b/test/asyncworker-nocallback.js
@@ -1,0 +1,15 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const common = require('./common');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  const resolving = binding.asyncworker.doWorkNoCallback(true, {});
+  resolving.then(common.mustCall()).catch(common.mustNotCall());
+
+  const rejecting = binding.asyncworker.doWorkNoCallback(false, {});
+  rejecting.then(common.mustNotCall()).catch(common.mustCall());
+  return;
+}

--- a/test/asyncworker.cc
+++ b/test/asyncworker.cc
@@ -29,8 +29,41 @@ private:
   bool _succeed;
 };
 
+class TestWorkerNoCallback : public AsyncWorker {
+public:
+  static Value DoWork(const CallbackInfo& info) {
+    napi_env env = info.Env();
+    bool succeed = info[0].As<Boolean>();
+    Object resource = info[1].As<Object>();
+
+    TestWorkerNoCallback* worker = new TestWorkerNoCallback(env, "TestResource", resource);
+    worker->_succeed = succeed;
+    worker->Queue();
+    return worker->_deferred.Promise();
+  }
+
+protected:
+  void Execute() override {
+  }
+  virtual void OnOK() override {
+      _deferred.Resolve(Env().Undefined());
+
+  }
+  virtual void OnError(const Napi::Error& e) override {
+      _deferred.Reject(Env().Undefined());
+  }
+
+private:
+  TestWorkerNoCallback(napi_env env, const char* resource_name, const Object& resource)
+      : AsyncWorker(env, resource_name, resource), _deferred(Napi::Promise::Deferred::New(env)) {
+      }
+  Promise::Deferred _deferred;
+  bool _succeed;
+};
+
 Object InitAsyncWorker(Env env) {
   Object exports = Object::New(env);
   exports["doWork"] = Function::New(env, TestWorker::DoWork);
+  exports["doWorkNoCallback"] = Function::New(env, TestWorkerNoCallback::DoWork);
   return exports;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ let testModules = [
   'arraybuffer',
   'asynccontext',
   'asyncworker',
+  'asyncworker-nocallback',
   'asyncworker-persistent',
   'basic_types/array',
   'basic_types/boolean',


### PR DESCRIPTION
`AsyncWorker` assumed that after work is complete,  a JavaScript  callback would need to execute.

This change removes the restriction of specifying a `Function` callback, and instead replaces it with an `Env` parameter. Since the purpose of `receiver` was for the `this` context for the callback, it has also been removed from the constructors.

Re: https://github.com/nodejs/node-addon-api/issues/231#issuecomment-483356091