### PR TITLE
Add ArrayBuffer::Detach() and ::IsDetached()

### DIFF
--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -130,4 +130,20 @@ void* Napi::ArrayBuffer::Data() const;
 
 Returns a pointer the wrapped data.
 
+### Detach
+
+```cpp
+void Napi::ArrayBuffer::Detach();
+```
+
+Invokes the `ArrayBuffer` detach operation on a detachable `ArrayBuffer`.
+
+### IsDetached
+
+```cpp
+bool Napi::ArrayBuffer::IsDetached() const;
+```
+
+Returns `true` if this `ArrayBuffer` has been detached.
+
 [`Napi::Object`]: ./object.md

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1530,6 +1530,20 @@ inline size_t ArrayBuffer::ByteLength() {
   return length;
 }
 
+#if NAPI_VERSION >= 7
+inline bool ArrayBuffer::IsDetached() const {
+  bool detached;
+  napi_status status = napi_is_detached_arraybuffer(_env, _value, &detached);
+  NAPI_THROW_IF_FAILED(_env, status, false);
+  return detached;
+}
+
+inline void ArrayBuffer::Detach() {
+  napi_status status = napi_detach_arraybuffer(_env, _value);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
+#endif  // NAPI_VERSION >= 7
+
 ////////////////////////////////////////////////////////////////////////////////
 // DataView class
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi.h
+++ b/napi.h
@@ -822,6 +822,11 @@ namespace Napi {
 
     void* Data();        ///< Gets a pointer to the data buffer.
     size_t ByteLength(); ///< Gets the length of the array buffer in bytes.
+
+#if NAPI_VERSION >= 7
+    bool IsDetached() const;
+    void Detach();
+#endif  // NAPI_VERSION >= 7
   };
 
   /// A JavaScript typed-array value with unknown array type.

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -58,8 +58,13 @@ function test(binding) {
 
     'ArrayBuffer updates data pointer and length when detached',
     () => {
+      // Detach the ArrayBuffer in JavaScript.
       const mem = new WebAssembly.Memory({ initial: 1 });
       binding.arraybuffer.checkDetachUpdatesData(mem.buffer, () => mem.grow(1));
+
+      // Let C++ detach the ArrayBuffer.
+      const extBuffer = binding.arraybuffer.createExternalBuffer();
+      binding.arraybuffer.checkDetachUpdatesData(extBuffer);
     },
   ]);
 }


### PR DESCRIPTION
I don't know what the proper guard is, seems like `NAPI_EXPERIMENTAL` and `NAPI_VERSION` are not good enough.

Refs: https://github.com/nodejs/node/pull/29768
Refs: https://github.com/nodejs/node/pull/30613