### PR TITLE
doc: fix return type of ArrayBuffer::Data

### DIFF
--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -123,7 +123,7 @@ Returns the length of the wrapped data, in bytes.
 ### Data
 
 ```cpp
-T* Napi::ArrayBuffer::Data() const;
+void* Napi::ArrayBuffer::Data() const;
 ```
 
 Returns a pointer the wrapped data.


### PR DESCRIPTION
`ArrayBuffer` itself is not typed and `Data()` returns a `void*`.