### PR TITLE
Fix compilation breakage on 1.7.0

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -125,6 +125,7 @@ struct FinalizeData {
   Hint* hint;
 };
 
+#if (NAPI_VERSION > 3)
 template <typename ContextType=void,
           typename Finalizer=std::function<void(Env, void*, ContextType*)>,
           typename FinalizerDataType=void>
@@ -196,6 +197,7 @@ struct ThreadSafeFinalize {
   Finalizer callback;
   napi_threadsafe_function* tsfn;
 };
+#endif
 
 template <typename Getter, typename Setter>
 struct AccessorCallbackData {
@@ -3740,6 +3742,7 @@ inline void AsyncWorker::OnWorkComplete(
   }
 }
 
+#if (NAPI_VERSION > 3)
 ////////////////////////////////////////////////////////////////////////////////
 // ThreadSafeFunction class
 ////////////////////////////////////////////////////////////////////////////////
@@ -4058,6 +4061,7 @@ inline void ThreadSafeFunction::CallJS(napi_env env,
     Function(env, jsCallback).Call({});
   }
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Memory Management class

--- a/napi.h
+++ b/napi.h
@@ -1830,6 +1830,7 @@ namespace Napi {
     bool _suppress_destruct;
   };
 
+  #if (NAPI_VERSION > 3)
   class ThreadSafeFunction {
   public:
     // This API may only be called from the main thread.
@@ -2029,6 +2030,7 @@ namespace Napi {
 
     std::unique_ptr<napi_threadsafe_function> _tsfn;
   };
+  #endif
 
   // Memory management.
   class MemoryManagement {

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,11 @@ if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
   testModules.splice(testModules.indexOf('version_management'), 1);
 }
 
+if ((process.env.npm_config_NAPI_VERSION !== undefined) &&
+    (process.env.npm_config_NAPI_VERSION < 4)) {
+  testModules.splice(testModules.indexOf('threadsafe_function/threadsafe_function'), 1);
+}
+
 if (typeof global.gc === 'function') {
   console.log('Starting test suite\n');
 

--- a/test/threadsafe_function/threadsafe_function.cc
+++ b/test/threadsafe_function/threadsafe_function.cc
@@ -2,6 +2,8 @@
 #include <thread>
 #include "napi.h"
 
+#if (NAPI_VERSION > 3)
+
 using namespace Napi;
 
 constexpr size_t ARRAY_LENGTH = 10;
@@ -177,3 +179,5 @@ Object InitThreadSafeFunction(Env env) {
 
   return exports;
 }
+
+#endif


### PR DESCRIPTION
Some users are experimenting compilation problem like reported in this issue: https://github.com/nodejs/node-addon-api/issues/517. I added a check if `NAPI_VERSION` is greater than 3 and in this case I enable the `Napi::ThreadsafeFunction`. Please review quickly.