### PR TITLE
error: remove unnecessary if condition

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1994,47 +1994,43 @@ inline Error Error::New(napi_env env) {
   status = napi_get_last_error_info(env, &info);
   NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_last_error_info");
 
-  if (status == napi_ok) {
-    if (info->error_code == napi_pending_exception) {
+  if (info->error_code == napi_pending_exception) {
+    status = napi_get_and_clear_last_exception(env, &error);
+    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
+  }
+  else {
+    const char* error_message = info->error_message != nullptr ?
+      info->error_message : "Error in native callback";
+
+    bool isExceptionPending;
+    status = napi_is_exception_pending(env, &isExceptionPending);
+    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_is_exception_pending");
+
+    if (isExceptionPending) {
       status = napi_get_and_clear_last_exception(env, &error);
       NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
     }
-    else {
-      const char* error_message = info->error_message != nullptr ?
-        info->error_message : "Error in native callback";
 
-      bool isExceptionPending;
-      status = napi_is_exception_pending(env, &isExceptionPending);
-      NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_is_exception_pending");
+    napi_value message;
+    status = napi_create_string_utf8(
+      env,
+      error_message,
+      std::strlen(error_message),
+      &message);
+    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_create_string_utf8");
 
-      if (isExceptionPending) {
-        status = napi_get_and_clear_last_exception(env, &error);
-        NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
-      }
-
-      napi_value message;
-      status = napi_create_string_utf8(
-        env,
-        error_message,
-        std::strlen(error_message),
-        &message);
-      NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_create_string_utf8");
-
-      if (status == napi_ok) {
-        switch (info->error_code) {
-        case napi_object_expected:
-        case napi_string_expected:
-        case napi_boolean_expected:
-        case napi_number_expected:
-          status = napi_create_type_error(env, nullptr, message, &error);
-          break;
-        default:
-          status = napi_create_error(env, nullptr,  message, &error);
-          break;
-        }
-        NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_create_error");
-      }
+    switch (info->error_code) {
+    case napi_object_expected:
+    case napi_string_expected:
+    case napi_boolean_expected:
+    case napi_number_expected:
+      status = napi_create_type_error(env, nullptr, message, &error);
+      break;
+    default:
+      status = napi_create_error(env, nullptr,  message, &error);
+      break;
     }
+    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_create_error");
   }
 
   return Error(env, error);


### PR DESCRIPTION
`NAPI_FATAL_IF_FAILED` would not return if the status is not `napi_ok`.