### PR TITLE
[WIP] tsfn: Add context to [Non]BlockingCall callback

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4574,7 +4574,7 @@ inline napi_status ThreadSafeFunction::CallInternal(
 // static
 inline void ThreadSafeFunction::CallJS(napi_env env,
                                        napi_value jsCallback,
-                                       void* /* context */,
+                                       void* context,
                                        void* data) {
   if (env == nullptr && jsCallback == nullptr) {
     return;
@@ -4582,7 +4582,7 @@ inline void ThreadSafeFunction::CallJS(napi_env env,
 
   if (data != nullptr) {
     auto* callbackWrapper = static_cast<CallbackWrapper*>(data);
-    (*callbackWrapper)(env, Function(env, jsCallback));
+    (*callbackWrapper)(env, Function(env, jsCallback), context);
     delete callbackWrapper;
   } else if (jsCallback != nullptr) {
     Function(env, jsCallback).Call({});

--- a/napi.h
+++ b/napi.h
@@ -2215,7 +2215,22 @@ namespace Napi {
     ConvertibleContext GetContext() const;
 
   private:
-    using CallbackWrapper = std::function<void(Napi::Env, Napi::Function)>;
+    class CallbackWrapper {
+    private:
+      using ContextlessCallback = std::function<void(Env, Function)>;
+      using ContextedCallback = std::function<void(Env, Function, void *)>;
+
+      ContextlessCallback ctxless;
+      ContextedCallback ctxfull;
+
+    public:
+      CallbackWrapper(ContextlessCallback arg) : ctxless(arg){};
+      CallbackWrapper(ContextedCallback arg) : ctxfull(arg){};
+
+      void operator()(Napi::Env env, Napi::Function callback, void *context) {
+        ctxfull ? ctxfull(env, callback, context) : ctxless(env, callback);
+      };
+    };
 
     template <typename ResourceString, typename ContextType,
               typename Finalizer, typename FinalizerDataType>

--- a/test/threadsafe_function/threadsafe_function_ctx.cc
+++ b/test/threadsafe_function/threadsafe_function_ctx.cc
@@ -2,9 +2,10 @@
 
 #if (NAPI_VERSION > 3)
 
-using namespace Napi;
-
 namespace {
+
+using namespace Napi;
+using TSFNContext = Reference<Napi::Value>;
 
 class TSFNWrap : public ObjectWrap<TSFNWrap> {
 public:
@@ -16,44 +17,54 @@ public:
     return ctx->Value();
   };
 
-  Napi::Value Release(const CallbackInfo &info) {
+  Napi::Value GetContextByCall(const CallbackInfo &info) {
     Napi::Env env = info.Env();
-    _deferred = std::unique_ptr<Promise::Deferred>(new Promise::Deferred(env));
+    std::shared_ptr<Promise::Deferred> deferred =
+        std::make_shared<Promise::Deferred>(env);
+    _tsfn.BlockingCall([deferred](Napi::Env env, Function cb, void *ctx) {
+      auto *ref = static_cast<Reference<Napi::Value> *>(ctx);
+      deferred->Resolve(ref->Value());
+    });
+    return deferred->Promise();
+  };
+
+  Napi::Value Release(const CallbackInfo &info) {
     _tsfn.Release();
-    return _deferred->Promise();
+    return _deferred.Promise();
   };
 
 private:
   ThreadSafeFunction _tsfn;
-  std::unique_ptr<Promise::Deferred> _deferred;
+  Promise::Deferred _deferred;
 };
 
 Object TSFNWrap::Init(Napi::Env env, Object exports) {
-  Function func =
-      DefineClass(env, "TSFNWrap",
-                  {InstanceMethod("getContext", &TSFNWrap::GetContext),
-                   InstanceMethod("release", &TSFNWrap::Release)});
+  Function func = DefineClass(
+      env, "TSFNWrap",
+      {InstanceMethod("getContext", &TSFNWrap::GetContext),
+       InstanceMethod("getContextByCall", &TSFNWrap::GetContextByCall),
+       InstanceMethod("release", &TSFNWrap::Release)});
 
   exports.Set("TSFNWrap", func);
   return exports;
 }
 
-TSFNWrap::TSFNWrap(const CallbackInfo &info) : ObjectWrap<TSFNWrap>(info) {
+TSFNWrap::TSFNWrap(const CallbackInfo &info)
+    : ObjectWrap<TSFNWrap>(info),
+      _deferred(Promise::Deferred::New(info.Env())) {
   Napi::Env env = info.Env();
 
-  Reference<Napi::Value> *_ctx = new Reference<Napi::Value>;
-  *_ctx = Persistent(info[0]);
+  TSFNContext *ctx = new TSFNContext;
+  *ctx = Persistent(info[0]);
 
   _tsfn = ThreadSafeFunction::New(
       info.Env(), Function::New(env, [](const CallbackInfo & /*info*/) {}),
-      Object::New(env), "Test", 1, 1, _ctx,
-      [this](Napi::Env env, Reference<Napi::Value> *ctx) {
-        _deferred->Resolve(env.Undefined());
+      Value(), "Test", 0, 1, ctx, [this](Napi::Env env, TSFNContext *ctx) {
+        _deferred.Resolve(env.Undefined());
         ctx->Reset();
         delete ctx;
       });
 }
-
 } // namespace
 
 Object InitThreadSafeFunctionCtx(Env env) {

--- a/test/threadsafe_function/threadsafe_function_ctx.js
+++ b/test/threadsafe_function/threadsafe_function_ctx.js
@@ -3,14 +3,15 @@
 const assert = require('assert');
 const buildType = process.config.target_defaults.default_configuration;
 
-module.exports = Promise.all[
+module.exports = Promise.all([
   test(require(`../build/${buildType}/binding.node`)),
   test(require(`../build/${buildType}/binding_noexcept.node`))
-];
+]);
 
 async function test(binding) {
   const ctx = { };
   const tsfn = new binding.threadsafe_function_ctx.TSFNWrap(ctx);
   assert(tsfn.getContext() === ctx);
+  assert(await tsfn.getContextByCall() === ctx);
   await tsfn.release();
 }


### PR DESCRIPTION
This is WIP, currently missing the overload functionality for `[Non]BlockingCall(DataType*, Callback)`, to allow the Callback to have either signature `void(Napi::Env, Function, DataType*)` [existing functionality] or `void(Napi::Env, Function, DataType*, void*)` [new context param]

Todo:
- [ ] Add `[Non]BlockingCall` with DataType* overloads
- [ ] Update docs

Fixes: #653 