### PR TITLE
src: fix objectwrap test case

### DIFF
--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -73,12 +73,11 @@ const test = (binding) => {
         keys.push(key);
       }
 
-      assert.deepEqual(keys, [
-        'testGetSet',
-        'testGetter',
-        'testValue',
-        'testMethod'
-      ]);
+      assert(keys.length = 4);
+      assert(obj.testGetSet);
+      assert(obj.testGetter);
+      assert(obj.testValue);
+      assert(obj.testMethod);
     }
   };
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node-addon-api/issues/485

The test case was relyingon the ordering of
"for in" which is not guarranteed as per
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in

Update the testcase to check in an way that does
not depend on ordering.