### PR TITLE
Use curly brackets to  include node_api.h

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -1,7 +1,7 @@
 #ifndef SRC_NAPI_H_
 #define SRC_NAPI_H_
 
-#include "node_api.h"
+#include <node_api.h>
 #include <functional>
 #include <initializer_list>
 #include <string>


### PR DESCRIPTION
In this PR I include `node_api.h` file using curly brackets because when native addon are building we have `node_api.h` in our include path.