### PR TITLE
doc: link threadsafe function from JS function

### DIFF
--- a/doc/function.md
+++ b/doc/function.md
@@ -11,8 +11,8 @@ functions that were created in JavaScript and passed to the native add-on.
 The `Napi::Function` class inherits its behavior from the `Napi::Object` class (for more info
 see: [`Napi::Object`](object.md)).
 
-> For callbacks, that will be called with an asynchronous events from
-> non-JavaScript thread, please refer to [`Napi::ThreadSafeFunction`] for more
+> For callbacks that will be called with asynchronous events from a
+> non-JavaScript thread, please refer to [`Napi::ThreadSafeFunction`][] for more
 > examples.
 
 ## Example

--- a/doc/function.md
+++ b/doc/function.md
@@ -11,6 +11,10 @@ functions that were created in JavaScript and passed to the native add-on.
 The `Napi::Function` class inherits its behavior from the `Napi::Object` class (for more info
 see: [`Napi::Object`](object.md)).
 
+> For callbacks, that will be called with an asynchronous events from
+> non-JavaScript thread, please refer to [`Napi::ThreadSafeFunction`] for more
+> examples.
+
 ## Example
 
 ```cpp
@@ -393,3 +397,5 @@ Napi::Value Napi::Function::operator ()(const std::initializer_list<napi_value>&
 - `[in] args`: Initializer list of JavaScript values as `napi_value`.
 
 Returns a `Napi::Value` representing the JavaScript value returned by the function.
+
+[`Napi::ThreadSafeFunction`]: ./threadsafe_function.md


### PR DESCRIPTION
I've seen complains that there is no documents on napi/node-addon-api alternatives for `uv_async_t`s.  Link `Napi::ThreadSafeFunction` from JS function docs to highlight the option.