### PR TITLE
Add napi_finalize override to ObjectWrap

### DIFF
--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -190,25 +190,16 @@ property of the `Napi::CallbackInfo`.
 
 Returns a `Napi::Function` representing the constructor function for the class.
 
-### OverrideFinalizeCallback
+### Finalize
 
-Overrides default `Napi::ObjectWrap::FinalizeCallback` with a user defined finalizer.
+Hooks into `Napi::ObjectWrap::FinalizeCallback` giving access to `Napi::Env`
+before the native instance is freed.
 
 ```cpp
-static void Napi::ObjectWrap::OverrideFinalizeCallback(T* instance,
-                  napi_finalize finalizeCallback);
+virtual void Finalize(Napi::Env env);
 ```
 
-- `[in] instance`: `this` pointer from the native instance.
-- `[in] finalizeCallback`: function that implements [napi_finalize](https://nodejs.org/api/n-api.html#n_api_napi_finalize "N-API documentation for napi_finalize.").
-
-`Napi::ObjectWrap::OverrideFinalizeCallback` is protected and
-intended to be called from a native instance method; for example, in the native
-constructor.
-
-NOTE: The default `Napi::ObjectWrap::FinalizeCallback` frees
-the native instance.  A user defined finalzier is, therefore, 
-responsible for freeing the native instance.
+- `[in] env`: `Napi::Env`.
 
 ### StaticMethod
 

--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -190,6 +190,26 @@ property of the `Napi::CallbackInfo`.
 
 Returns a `Napi::Function` representing the constructor function for the class.
 
+### OverrideFinalizeCallback
+
+Overrides default `Napi::ObjectWrap::FinalizeCallback` with a user defined finalizer.
+
+```cpp
+static void Napi::ObjectWrap::OverrideFinalizeCallback(T* instance,
+                  napi_finalize finalizeCallback);
+```
+
+- `[in] instance`: `this` pointer from the native instance.
+- `[in] finalizeCallback`: function that implements [napi_finalize](https://nodejs.org/api/n-api.html#n_api_napi_finalize "N-API documentation for napi_finalize.").
+
+`Napi::ObjectWrap::OverrideFinalizeCallback` is protected and
+intended to be called from a native instance method; for example, in the native
+constructor.
+
+NOTE: The default `Napi::ObjectWrap::FinalizeCallback` frees
+the native instance.  A user defined finalzier is, therefore, 
+responsible for freeing the native instance.
+
 ### StaticMethod
 
 Creates property descriptor that represents a static method of a JavaScript class.

--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -192,8 +192,8 @@ Returns a `Napi::Function` representing the constructor function for the class.
 
 ### Finalize
 
-Hooks into `Napi::ObjectWrap::FinalizeCallback` giving access to `Napi::Env`
-before the native instance is freed.
+Provides an opportunity to run cleanup code that requires access to the `Napi::Env` 
+before the wrapped native object instance is freed.  Override to implement. 
 
 ```cpp
 virtual void Finalize(Napi::Env env);

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3260,6 +3260,13 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
 }
 
 template <typename T>
+inline void ObjectWrap<T>::OverrideFinalizeCallback(T* instance,
+    napi_finalize finalizeCallback) {
+  ObjectWrap<T>* base = instance;
+  base->_finalizeCallbackOverride = finalizeCallback;
+}
+
+template <typename T>
 inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
     napi_env env,
     napi_callback_info info) {
@@ -3400,9 +3407,13 @@ inline napi_value ObjectWrap<T>::InstanceSetterCallbackWrapper(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::FinalizeCallback(napi_env /*env*/, void* data, void* /*hint*/) {
+inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* hint) {
   T* instance = reinterpret_cast<T*>(data);
-  delete instance;
+  if(instance->_finalizeCallbackOverride == nullptr){
+    delete instance;
+  } else {
+    (*(instance->_finalizeCallbackOverride))(env, data, hint);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3260,11 +3260,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::OverrideFinalizeCallback(T* instance,
-    napi_finalize finalizeCallback) {
-  ObjectWrap<T>* base = instance;
-  base->_finalizeCallbackOverride = finalizeCallback;
-}
+inline void ObjectWrap<T>::Finalize(Napi::Env env) {}
 
 template <typename T>
 inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
@@ -3407,13 +3403,10 @@ inline napi_value ObjectWrap<T>::InstanceSetterCallbackWrapper(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* hint) {
+inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hint*/) {
   T* instance = reinterpret_cast<T*>(data);
-  if(instance->_finalizeCallbackOverride == nullptr){
-    delete instance;
-  } else {
-    (*(instance->_finalizeCallbackOverride))(env, data, hint);
-  }
+  instance->Finalize(Napi::Env(env));
+  delete instance;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2887,6 +2887,9 @@ inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
 }
 
 template<typename T>
+inline ObjectWrap<T>::~ObjectWrap() {}
+
+template<typename T>
 inline T* ObjectWrap<T>::Unwrap(Object wrapper) {
   T* unwrapped;
   napi_status status = napi_unwrap(wrapper.Env(), wrapper, reinterpret_cast<void**>(&unwrapped));
@@ -3260,7 +3263,7 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::InstanceValue(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::Finalize(Napi::Env env) {}
+inline void ObjectWrap<T>::Finalize(Napi::Env /*env*/) {}
 
 template <typename T>
 inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(

--- a/napi.h
+++ b/napi.h
@@ -1657,8 +1657,10 @@ namespace Napi {
     static PropertyDescriptor InstanceValue(Symbol name,
                                             Napi::Value value,
                                             napi_property_attributes attributes = napi_default);
-
+  protected:
+    static void OverrideFinalizeCallback(T* instance, napi_finalize finalizeCallback);
   private:
+    napi_finalize _finalizeCallbackOverride = nullptr;
     static napi_value ConstructorCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticMethodCallbackWrapper(napi_env env, napi_callback_info info);

--- a/napi.h
+++ b/napi.h
@@ -1657,10 +1657,8 @@ namespace Napi {
     static PropertyDescriptor InstanceValue(Symbol name,
                                             Napi::Value value,
                                             napi_property_attributes attributes = napi_default);
-  protected:
-    static void OverrideFinalizeCallback(T* instance, napi_finalize finalizeCallback);
+    virtual void Finalize(Napi::Env env);
   private:
-    napi_finalize _finalizeCallbackOverride = nullptr;
     static napi_value ConstructorCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticMethodCallbackWrapper(napi_env env, napi_callback_info info);

--- a/napi.h
+++ b/napi.h
@@ -1570,7 +1570,8 @@ namespace Napi {
   class ObjectWrap : public Reference<Object> {
   public:
     ObjectWrap(const CallbackInfo& callbackInfo);
-
+    virtual ~ObjectWrap();
+    
     static T* Unwrap(Object wrapper);
 
     // Methods exposed to JavaScript must conform to one of these callback signatures.

--- a/napi.h
+++ b/napi.h
@@ -1658,6 +1658,7 @@ namespace Napi {
                                             Napi::Value value,
                                             napi_property_attributes attributes = napi_default);
     virtual void Finalize(Napi::Env env);
+
   private:
     static napi_value ConstructorCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -24,6 +24,11 @@ class Test : public Napi::ObjectWrap<Test> {
 public:
   Test(const Napi::CallbackInfo& info) :
     Napi::ObjectWrap<Test>(info) {
+    
+    if(info.Length() > 0){
+      finalizerCb_ = Napi::Persistent(info[0].As<Napi::Function>());
+    }
+
   }
 
   void Setter(const Napi::CallbackInfo& /*info*/, const Napi::Value& value) {
@@ -105,8 +110,20 @@ public:
     }));
   }
 
+  void Finalize(Napi::Env env){
+    
+    if(finalizerCb_.IsEmpty()){
+      return;
+    }
+
+    finalizerCb_.Call(env.Global(), {Napi::Boolean::New(env, true)});
+    finalizerCb_.Unref();
+
+  }
+
 private:
   std::string value_;
+  Napi::FunctionReference finalizerCb_;
 };
 
 Napi::Object InitObjectWrap(Napi::Env env) {

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -25,8 +25,8 @@ public:
   Test(const Napi::CallbackInfo& info) :
     Napi::ObjectWrap<Test>(info) {
     
-    if(info.Length() > 0){
-      finalizerCb_ = Napi::Persistent(info[0].As<Napi::Function>());
+    if(info.Length() > 0) {
+      finalizeCb_ = Napi::Persistent(info[0].As<Napi::Function>());
     }
 
   }
@@ -110,20 +110,20 @@ public:
     }));
   }
 
-  void Finalize(Napi::Env env){
+  void Finalize(Napi::Env env) {
     
-    if(finalizerCb_.IsEmpty()){
+    if(finalizeCb_.IsEmpty()) {
       return;
     }
 
-    finalizerCb_.Call(env.Global(), {Napi::Boolean::New(env, true)});
-    finalizerCb_.Unref();
+    finalizeCb_.Call(env.Global(), {Napi::Boolean::New(env, true)});
+    finalizeCb_.Unref();
 
   }
 
 private:
   std::string value_;
-  Napi::FunctionReference finalizerCb_;
+  Napi::FunctionReference finalizeCb_;
 };
 
 Napi::Object InitObjectWrap(Napi::Env env) {

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -182,21 +182,21 @@ const test = (binding) => {
     }
   };
 
-  const testFinalizer = (clazz) => {
+  const testFinalize = (clazz) => {
     
-    let finalizerCalled = false;
-    const finalizerCb = function(called){
-      finalizerCalled = called;
+    let finalizeCalled = false;
+    const finalizeCb = function(called) {
+      finalizeCalled = called;
     };
 
-    //Scope Test instance so that it can be gc'd
-    (function(){
-      new Test(finalizerCb);
+    //Scope Test instance so that it can be gc'd.
+    (function() {
+      new Test(finalizeCb);
     })();
 
     global.gc();
 
-    assert.strictEqual(finalizerCalled, true);
+    assert.strictEqual(finalizeCalled, true);
 
   };
 
@@ -216,7 +216,7 @@ const test = (binding) => {
     testStaticMethod(clazz);
 
     testStaticEnumerables(clazz);    
-    testFinalizer(clazz);
+    testFinalize(clazz);
   };
 
   // `Test` is needed for accessing exposed symbols

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -182,6 +182,24 @@ const test = (binding) => {
     }
   };
 
+  const testFinalizer = (clazz) => {
+    
+    let finalizerCalled = false;
+    const finalizerCb = function(called){
+      finalizerCalled = called;
+    };
+
+    //Scope Test instance so that it can be gc'd
+    (function(){
+      new Test(finalizerCb);
+    })();
+
+    global.gc();
+
+    assert.strictEqual(finalizerCalled, true);
+
+  };
+
   const testObj = (obj, clazz) => {
     testValue(obj, clazz);
     testAccessor(obj, clazz);
@@ -197,7 +215,8 @@ const test = (binding) => {
     testStaticAccessor(clazz);
     testStaticMethod(clazz);
 
-    testStaticEnumerables(clazz);
+    testStaticEnumerables(clazz);    
+    testFinalizer(clazz);
   };
 
   // `Test` is needed for accessing exposed symbols


### PR DESCRIPTION
By implementing the release of the native instance, `ObjectWrap` takes an opinionated approach to the `finalize_cb` in  N-API [`napi_wrap`](https://nodejs.org/api/n-api.html#n_api_napi_wrap).  This is arguably the correct default as the central theme of the [`Object Wrap`](https://nodejs.org/api/n-api.html#n_api_object_wrap) methods in N-API is encapsulation.  Specifically tying the properties and **lifetimes** of a native instance to a JS object.

However, because this default is not optional/overridable, it excludes access to more complex finalization scenarios allowed by N-API.  Specifically when access to the `napi_env` is required.  Because node-addon-api is meant to be a thin convenience wrapper, it follows that some method of access to the underlying N-API should exist where defaults are not merely a difference in syntax and style between C++ and C.

I've added `ObjectWrap::OverrideFinalizeCallback` to accomplish this in regards to the default `napi_finalize` in `ObjectWrap`.   I prefixed with "Override" as opposed to "Set" in order to make it clear that there is a default behavior that is being overridden.  I also stated in the documentation that the responsibility of freeing the native instance is passed to the user defined `napi_finalize` callback when `ObjectWrap::OverrideFinalizeCallback` is used.