### PR TITLE
fixes v8 GC access violation for zombie objects

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3697,7 +3697,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
   }
 
   T* instance;
-  napi_value wrapper = details::WrapCallback([&] {
+  napi_value wrapper = details::WrapCallback([&] () -> napi_value {
     CallbackInfo callbackInfo(env, info);
     callbackInfo.zombie = new Zombie();
 #ifdef NAPI_CPP_EXCEPTIONS

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3700,6 +3700,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
   napi_value wrapper = details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     callbackInfo.zombie = new Zombie();
+#ifdef NAPI_CPP_EXCEPTIONS
     try {
       instance = new T(callbackInfo);
       return callbackInfo.This();
@@ -3708,6 +3709,14 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
       callbackInfo.zombie->isZombie = true;
       throw;
     }
+#else
+    instance = new T(callbackInfo);
+    if (callbackInfo.Env().IsExceptionPending()) {
+      callbackInfo.zombie->isZombie = true;
+      return nullptr;
+    }
+    return callbackInfo.This();
+#endif
   });
 
   return wrapper;

--- a/napi.h
+++ b/napi.h
@@ -1396,11 +1396,8 @@ namespace Napi {
     RangeError(napi_env env, napi_value value);
   };
 
-  struct Zombie {
-    bool isZombie = false;
-  };
-
   class CallbackInfo {
+    friend class FinalizerHint;
   public:
     CallbackInfo(napi_env env, napi_callback_info info);
     ~CallbackInfo();
@@ -1418,8 +1415,6 @@ namespace Napi {
     void* Data() const;
     void SetData(void* data);
 
-    Zombie* zombie;
-
   private:
     const size_t _staticArgCount = 6;
     napi_env _env;
@@ -1430,6 +1425,7 @@ namespace Napi {
     napi_value _staticArgs[6];
     napi_value* _dynamicArgs;
     void* _data;
+    FinalizerHint* finalizerHint;
   };
 
   class PropertyDescriptor {

--- a/napi.h
+++ b/napi.h
@@ -1396,6 +1396,10 @@ namespace Napi {
     RangeError(napi_env env, napi_value value);
   };
 
+  struct Zombie {
+    bool isZombie = false;
+  };
+
   class CallbackInfo {
   public:
     CallbackInfo(napi_env env, napi_callback_info info);
@@ -1413,6 +1417,8 @@ namespace Napi {
     Value This() const;
     void* Data() const;
     void SetData(void* data);
+
+    Zombie* zombie;
 
   private:
     const size_t _staticArgCount = 6;

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -172,19 +172,24 @@ private:
 
 std::string Test::s_staticMethodText;
 
-#ifdef NAPI_CPP_EXCEPTIONS
+
 class TestConstructorExceptions : public Napi::ObjectWrap<TestConstructorExceptions> {
 public:
   TestConstructorExceptions(const Napi::CallbackInfo& info) : 
     Napi::ObjectWrap<TestConstructorExceptions>(info) {
-      throw Napi::Error::New(info.Env(), "Constructor exceptions should not cause v8 GC to fail");
+      #ifdef NAPI_CPP_EXCEPTIONS
+        throw Napi::Error::New(info.Env(), "Constructor exceptions should not cause v8 GC to fail");
+      #else
+        Napi::Error::New(info.Env(), "Constructor exceptions should not cause v8 GC to fail").ThrowAsJavaScriptException();
+        return;
+      #endif
     }
 
     static void Initialize(Napi::Env env, Napi::Object exports) {
       exports.Set("TestConstructorExceptions", DefineClass(env, "TestConstructorExceptions", {}));
     }
 };
-#endif
+
 
 
 Napi::Object InitObjectWrap(Napi::Env env) {

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -172,11 +172,30 @@ private:
 
 std::string Test::s_staticMethodText;
 
+#ifdef NAPI_CPP_EXCEPTIONS
+class TestConstructorExceptions : public Napi::ObjectWrap<TestConstructorExceptions> {
+public:
+  TestConstructorExceptions(const Napi::CallbackInfo& info) : 
+    Napi::ObjectWrap<TestConstructorExceptions>(info) {
+      throw Napi::Error::New(info.Env(), "Constructor exceptions should not cause v8 GC to fail");
+    }
+
+    static void Initialize(Napi::Env env, Napi::Object exports) {
+      exports.Set("TestConstructorExceptions", DefineClass(env, "TestConstructorExceptions", {}));
+    }
+};
+#endif
+
+
 Napi::Object InitObjectWrap(Napi::Env env) {
   testStaticContextRef = Napi::Persistent(Napi::Object::New(env));
   testStaticContextRef.SuppressDestruct();
 
   Napi::Object exports = Napi::Object::New(env);
   Test::Initialize(env, exports);
+
+#ifdef NAPI_CPP_EXCEPTIONS
+  TestConstructorExceptions::Initialize(env, exports);
+#endif
   return exports;
 }

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -256,9 +256,21 @@ const test = (binding) => {
     testFinalize(clazz);
   };
 
+  const testConstructorExceptions = () => {
+    const TestConstructorExceptions = binding.objectwrap.TestConstructorExceptions;
+    if (TestConstructorExceptions) {
+      console.log("Runnig test testConstructorExceptions");
+      assert.throws(() => { new TestConstructorExceptions(); });
+      global.gc();
+      console.log("Test testConstructorExceptions complete");
+    }
+  }
+
   // `Test` is needed for accessing exposed symbols
   testObj(new Test(), Test);
   testClass(Test);
+
+  testConstructorExceptions();
 }
 
 test(require(`./build/${buildType}/binding.node`));

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -258,12 +258,10 @@ const test = (binding) => {
 
   const testConstructorExceptions = () => {
     const TestConstructorExceptions = binding.objectwrap.TestConstructorExceptions;
-    if (TestConstructorExceptions) {
-      console.log("Runnig test testConstructorExceptions");
-      assert.throws(() => { new TestConstructorExceptions(); });
-      global.gc();
-      console.log("Test testConstructorExceptions complete");
-    }
+    console.log("Runnig test testConstructorExceptions");
+    assert.throws(() => { new TestConstructorExceptions(); });
+    global.gc();
+    console.log("Test testConstructorExceptions complete");
   }
 
   // `Test` is needed for accessing exposed symbols


### PR DESCRIPTION
fix v8 GC access violation after napi ObjectWrap instance is left in zombie state by an exception in its constructor

closes this https://github.com/nodejs/node-addon-api/issues/635