### PR TITLE
Fix example code in doc/class_property_descriptor

### DIFF
--- a/doc/class_property_descriptor.md
+++ b/doc/class_property_descriptor.md
@@ -20,7 +20,7 @@ class Example : public Napi::ObjectWrap<Example> {
     static Napi::FunctionReference constructor;
     double _value;
     Napi::Value GetValue(const Napi::CallbackInfo &info);
-    Napi::Value SetValue(const Napi::CallbackInfo &info);
+    void SetValue(const Napi::CallbackInfo &info, const Napi::Value &value);
 };
 
 Napi::Object Example::Init(Napi::Env env, Napi::Object exports) {
@@ -52,12 +52,11 @@ Napi::Value Example::GetValue(const Napi::CallbackInfo &info) {
     return Napi::Number::New(env, this->_value);
 }
 
-Napi::Value Example::SetValue(const Napi::CallbackInfo &info, const Napi::Value &value) {
+void Example::SetValue(const Napi::CallbackInfo &info, const Napi::Value &value) {
     Napi::Env env = info.Env();
     // ...
     Napi::Number arg = value.As<Napi::Number>();
     this->_value = arg.DoubleValue();
-    return this->GetValue(info);
 }
 
 // Initialize native add-on


### PR DESCRIPTION
Return type should be void and second function argument of type Napi::Value should be present.  
See typedef:   
https://github.com/nodejs/node-addon-api/blob/295e560f5554c87d0a9dde6b73942ebd85fddb9d/napi.h#L1623