### PR TITLE
src: make OnWorkComplete and OnExecute override-able

### DIFF
--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -136,6 +136,35 @@ class was created, passing in the error as the first parameter.
 virtual void Napi::AsyncWorker::OnError(const Napi::Error& e);
 ```
 
+### OnWorkComplete
+
+This method is invoked after the work has completed on JavaScript thread.
+The default implementation of this method checks the status of the work and
+tries to dispatch the result to `Napi::AsyncWorker::OnOk` or `Napi::AsyncWorker::Error`
+if the work has committed an error. If the work was cancelled, neither
+`Napi::AsyncWorker::OnOk` nor `Napi::AsyncWorker::Error` will be invoked.
+After the result is dispatched, the default implementation will call into
+`Napi::AsyncWorker::Destroy` if `SuppressDestruct()` was not called.
+
+```cpp
+virtual void OnWorkComplete(Napi::Env env, napi_status status);
+```
+
+### OnExecute
+
+This method is invoked immediately on the work thread when scheduled.
+The default implementation of this method just calls the `Napi::AsyncWorker::Execute`
+and handles exceptions if cpp exceptions were enabled.
+
+The `OnExecute` method receives an `napi_env` argument. However, do NOT
+use it within this method, as it does not run on the main thread and must
+not run any method that would cause JavaScript to run. In practice, this
+means that almost any use of `napi_env` will be incorrect.
+
+```cpp
+virtual void OnExecute(Napi::Env env);
+```
+
 ### Destroy
 
 This method is invoked when the instance must be deallocated. If

--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -157,9 +157,9 @@ The default implementation of this method just calls the `Napi::AsyncWorker::Exe
 and handles exceptions if cpp exceptions were enabled.
 
 The `OnExecute` method receives an `napi_env` argument. However, do NOT
-use it within this method, as it does not run on the main thread and must
-not run any method that would cause JavaScript to run. In practice, this
-means that almost any use of `napi_env` will be incorrect.
+use it within this method, as it does not run on the JavaScript thread and
+must not run any method that would cause JavaScript to run. In practice,
+this means that almost any use of `napi_env` will be incorrect.
 
 ```cpp
 virtual void OnExecute(Napi::Env env);

--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -156,10 +156,10 @@ This method is invoked immediately on the work thread when scheduled.
 The default implementation of this method just calls the `Napi::AsyncWorker::Execute`
 and handles exceptions if cpp exceptions were enabled.
 
-The `OnExecute` method receives an `napi_env` argument. However, do NOT
-use it within this method, as it does not run on the JavaScript thread and
-must not run any method that would cause JavaScript to run. In practice,
-this means that almost any use of `napi_env` will be incorrect.
+The `OnExecute` method receives an `napi_env` argument. However, the `napi_env`
+must NOT be used within this method, as it does not run on the JavaScript
+thread and must not run any method that would cause JavaScript to run. In
+practice, this means that almost any use of `napi_env` will be incorrect.
 
 ```cpp
 virtual void OnExecute(Napi::Env env);

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4212,17 +4212,17 @@ inline std::vector<napi_value> AsyncWorker::GetResult(Napi::Env /*env*/) {
   return {};
 }
 // The OnAsyncWorkExecute method receives an napi_env argument. However, do NOT
-// use it within this method, as it does not run on the main thread and must
-// not run any method that would cause JavaScript to run. In practice, this
-// means that almost any use of napi_env will be incorrect.
+// use it within this method, as it does not run on the JavaScript thread and
+// must not run any method that would cause JavaScript to run. In practice,
+// this means that almost any use of napi_env will be incorrect.
 inline void AsyncWorker::OnAsyncWorkExecute(napi_env env, void* asyncworker) {
   AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
   self->OnExecute(env);
 }
 // The OnExecute method receives an napi_env argument. However, do NOT
