### PR TITLE
test: update BigInt test for recent change in core

### DIFF
--- a/test/bigint.js
+++ b/test/bigint.js
@@ -46,7 +46,7 @@ function test(binding) {
   });
 
   assert.throws(TestTooBigBigInt, {
-    name: 'RangeError',
-    message: 'Maximum BigInt size exceeded',
+    name: /^(RangeError|Error)$/,
+    message: /^(Maximum BigInt size exceeded|Invalid argument)$/,
   });
 }


### PR DESCRIPTION
https://github.com/nodejs/node/commit/689ab46c646bc8add5560a606ba73d3760f8f924
changed the expected error for one of the BigInt test cases. This is
ok because BigInt is still in experimental. However, the
result was a failed/hanging test. See
https://github.com/nodejs/build/issues/2131

This changes the test to accept either the new or old behaviour.
We need that so that older versions of Node.js will also pass the
test until the the node core commit above is backported.