### PR TITLE
objectwrap: gracefully handle constructor exceptions

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3137,12 +3137,11 @@ inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
   napi_value wrapper = callbackInfo.This();
   napi_status status;
   napi_ref ref;
-  T* instance = static_cast<T*>(this);
-  status = napi_wrap(env, wrapper, instance, FinalizeCallback, nullptr, &ref);
+  status = napi_wrap(env, wrapper, this, FinalizeCallback, nullptr, &ref);
   NAPI_THROW_IF_FAILED_VOID(env, status);
 
   ObjectWrapCleanup::MarkWrapOK(callbackInfo);
-  Reference<Object>* instanceRef = instance;
+  Reference<Object>* instanceRef = this;
   *instanceRef = Reference<Object>(env, ref);
 }
 
@@ -3722,7 +3721,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
     try {
       new T(callbackInfo);
     } catch (const Error& e) {
-      // re-throw the error after removing the failed wrap.
+      // Re-throw the error after removing the failed wrap.
       cleanup.RemoveWrap(callbackInfo);
       throw e;
     }

--- a/napi.h
+++ b/napi.h
@@ -138,7 +138,7 @@ namespace Napi {
   class CallbackInfo;
   class TypedArray;
   template <typename T> class TypedArrayOf;
-  class ObjectWrapCleanup;
+  class ObjectWrapConstructionContext;
 
   typedef TypedArrayOf<int8_t> Int8Array;     ///< Typed-array of signed 8-bit integers
   typedef TypedArrayOf<uint8_t> Uint8Array;   ///< Typed-array of unsigned 8-bit integers
@@ -1403,7 +1403,7 @@ namespace Napi {
 
   class CallbackInfo {
   public:
-    friend class ObjectWrapCleanup;
+    friend class ObjectWrapConstructionContext;
     CallbackInfo(napi_env env, napi_callback_info info);
     ~CallbackInfo();
 
@@ -1429,7 +1429,7 @@ namespace Napi {
     napi_value _staticArgs[6];
     napi_value* _dynamicArgs;
     void* _data;
-    ObjectWrapCleanup* _object_wrap_cleanup;
+    ObjectWrapConstructionContext* _objectWrapConstructionContext;
   };
 
   class PropertyDescriptor {

--- a/napi.h
+++ b/napi.h
@@ -138,6 +138,7 @@ namespace Napi {
   class CallbackInfo;
   class TypedArray;
   template <typename T> class TypedArrayOf;
+  class ObjectWrapCleanup;
 
   typedef TypedArrayOf<int8_t> Int8Array;     ///< Typed-array of signed 8-bit integers
   typedef TypedArrayOf<uint8_t> Uint8Array;   ///< Typed-array of unsigned 8-bit integers
@@ -1402,6 +1403,7 @@ namespace Napi {
 
   class CallbackInfo {
   public:
+    friend class ObjectWrapCleanup;
     CallbackInfo(napi_env env, napi_callback_info info);
     ~CallbackInfo();
 
@@ -1427,6 +1429,7 @@ namespace Napi {
     napi_value _staticArgs[6];
     napi_value* _dynamicArgs;
     void* _data;
+    ObjectWrapCleanup* _object_wrap_cleanup;
   };
 
   class PropertyDescriptor {

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -50,6 +50,7 @@ Object InitThreadSafeFunction(Env env);
 #endif
 Object InitTypedArray(Env env);
 Object InitObjectWrap(Env env);
+Object InitObjectWrapConstructorException(Env env);
 Object InitObjectReference(Env env);
 Object InitVersionManagement(Env env);
 Object InitThunkingManual(Env env);
@@ -104,6 +105,8 @@ Object Init(Env env, Object exports) {
 #endif
   exports.Set("typedarray", InitTypedArray(env));
   exports.Set("objectwrap", InitObjectWrap(env));
+  exports.Set("objectwrapConstructorException",
+      InitObjectWrapConstructorException(env));
   exports.Set("objectreference", InitObjectReference(env));
   exports.Set("version_management", InitVersionManagement(env));
   exports.Set("thunking_manual", InitThunkingManual(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -41,6 +41,7 @@
         'threadsafe_function/threadsafe_function.cc',
         'typedarray.cc',
         'objectwrap.cc',
+        'objectwrap_constructor_exception.cc',
         'objectreference.cc',
         'version_management.cc',
         'thunking_manual.cc',

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,7 @@ let testModules = [
   'typedarray',
   'typedarray-bigint',
   'objectwrap',
+  'objectwrap_constructor_exception',
   'objectreference',
   'version_management'
 ];

--- a/test/objectwrap_constructor_exception.cc
+++ b/test/objectwrap_constructor_exception.cc
@@ -1,0 +1,26 @@
+#include <napi.h>
+
+class ConstructorExceptionTest :
+  public Napi::ObjectWrap<ConstructorExceptionTest> {
+public:
+  ConstructorExceptionTest(const Napi::CallbackInfo& info) :
+    Napi::ObjectWrap<ConstructorExceptionTest>(info) {
+    Napi::Error error = Napi::Error::New(info.Env(), "an exception");
+#ifdef NAPI_DISABLE_CPP_EXCEPTIONS
+    error.ThrowAsJavaScriptException();
+#else
+    throw error;
+#endif  // NAPI_DISABLE_CPP_EXCEPTIONS
+  }
+
+  static void Initialize(Napi::Env env, Napi::Object exports) {
+    const char* name = "ConstructorExceptionTest";
+    exports.Set(name, DefineClass(env, name, {}));
+  }
+};
+
+Napi::Object InitObjectWrapConstructorException(Napi::Env env) {
+  Napi::Object exports = Napi::Object::New(env);
+  ConstructorExceptionTest::Initialize(env, exports);
+  return exports;
+}

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const test = (binding) => {
   const { ConstructorExceptionTest } = binding.objectwrapConstructorException;
-  assert.throws(() => (new ConstructorExceptionTest()));
+  assert.throws(() => (new ConstructorExceptionTest()), /an exception/);
   global.gc();
 }
 

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -4,15 +4,8 @@ const assert = require('assert');
 
 const test = (binding) => {
   const { ConstructorExceptionTest } = binding.objectwrapConstructorException;
-  let gotException = false;
-  try {
-    new ConstructorExceptionTest();
-  } catch (anException) {
-    gotException = true;
-  }
+  assert.throws(() => (new ConstructorExceptionTest()));
   global.gc();
-
-  assert.strictEqual(gotException, true);
 }
 
 test(require(`./build/${buildType}/binding.node`));

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -1,0 +1,19 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+
+const test = (binding) => {
+  const { ConstructorExceptionTest } = binding.objectwrapConstructorException;
+  let gotException = false;
+  try {
+    new ConstructorExceptionTest();
+  } catch (anException) {
+    gotException = true;
+  }
+  global.gc();
+
+  assert.strictEqual(gotException, true);
+}
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));


### PR DESCRIPTION
Move the `napi_wrap()` step out of the
`Napi::ObjectWrap<T>::ObjectWrap()` constructor to ensure that no
native instance pointer is associated with the JavaScript object under
construction if the native constructor should cause a JavaScript
exception to be thrown.

Fixes: https://github.com/nodejs/node-addon-api/issues/599