-// use it within this method, as it does not run on the main thread and must
-// not run any method that would cause JavaScript to run. In practice, this
-// means that almost any use of napi_env will be incorrect.
+// use it within this method, as it does not run on the JavaScript thread and
+// must not run any method that would cause JavaScript to run. In practice,
+// this means that almost any use of napi_env will be incorrect.
 inline void AsyncWorker::OnExecute(Napi::Env /*DO_NOT_USE*/) {
 #ifdef NAPI_CPP_EXCEPTIONS
   try {

--- a/napi.h
+++ b/napi.h
@@ -1991,6 +1991,10 @@ namespace Napi {
     ObjectReference& Receiver();
     FunctionReference& Callback();
 
+    virtual void OnExecute(Napi::Env env);
+    virtual void OnWorkComplete(Napi::Env env,
+                                napi_status status);
+
   protected:
     explicit AsyncWorker(const Function& callback);
     explicit AsyncWorker(const Function& callback,
@@ -2024,10 +2028,10 @@ namespace Napi {
     void SetError(const std::string& error);
 
   private:
-    static void OnExecute(napi_env env, void* this_pointer);
-    static void OnWorkComplete(napi_env env,
-                               napi_status status,
-                               void* this_pointer);
+    static inline void OnAsyncWorkExecute(napi_env env, void* asyncworker);
+    static inline void OnAsyncWorkComplete(napi_env env,
+                                           napi_status status,
+                                           void* asyncworker);
 
     napi_env _env;
     napi_async_work _work;
@@ -2259,33 +2263,32 @@ namespace Napi {
      };
 
     protected:
-    explicit AsyncProgressWorker(const Function& callback);
-    explicit AsyncProgressWorker(const Function& callback,
-                         const char* resource_name);
-    explicit AsyncProgressWorker(const Function& callback,
-                         const char* resource_name,
-                         const Object& resource);
-    explicit AsyncProgressWorker(const Object& receiver,
-                         const Function& callback);
-    explicit AsyncProgressWorker(const Object& receiver,
-                         const Function& callback,
-                         const char* resource_name);
-    explicit AsyncProgressWorker(const Object& receiver,
-                         const Function& callback,
-                         const char* resource_name,
-                         const Object& resource);
+     explicit AsyncProgressWorker(const Function& callback);
+     explicit AsyncProgressWorker(const Function& callback,
+                                  const char* resource_name);
+     explicit AsyncProgressWorker(const Function& callback,
+                                  const char* resource_name,
+                                  const Object& resource);
+     explicit AsyncProgressWorker(const Object& receiver,
+                                  const Function& callback);
+     explicit AsyncProgressWorker(const Object& receiver,
+                                  const Function& callback,
+                                  const char* resource_name);
+     explicit AsyncProgressWorker(const Object& receiver,
+                                  const Function& callback,
+                                  const char* resource_name,
+                                  const Object& resource);
 
 // Optional callback of Napi::ThreadSafeFunction only available after NAPI_VERSION 4.
 // Refs: https://github.com/nodejs/node/pull/27791
 #if NAPI_VERSION > 4
-    explicit AsyncProgressWorker(Napi::Env env);
-    explicit AsyncProgressWorker(Napi::Env env,
-                         const char* resource_name);
-    explicit AsyncProgressWorker(Napi::Env env,
-                         const char* resource_name,
-                         const Object& resource);
+     explicit AsyncProgressWorker(Napi::Env env);
+     explicit AsyncProgressWorker(Napi::Env env,
+                                  const char* resource_name);
+     explicit AsyncProgressWorker(Napi::Env env,
+                                  const char* resource_name,
+                                  const Object& resource);
 #endif
-
      virtual void Execute(const ExecutionProgress& progress) = 0;
      virtual void OnProgress(const T* data, size_t count) = 0;
 


### PR DESCRIPTION
No breaking changes on existing code were expected. All existing tests shall pass without any touch.
Changes on declaration:
- Added `Napi::AsyncWorker::OnWorkComplete`.
- Added `Napi::AsyncWorker::OnExecute`.

Fixes: #582 

- [x] npm test passed.
- [x] documentation has changed.