### PR TITLE
error: do not replace pending exception

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2037,27 +2037,25 @@ inline void Buffer<T>::EnsureInfo() const {
 inline Error Error::New(napi_env env) {
   napi_status status;
   napi_value error = nullptr;
-
+  bool is_exception_pending;
   const napi_extended_error_info* info;
+
+  // We must retrieve the last error info before doing anything else, because
+  // doing anything else will replace the last error info.
   status = napi_get_last_error_info(env, &info);
   NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_last_error_info");
 
-  if (info->error_code == napi_pending_exception) {
+  status = napi_is_exception_pending(env, &is_exception_pending);
+  NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_is_exception_pending");
+
+  // A pending exception takes precedence over any internal error status.
+  if (is_exception_pending) {
     status = napi_get_and_clear_last_exception(env, &error);
     NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
   }
   else {
     const char* error_message = info->error_message != nullptr ?
       info->error_message : "Error in native callback";
-
-    bool isExceptionPending;
-    status = napi_is_exception_pending(env, &isExceptionPending);
-    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_is_exception_pending");
-
-    if (isExceptionPending) {
-      status = napi_get_and_clear_last_exception(env, &error);
-      NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
-    }
 
     napi_value message;
     status = napi_create_string_utf8(

--- a/test/error.js
+++ b/test/error.js
@@ -70,4 +70,10 @@ function test(bindingPath) {
   assert.ifError(p.error);
   assert.ok(p.stderr.toString().includes(
       'FATAL ERROR: Error::ThrowFatalError This is a fatal error'));
+
+  assert.throws(() => binding.error.throwDefaultError(false),
+    /Cannot convert undefined or null to object/);
+
+  assert.throws(() => binding.error.throwDefaultError(true),
+    /A number was expected/);
 }

--- a/test/object/delete_property.js
+++ b/test/object/delete_property.js
@@ -22,7 +22,7 @@ function test(binding) {
   function testShouldThrowErrorIfKeyIsInvalid(nativeDeleteProperty) {
     assert.throws(() => {
       nativeDeleteProperty(undefined, 'test');
-    }, /object was expected/);
+    }, /Cannot convert undefined or null to object/);
   }
 
   testDeleteProperty(binding.object.deletePropertyWithNapiValue);

--- a/test/object/get_property.js
+++ b/test/object/get_property.js
@@ -15,7 +15,7 @@ function test(binding) {
   function testShouldThrowErrorIfKeyIsInvalid(nativeGetProperty) {
     assert.throws(() => {
       nativeGetProperty(undefined, 'test');
-    }, /object was expected/);
+    }, /Cannot convert undefined or null to object/);
   }
 
   testGetProperty(binding.object.getPropertyWithNapiValue);

--- a/test/object/has_own_property.js
+++ b/test/object/has_own_property.js
@@ -21,7 +21,7 @@ function test(binding) {
   function testShouldThrowErrorIfKeyIsInvalid(nativeHasOwnProperty) {
     assert.throws(() => {
       nativeHasOwnProperty(undefined, 'test');
-    }, /object was expected/);
+    }, /Cannot convert undefined or null to object/);
   }
 
   testHasOwnProperty(binding.object.hasOwnPropertyWithNapiValue);

--- a/test/object/has_property.js
+++ b/test/object/has_property.js
@@ -21,7 +21,7 @@ function test(binding) {
   function testShouldThrowErrorIfKeyIsInvalid(nativeHasProperty) {
     assert.throws(() => {
       nativeHasProperty(undefined, 'test');
-    }, /object was expected/);
+    }, /Cannot convert undefined or null to object/);
   }
 
   testHasProperty(binding.object.hasPropertyWithNapiValue);

--- a/test/object/set_property.js
+++ b/test/object/set_property.js
@@ -16,7 +16,7 @@ function test(binding) {
   function testShouldThrowErrorIfKeyIsInvalid(nativeSetProperty) {
     assert.throws(() => {
       nativeSetProperty(undefined, 'test', 1);
-    }, /object was expected/);
+    }, /Cannot convert undefined or null to object/);
   }
 
   testSetProperty(binding.object.setPropertyWithNapiValue);


### PR DESCRIPTION
Only construct a `Napi::Error` from the last non-`napi_ok` error code
if there is no exception pending.

A consequence for the object property test suite is that it must now
expect the exception thrown by the engine when N-API core attempts
to convert the undefined value to an object.

Fixes: https://github.com/nodejs/node-addon-api/issues/621