### PR TITLE
Fix std::string encoding

### DIFF
--- a/doc/string.md
+++ b/doc/string.md
@@ -62,7 +62,7 @@ Napi::String::New(napi_env env, const char16_t* value, size_t length);
 
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Value` object.
 - `[in] value`: The C++ primitive from which to instantiate the `Napi::Value`. `value` may be any of:
-  - `std::string&` - represents an ANSI string.
+  - `std::string&` - represents a UTF8 string.
   - `std::u16string&` - represents a UTF16-LE string.
   - `const char*` - represents a UTF8 string.
   - `const char16_t*` - represents a UTF16-LE string.

--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -23,7 +23,7 @@ Napi::Symbol::New(napi_env env, napi_value description);
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Symbol` object.
 - `[in] value`: The C++ primitive which represents the description hint for the `Napi::Symbol`.
   `description` may be any of:
-  - `std::string&` - ANSI string description.
+  - `std::string&` - UTF8 string description.
   - `const char*` - represents a UTF8 string description.
   - `String` - Node addon API String description.
   - `napi_value` - N-API `napi_value` description.


### PR DESCRIPTION
1. "ANSI" is misleading and not a good description of any string encoding. It is commonly used to refer to "Windows code pages" such as Windows-125x, but these code pages have never been standardized by ANSI.
2. It is wrong, we treat `std::string` as UTF8.