### PR TITLE
tsfn: implement ThreadSafeFunctionEx for GCC 5+

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -218,6 +218,44 @@ struct ThreadSafeFinalize {
   FinalizerDataType* data;
   Finalizer callback;
 };
+
+template <typename ContextType, typename DataType, typename CallJs, CallJs call>
+typename std::enable_if<call != nullptr>::type
+static inline CallJsWrapper(napi_env env, napi_value jsCallback, void *context, void *data) {
+  call(env, Function(env, jsCallback), static_cast<ContextType *>(context),
+       static_cast<DataType *>(data));
+}
+
+template <typename ContextType, typename DataType, typename CallJs, CallJs call>
+typename std::enable_if<call == nullptr>::type
+static inline CallJsWrapper(napi_env env, napi_value jsCallback, void * /*context*/,
+              void * /*data*/) {
+  if (jsCallback != nullptr) {
+    Function(env, jsCallback).Call(0, nullptr);
+  }
+}
+
+#if NAPI_VERSION > 4
+
+template <typename CallbackType, typename TSFN>
+napi_value DefaultCallbackWrapper(napi_env /*env*/, std::nullptr_t /*cb*/) {
+  return nullptr;
+}
+
+template <typename CallbackType, typename TSFN>
+napi_value DefaultCallbackWrapper(napi_env /*env*/, Napi::Function cb) {
+  return cb;
+}
+
+#else
+template <typename CallbackType, typename TSFN>
+napi_value DefaultCallbackWrapper(napi_env env, Napi::Function cb) {
+  if (cb.IsEmpty()) {
+    return TSFN::EmptyFunctionFactory(env);
+  }
+  return cb;
+}
+#endif  // NAPI_VERSION > 4
 #endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
 
 template <typename Getter, typename Setter>
@@ -4356,6 +4394,363 @@ inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
 }
 
 #if (NAPI_VERSION > 3 && !defined(__wasm32__))
