### PR TITLE
Preliminary refactoring from Babylon Native

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -462,7 +462,7 @@ inline bool Value::IsDataView() const {
   NAPI_THROW_IF_FAILED(_env, status, false);
   return result;
 }
-
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 inline bool Value::IsBuffer() const {
   if (IsEmpty()) {
     return false;
@@ -473,6 +473,7 @@ inline bool Value::IsBuffer() const {
   NAPI_THROW_IF_FAILED(_env, status, false);
   return result;
 }
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 inline bool Value::IsExternal() const {
   return Type() == napi_external;
@@ -1354,12 +1355,12 @@ inline ArrayBuffer::ArrayBuffer(napi_env env, napi_value value, void* data, size
   : Object(env, value), _data(data), _length(length) {
 }
 
-inline void* ArrayBuffer::Data() {
+inline void* ArrayBuffer::Data() const {
   EnsureInfo();
   return _data;
 }
 
-inline size_t ArrayBuffer::ByteLength() {
+inline size_t ArrayBuffer::ByteLength() const {
   EnsureInfo();
   return _length;
 }
@@ -1787,6 +1788,7 @@ inline Value Function::Call(napi_value recv, size_t argc, const napi_value* args
   return Value(_env, result);
 }
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 inline Value Function::MakeCallback(
     napi_value recv,
     const std::initializer_list<napi_value>& args,
@@ -1812,6 +1814,7 @@ inline Value Function::MakeCallback(
   NAPI_THROW_IF_FAILED(_env, status, Value());
   return Value(_env, result);
 }
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 inline Object Function::New(const std::initializer_list<napi_value>& args) const {
   return New(args.size(), args.begin());
@@ -1863,6 +1866,7 @@ inline void Promise::Deferred::Reject(napi_value value) const {
 inline Promise::Promise(napi_env env, napi_value value) : Object(env, value) {
 }
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 ////////////////////////////////////////////////////////////////////////////////
 // Buffer<T> class
 ////////////////////////////////////////////////////////////////////////////////
@@ -1981,6 +1985,7 @@ inline void Buffer<T>::EnsureInfo() const {
     _data = static_cast<T*>(voidData);
   }
 }
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 ////////////////////////////////////////////////////////////////////////////////
 // Error class
@@ -2045,7 +2050,7 @@ inline Error Error::New(napi_env env, const std::string& message) {
 }
 
 inline NAPI_NO_RETURN void Error::Fatal(const char* location, const char* message) {
-  napi_fatal_error(location, NAPI_AUTO_LENGTH, message, NAPI_AUTO_LENGTH);
+    napi_fatal_error(location, NAPI_AUTO_LENGTH, message, NAPI_AUTO_LENGTH);
 }
 
 inline Error::Error() : ObjectReference() {
@@ -2567,6 +2572,7 @@ inline Napi::Value FunctionReference::Call(
   return scope.Escape(result);
 }
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 inline Napi::Value FunctionReference::MakeCallback(
     napi_value recv,
     const std::initializer_list<napi_value>& args,
@@ -2603,6 +2609,7 @@ inline Napi::Value FunctionReference::MakeCallback(
   }
   return scope.Escape(result);
 }
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 inline Object FunctionReference::New(const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
@@ -3511,7 +3518,7 @@ inline Value EscapableHandleScope::Escape(napi_value escapee) {
   return Value(_env, result);
 }
 
-
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 #if (NAPI_VERSION > 2)
 ////////////////////////////////////////////////////////////////////////////////
 // CallbackScope class
@@ -4138,6 +4145,7 @@ inline const napi_node_version* VersionManagement::GetNodeVersion(Env env) {
   NAPI_THROW_IF_FAILED(env, status, 0);
   return result;
 }
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 } // namespace Napi
 

--- a/napi.h
+++ b/napi.h
@@ -1,7 +1,16 @@
 #ifndef SRC_NAPI_H_
 #define SRC_NAPI_H_
 
+#ifdef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
+#define NAPI_NO_RETURN
+#endif
+
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 #include <node_api.h>
+#else
+#include "js_native_api.h"
+#endif
+
 #include <functional>
 #include <initializer_list>
 #include <memory>
@@ -787,8 +796,8 @@ namespace Napi {
     ArrayBuffer();                               ///< Creates a new _empty_ ArrayBuffer instance.
     ArrayBuffer(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
 
-    void* Data();        ///< Gets a pointer to the data buffer.
-    size_t ByteLength(); ///< Gets the length of the array buffer in bytes.
+    void* Data() const;        ///< Gets a pointer to the data buffer.
+    size_t ByteLength() const; ///< Gets the length of the array buffer in bytes.
 
   private:
     mutable void* _data;
@@ -1006,6 +1015,7 @@ namespace Napi {
     Value Call(napi_value recv, const std::vector<napi_value>& args) const;
     Value Call(napi_value recv, size_t argc, const napi_value* args) const;
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
     Value MakeCallback(napi_value recv,
                        const std::initializer_list<napi_value>& args,
                        napi_async_context context = nullptr) const;
@@ -1016,6 +1026,7 @@ namespace Napi {
                        size_t argc,
                        const napi_value* args,
                        napi_async_context context = nullptr) const;
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
     Object New(const std::initializer_list<napi_value>& args) const;
     Object New(const std::vector<napi_value>& args) const;
@@ -1044,6 +1055,7 @@ namespace Napi {
     Promise(napi_env env, napi_value value);
   };
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
   template <typename T>
   class Buffer : public Uint8Array {
   public:
@@ -1076,6 +1088,7 @@ namespace Napi {
     Buffer(napi_env env, napi_value value, size_t length, T* data);
     void EnsureInfo() const;
   };
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
   /// Holds a counted reference to a value; initially a weak reference unless otherwise specified,
   /// may be changed to/from a strong reference by adjusting the refcount.
@@ -1187,6 +1200,7 @@ namespace Napi {
     Napi::Value Call(napi_value recv, const std::vector<napi_value>& args) const;
     Napi::Value Call(napi_value recv, size_t argc, const napi_value* args) const;
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
     Napi::Value MakeCallback(napi_value recv,
                              const std::initializer_list<napi_value>& args,
                              napi_async_context context = nullptr) const;
@@ -1197,6 +1211,7 @@ namespace Napi {
                              size_t argc,
                              const napi_value* args,
                              napi_async_context context = nullptr) const;
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
     Object New(const std::initializer_list<napi_value>& args) const;
     Object New(const std::vector<napi_value>& args) const;
@@ -1754,6 +1769,7 @@ namespace Napi {
     napi_escapable_handle_scope _scope;
   };
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 #if (NAPI_VERSION > 2)
   class CallbackScope {
   public:
@@ -1855,6 +1871,7 @@ namespace Napi {
     std::string _error;
     bool _suppress_destruct;
   };
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
   #if (NAPI_VERSION > 3)
   class ThreadSafeFunction {
@@ -2063,6 +2080,7 @@ namespace Napi {
   };
   #endif
 
+#ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
   // Memory management.
   class MemoryManagement {
     public:
@@ -2075,6 +2093,7 @@ namespace Napi {
       static uint32_t GetNapiVersion(Env env);
       static const napi_node_version* GetNodeVersion(Env env);
   };
+#endif // NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 
 } // namespace Napi
 


### PR DESCRIPTION
Pursuant to issue #399, this is a minimal set of changes that allows [Babylon Native](https://github.com/BabylonJS/BabylonNative) to use `napi.h` and `napi_inl.h` without modification. This may just be a first step as we're still trying to understand what the right integration strategy would be, and it's possible there might be a better way to achieve the result we're looking for (for instance, factoring out the node-specific APIs instead of guarding them inside a compiler define), but this PR may be a good place to start the relevant conversation.