### PR TITLE
[doc] Fixed links to array documentation

### DIFF
--- a/doc/object.md
+++ b/doc/object.md
@@ -2,7 +2,7 @@
 
 The `Napi::Object` class corresponds to a JavaScript object. It is extended by the following node-addon-api classes that you may use when working with more specific types:
 
-- [`Napi::Value`](value.md) and extends [`Napi::Array`](array.md)
+- [`Napi::Value`](value.md) and extends [`Napi::Array`](basic_types.md#array)
 - [`Napi::ArrayBuffer`](array_buffer.md)
 - [`Napi::Buffer<T>`](buffer.md)
 - [`Napi::Function`](function.md)

--- a/doc/object.md
+++ b/doc/object.md
@@ -2,7 +2,7 @@
 
 The `Napi::Object` class corresponds to a JavaScript object. It is extended by the following node-addon-api classes that you may use when working with more specific types:
 
-- [`Napi::Value`](value.md) and extends [`Napi::Array`](basic_types.md#array)
+- [`Napi::Value`](value.md) which is extended by [`Napi::Array`](basic_types.md#array)
 - [`Napi::ArrayBuffer`](array_buffer.md)
 - [`Napi::Buffer<T>`](buffer.md)
 - [`Napi::Function`](function.md)

--- a/doc/value.md
+++ b/doc/value.md
@@ -6,7 +6,7 @@ Value is a the base class upon which other JavaScript values such as Number, Boo
 
 The following classes inherit, either directly or indirectly, from `Napi::Value`:
 
-- [`Napi::Array`](array.md)
+- [`Napi::Array`](basic_types.md#array)
 - [`Napi::ArrayBuffer`](array_buffer.md)
 - [`Napi::Boolean`](boolean.md)
 - [`Napi::Buffer`](buffer.md)


### PR DESCRIPTION
Fixed all the links to `Napi::Array` documentation.
Fixes issue https://github.com/nodejs/node-addon-api/issues/612