+////////////////////////////////////////////////////////////////////////////////
+// ThreadSafeFunctionEx<ContextType,DataType,CallJs> class
+////////////////////////////////////////////////////////////////////////////////
+
+// Starting with NAPI 5, the JavaScript function `func` parameter of
+// `napi_create_threadsafe_function` is optional.
+#if NAPI_VERSION > 4
+// static, with Callback [missing] Resource [missing] Finalizer [missing]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, ResourceString resourceName, size_t maxQueueSize,
+    size_t initialThreadCount, ContextType *context) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  napi_status status = napi_create_threadsafe_function(
+      env, nullptr, nullptr, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, nullptr, nullptr, context,
+      CallJsInternal, &tsfn._tsfn);
+  if (status != napi_ok) {
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with Callback [missing] Resource [passed] Finalizer [missing]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, const Object &resource, ResourceString resourceName,
+    size_t maxQueueSize, size_t initialThreadCount, ContextType *context) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  napi_status status = napi_create_threadsafe_function(
+      env, nullptr, resource, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, nullptr, nullptr, context, CallJsInternal,
+      &tsfn._tsfn);
+  if (status != napi_ok) {
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with Callback [missing] Resource [missing] Finalizer [passed]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString, typename Finalizer,
+          typename FinalizerDataType>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, ResourceString resourceName, size_t maxQueueSize,
+    size_t initialThreadCount, ContextType *context, Finalizer finalizeCallback,
+    FinalizerDataType *data) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  auto *finalizeData = new details::ThreadSafeFinalize<ContextType, Finalizer,
+                                                       FinalizerDataType>(
+      {data, finalizeCallback});
+  napi_status status = napi_create_threadsafe_function(
+      env, nullptr, nullptr, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, finalizeData,
+      details::ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>::
+          FinalizeFinalizeWrapperWithDataAndContext,
+      context, CallJsInternal, &tsfn._tsfn);
+  if (status != napi_ok) {
+    delete finalizeData;
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with Callback [missing] Resource [passed] Finalizer [passed]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString, typename Finalizer,
+          typename FinalizerDataType>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, const Object &resource, ResourceString resourceName,
+    size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
+    Finalizer finalizeCallback, FinalizerDataType *data) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  auto *finalizeData = new details::ThreadSafeFinalize<ContextType, Finalizer,
+                                                       FinalizerDataType>(
+      {data, finalizeCallback});
+  napi_status status = napi_create_threadsafe_function(
+      env, nullptr, resource, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, finalizeData,
+      details::ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>::
+          FinalizeFinalizeWrapperWithDataAndContext,
+      context, CallJsInternal, &tsfn._tsfn);
+  if (status != napi_ok) {
+    delete finalizeData;
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+#endif
+
+// static, with Callback [passed] Resource [missing] Finalizer [missing]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, const Function &callback, ResourceString resourceName,
+    size_t maxQueueSize, size_t initialThreadCount, ContextType *context) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  napi_status status = napi_create_threadsafe_function(
+      env, callback, nullptr, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, nullptr, nullptr, context, CallJsInternal,
+      &tsfn._tsfn);
+  if (status != napi_ok) {
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with Callback [passed] Resource [passed] Finalizer [missing]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, const Function &callback, const Object &resource,
+    ResourceString resourceName, size_t maxQueueSize, size_t initialThreadCount,
+    ContextType *context) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  napi_status status = napi_create_threadsafe_function(
+      env, callback, resource, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, nullptr, nullptr, context, CallJsInternal,
+      &tsfn._tsfn);
+  if (status != napi_ok) {
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with Callback [passed] Resource [missing] Finalizer [passed]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename ResourceString, typename Finalizer,
+          typename FinalizerDataType>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, const Function &callback, ResourceString resourceName,
+    size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
+    Finalizer finalizeCallback, FinalizerDataType *data) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  auto *finalizeData = new details::ThreadSafeFinalize<ContextType, Finalizer,
+                                                       FinalizerDataType>(
+      {data, finalizeCallback});
+  napi_status status = napi_create_threadsafe_function(
+      env, callback, nullptr, String::From(env, resourceName), maxQueueSize,
+      initialThreadCount, finalizeData,
+      details::ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>::
+          FinalizeFinalizeWrapperWithDataAndContext,
+      context, CallJsInternal, &tsfn._tsfn);
+  if (status != napi_ok) {
+    delete finalizeData;
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+// static, with: Callback [passed] Resource [passed] Finalizer [passed]
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+template <typename CallbackType, typename ResourceString, typename Finalizer,
+          typename FinalizerDataType>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::New(
+    napi_env env, CallbackType callback, const Object &resource,
+    ResourceString resourceName, size_t maxQueueSize, size_t initialThreadCount,
+    ContextType *context, Finalizer finalizeCallback, FinalizerDataType *data) {
+  ThreadSafeFunctionEx<ContextType, DataType, CallJs> tsfn;
+
+  auto *finalizeData = new details::ThreadSafeFinalize<ContextType, Finalizer,
+                                                       FinalizerDataType>(
+      {data, finalizeCallback});
+  napi_status status = napi_create_threadsafe_function(
+      env, details::DefaultCallbackWrapper<CallbackType, ThreadSafeFunctionEx<ContextType, DataType, CallJs>>(env, callback), resource,
+      String::From(env, resourceName), maxQueueSize, initialThreadCount,
+      finalizeData,
+      details::ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>::
+          FinalizeFinalizeWrapperWithDataAndContext,
+      context, CallJsInternal, &tsfn._tsfn);
+  if (status != napi_ok) {
+    delete finalizeData;
+    NAPI_THROW_IF_FAILED(env, status,
+                         ThreadSafeFunctionEx<ContextType, DataType, CallJs>());
+  }
+
+  return tsfn;
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline ThreadSafeFunctionEx<ContextType, DataType,
+                            CallJs>::ThreadSafeFunctionEx()
+    : _tsfn() {}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>::
+    ThreadSafeFunctionEx(napi_threadsafe_function tsfn)
+    : _tsfn(tsfn) {}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline ThreadSafeFunctionEx<ContextType, DataType, CallJs>::
+operator napi_threadsafe_function() const {
+  return _tsfn;
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline napi_status
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::BlockingCall(
+    DataType *data) const {
+  return napi_call_threadsafe_function(_tsfn, data, napi_tsfn_blocking);
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline napi_status
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::NonBlockingCall(
+    DataType *data) const {
+  return napi_call_threadsafe_function(_tsfn, data, napi_tsfn_nonblocking);
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline void
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::Ref(napi_env env) const {
+  if (_tsfn != nullptr) {
+    napi_status status = napi_ref_threadsafe_function(env, _tsfn);
+    NAPI_THROW_IF_FAILED_VOID(env, status);
+  }
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline void
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::Unref(napi_env env) const {
+  if (_tsfn != nullptr) {
+    napi_status status = napi_unref_threadsafe_function(env, _tsfn);
+    NAPI_THROW_IF_FAILED_VOID(env, status);
+  }
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline napi_status
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::Acquire() const {
+  return napi_acquire_threadsafe_function(_tsfn);
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline napi_status
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::Release() {
+  return napi_release_threadsafe_function(_tsfn, napi_tsfn_release);
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline napi_status
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::Abort() {
+  return napi_release_threadsafe_function(_tsfn, napi_tsfn_abort);
+}
+
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+inline ContextType *
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::GetContext() const {
+  void *context;
+  napi_status status = napi_get_threadsafe_function_context(_tsfn, &context);
+  NAPI_FATAL_IF_FAILED(status, "ThreadSafeFunctionEx::GetContext",
+                       "napi_get_threadsafe_function_context");
+  return static_cast<ContextType *>(context);
+}
+
+// static
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+void ThreadSafeFunctionEx<ContextType, DataType, CallJs>::CallJsInternal(
+    napi_env env, napi_value jsCallback, void *context, void *data) {
+  details::CallJsWrapper<ContextType, DataType, decltype(CallJs), CallJs>(
+      env, jsCallback, context, data);
+}
+
+#if NAPI_VERSION == 4
+// static
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+Napi::Function
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::EmptyFunctionFactory(
+    Napi::Env env) {
+  return Napi::Function::New(env, [](const CallbackInfo &cb) {});
+}
+
+// static
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+Napi::Function
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::FunctionOrEmpty(
+    Napi::Env env, Napi::Function &callback) {
+  if (callback.IsEmpty()) {
+    return EmptyFunctionFactory(env);
+  }
+  return callback;
+}
+
+#else
+// static
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+std::nullptr_t
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::EmptyFunctionFactory(
+    Napi::Env /*env*/) {
+  return nullptr;
+}
+
+// static
+template <typename ContextType, typename DataType,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType *, DataType *)>
+Napi::Function
+ThreadSafeFunctionEx<ContextType, DataType, CallJs>::FunctionOrEmpty(
+    Napi::Env /*env*/, Napi::Function &callback) {
+  return callback;
+}
+
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 // ThreadSafeFunction class
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi.h
+++ b/napi.h
@@ -2062,7 +2062,164 @@ namespace Napi {
   };
 
   #if (NAPI_VERSION > 3 && !defined(__wasm32__))
-  class ThreadSafeFunction {
+  class ThreadSafeFunction;
+
+  // A ThreadSafeFunctionEx by default has no context (nullptr) and can accept
+  // any type (void) to its CallJs.
+  template <typename ContextType = std::nullptr_t, typename DataType = void,
+            void (*CallJs)(Napi::Env, Napi::Function, ContextType *,
+                           DataType *) = nullptr>
+  class ThreadSafeFunctionEx {
+
+  public:
+
+    // This API may only be called from the main thread.
+    // Helper function that returns nullptr if running N-API 5+, otherwise a
+    // non-empty, no-op Function. This provides the ability to specify at
+    // compile-time a callback parameter to `New` that safely does no action
+    // when targeting _any_ N-API version.
+#if NAPI_VERSION > 4
+    static std::nullptr_t EmptyFunctionFactory(Napi::Env env);
+#else
+    static Napi::Function EmptyFunctionFactory(Napi::Env env);
+#endif
+    static Napi::Function FunctionOrEmpty(Napi::Env env, Napi::Function& callback);
+
+#if NAPI_VERSION > 4
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [missing] Resource [missing] Finalizer [missing]
+    template <typename ResourceString>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, ResourceString resourceName, size_t maxQueueSize,
+        size_t initialThreadCount, ContextType *context = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [missing] Resource [passed] Finalizer [missing]
+    template <typename ResourceString>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Object &resource, ResourceString resourceName,
+        size_t maxQueueSize, size_t initialThreadCount,
+        ContextType *context = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [missing] Resource [missing] Finalizer [passed]
+    template <typename ResourceString, typename Finalizer,
+              typename FinalizerDataType = void>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, ResourceString resourceName, size_t maxQueueSize,
+        size_t initialThreadCount, ContextType *context,
+        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [missing] Resource [passed] Finalizer [passed]
+    template <typename ResourceString, typename Finalizer,
+              typename FinalizerDataType = void>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Object &resource, ResourceString resourceName,
+        size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
+        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
+#endif
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [passed] Resource [missing] Finalizer [missing]
+    template <typename ResourceString>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Function &callback, ResourceString resourceName,
+        size_t maxQueueSize, size_t initialThreadCount,
+        ContextType *context = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [passed] Resource [passed] Finalizer [missing]
+    template <typename ResourceString>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Function &callback, const Object &resource,
+        ResourceString resourceName, size_t maxQueueSize,
+        size_t initialThreadCount, ContextType *context = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [passed] Resource [missing] Finalizer [passed]
+    template <typename ResourceString, typename Finalizer,
+              typename FinalizerDataType = void>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Function &callback, ResourceString resourceName,
+        size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
+        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
+
+    // This API may only be called from the main thread.
+    // Creates a new threadsafe function with:
+    //   Callback [passed] Resource [passed] Finalizer [passed]
+    template <typename CallbackType, typename ResourceString, typename Finalizer,
+          typename FinalizerDataType>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, CallbackType callback, const Object &resource,
+        ResourceString resourceName, size_t maxQueueSize,
+        size_t initialThreadCount, ContextType *context,
+        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
+
+    ThreadSafeFunctionEx<ContextType, DataType, CallJs>();
+    ThreadSafeFunctionEx<ContextType, DataType, CallJs>(
+        napi_threadsafe_function tsFunctionValue);
+
+    operator napi_threadsafe_function() const;
+
+    // This API may be called from any thread.
+    napi_status BlockingCall(DataType *data = nullptr) const;
+
+    // This API may be called from any thread.
+    napi_status NonBlockingCall(DataType *data = nullptr) const;
+
+    // This API may only be called from the main thread.
+    void Ref(napi_env env) const;
+
+    // This API may only be called from the main thread.
+    void Unref(napi_env env) const;
+
+    // This API may be called from any thread.
+    napi_status Acquire() const;
+
+    // This API may be called from any thread.
+    napi_status Release();
+
+    // This API may be called from any thread.
+    napi_status Abort();
+
+    // This API may be called from any thread.
+    ContextType *GetContext() const;
+
+  private:
+    // To access private methods New and ThreadSafeFunctionCallJs
+    friend class ThreadSafeFunction;
+    
+    template <typename ResourceString, typename Finalizer,
+              typename FinalizerDataType>
+    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
+    New(napi_env env, const Function &callback, const Object &resource,
+        ResourceString resourceName, size_t maxQueueSize,
+        size_t initialThreadCount, ContextType *context,
+        Finalizer finalizeCallback, FinalizerDataType *data,
+        napi_finalize wrapper);
+
+    static void CallJsInternal(napi_env env, napi_value jsCallback,
+                               void *context, void *data);
+  // Function used for ThreadSafeFunction's static callback
+  static void ThreadSafeFunctionCallJs(Napi::Env env,
+                                        Napi::Function jsCallback,
+                                        void *context, void *data);
+
+  protected:
+    napi_threadsafe_function _tsfn;
+  };
+
+  class ThreadSafeFunction
+      : private ThreadSafeFunctionEx<
+            void, void, ThreadSafeFunctionEx<>::ThreadSafeFunctionCallJs> {
   public:
     // This API may only be called from the main thread.
     template <typename ResourceString>
@@ -2241,6 +2398,9 @@ namespace Napi {
     ConvertibleContext GetContext() const;
 
   private:
+    using base =
+        ThreadSafeFunctionEx<void, void,
+                             ThreadSafeFunctionEx<>::ThreadSafeFunctionCallJs>;
     using CallbackWrapper = std::function<void(Napi::Env, Napi::Function)>;
 
     template <typename ResourceString, typename ContextType,
@@ -2258,160 +2418,8 @@ namespace Napi {
 
     napi_status CallInternal(CallbackWrapper* callbackWrapper,
                         napi_threadsafe_function_call_mode mode) const;
-
-    static void CallJS(napi_env env,
-                       napi_value jsCallback,
-                       void* context,
-                       void* data);
-
-    napi_threadsafe_function _tsfn;
   };
 
-  // A ThreadSafeFunctionEx by default has no context (nullptr) and can accept
-  // any type (void) to its CallJs.
-  template <typename ContextType = std::nullptr_t, typename DataType = void,
-            void (*CallJs)(Napi::Env, Napi::Function, ContextType *,
-                           DataType *) = nullptr>
-  class ThreadSafeFunctionEx {
-
-  public:
-
-    // This API may only be called from the main thread.
-    // Helper function that returns nullptr if running N-API 5+, otherwise a
-    // non-empty, no-op Function. This provides the ability to specify at
-    // compile-time a callback parameter to `New` that safely does no action
-    // when targeting _any_ N-API version.
-#if NAPI_VERSION > 4
-    static std::nullptr_t EmptyFunctionFactory(Napi::Env env);
-#else
-    static Napi::Function EmptyFunctionFactory(Napi::Env env);
-#endif
-    static Napi::Function FunctionOrEmpty(Napi::Env env, Napi::Function& callback);
-
-#if NAPI_VERSION > 4
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [missing] Finalizer [missing]
-    template <typename ResourceString>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, ResourceString resourceName, size_t maxQueueSize,
-        size_t initialThreadCount, ContextType *context = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [passed] Finalizer [missing]
-    template <typename ResourceString>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Object &resource, ResourceString resourceName,
-        size_t maxQueueSize, size_t initialThreadCount,
-        ContextType *context = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [missing] Finalizer [passed]
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType = void>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, ResourceString resourceName, size_t maxQueueSize,
-        size_t initialThreadCount, ContextType *context,
-        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [passed] Finalizer [passed]
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType = void>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Object &resource, ResourceString resourceName,
-        size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
-        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
-#endif
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [missing] Finalizer [missing]
-    template <typename ResourceString>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Function &callback, ResourceString resourceName,
-        size_t maxQueueSize, size_t initialThreadCount,
-        ContextType *context = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [passed] Finalizer [missing]
-    template <typename ResourceString>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Function &callback, const Object &resource,
-        ResourceString resourceName, size_t maxQueueSize,
-        size_t initialThreadCount, ContextType *context = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [missing] Finalizer [passed]
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType = void>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Function &callback, ResourceString resourceName,
-        size_t maxQueueSize, size_t initialThreadCount, ContextType *context,
-        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
-
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [passed] Finalizer [passed]
-    template <typename CallbackType, typename ResourceString, typename Finalizer,
-          typename FinalizerDataType>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, CallbackType callback, const Object &resource,
-        ResourceString resourceName, size_t maxQueueSize,
-        size_t initialThreadCount, ContextType *context,
-        Finalizer finalizeCallback, FinalizerDataType *data = nullptr);
-
-    ThreadSafeFunctionEx<ContextType, DataType, CallJs>();
-    ThreadSafeFunctionEx<ContextType, DataType, CallJs>(
-        napi_threadsafe_function tsFunctionValue);
-
-    operator napi_threadsafe_function() const;
-
-    // This API may be called from any thread.
-    napi_status BlockingCall(DataType *data = nullptr) const;
-
-    // This API may be called from any thread.
-    napi_status NonBlockingCall(DataType *data = nullptr) const;
-
-    // This API may only be called from the main thread.
-    void Ref(napi_env env) const;
-
-    // This API may only be called from the main thread.
-    void Unref(napi_env env) const;
-
-    // This API may be called from any thread.
-    napi_status Acquire() const;
-
-    // This API may be called from any thread.
-    napi_status Release();
-
-    // This API may be called from any thread.
-    napi_status Abort();
-
-    // This API may be called from any thread.
-    ContextType *GetContext() const;
-
-  private:
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType>
-    static ThreadSafeFunctionEx<ContextType, DataType, CallJs>
-    New(napi_env env, const Function &callback, const Object &resource,
-        ResourceString resourceName, size_t maxQueueSize,
-        size_t initialThreadCount, ContextType *context,
-        Finalizer finalizeCallback, FinalizerDataType *data,
-        napi_finalize wrapper);
-
-    static void CallJsInternal(napi_env env, napi_value jsCallback,
-                               void *context, void *data);
-
-  protected:
-    napi_threadsafe_function _tsfn;
-  };
   template <typename DataType>
   class AsyncProgressWorkerBase : public AsyncWorker {
     public:


### PR DESCRIPTION
This PR backs the existing `ThreadSafeFunction` class with the new `ThreadSafeFunctionEx` class. However, there are compilation issues on gcc-4.8 used by the CI.  node v10 has a minimum build requirement of [gcc-4.9](https://github.com/nodejs/node/blob/v10.x/BUILDING.md#unixmacos). 

We discussed somewhere (possibly an N-API meeting) that we can have this PR blocked until node 10 is decommissioned, so we can update our CI's gcc and possibly incorporate these changes.