### PR TITLE
ci: enable travis for fast PR check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,15 @@ env:
     # https://github.com/jasongin/nvs/blob/master/doc/CI.md
     - NVS_VERSION=1.4.2
   matrix:
-    - NODEJS_VERSION=node/4
     - NODEJS_VERSION=node/6
     - NODEJS_VERSION=node/8
-    - NODEJS_VERSION=node/9
     - NODEJS_VERSION=node/10
-    - NODEJS_VERSION=chakracore/8
-    - NODEJS_VERSION=chakracore/10
+    - NODEJS_VERSION=node/12
     - NODEJS_VERSION=nightly
-    - NODEJS_VERSION=chakracore-nightly
 matrix:
   fast_finish: true
   allow_failures:
     - env: NODEJS_VERSION=nightly
-    - env: NODEJS_VERSION=chakracore-nightly
 sudo: false
 cache:
   directories:
@@ -59,7 +54,13 @@ install:
 script:
   # Travis CI sets NVM_NODEJS_ORG_MIRROR, but it makes node-gyp fail to download headers for nightly builds.
   - unset NVM_NODEJS_ORG_MIRROR
+  - NODEJS_MAJOR_VERSION=$(node -p "process.versions.node.match(/\d+/)[0]")
 
-  - npm test $NPMOPT
+  - |
+    if [ ${NODEJS_MAJOR_VERSION} -gt 11 ]; then
+      npm test
+    else
+      npm test $NPMOPT --NAPI_VERSION=$(node -p "process.versions.napi")
+    fi
 after_success:
   - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test

--- a/test/basic_types/array.cc
+++ b/test/basic_types/array.cc
@@ -1,4 +1,3 @@
-#define NAPI_EXPERIMENTAL
 #include "napi.h"
 
 using namespace Napi;


### PR DESCRIPTION
##### test: remove unnecessary NAPI_EXPERIMENTAL
-----
As ci.nodejs.org doesn't automatically run for PRs, travis is still the easiest way to determine if the PR is test passed on multiple node variants and platforms.

##### travis: remove chakracore on travis
1. node-chakracore v8 doesn’t expose napi version
2. node-chakracore v10 doesn’t throws on handlescope double escape
3. set npm_config_NAPI_VERSION to override NAPI_EXPERIMENTAL expansion
  on Node.js version lower than 11 for napi_date_* not back ported to v10

- [x] npm test passed