### PR TITLE
src: change guards for BigInt to NAPI_VERSION > 5

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -1,7 +1,6 @@
 {
   'variables': {
     'NAPI_VERSION%': "<!(node -p \"process.versions.napi\")",
-    'NODE_MAJOR_VERSION%': "<!(node -p \"process.versions.node.match(/\\d+/)[0]\")",
     'disable_deprecated': "<!(node -p \"process.env['npm_config_disable_deprecated']\")"
   },
   'conditions': [
@@ -16,7 +15,6 @@
       }
     }]
   ],
-  'defines': ['NODE_MAJOR_VERSION=<@(NODE_MAJOR_VERSION)'],
   'include_dirs': ["<!@(node -p \"require('../').include\")"],
   'cflags': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ],
   'cflags_cc': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ]

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -386,14 +386,11 @@ inline bool Value::IsNumber() const {
   return Type() == napi_number;
 }
 
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
 inline bool Value::IsBigInt() const {
   return Type() == napi_bigint;
 }
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 
 #if (NAPI_VERSION > 4)
 inline bool Value::IsDate() const {
@@ -624,10 +621,7 @@ inline double Number::DoubleValue() const {
   return result;
 }
 
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
 ////////////////////////////////////////////////////////////////////////////////
 // BigInt Class
 ////////////////////////////////////////////////////////////////////////////////
@@ -688,7 +682,7 @@ inline void BigInt::ToWords(int* sign_bit, size_t* word_count, uint64_t* words) 
       _env, _value, sign_bit, word_count, words);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 
 #if (NAPI_VERSION > 4)
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4792,7 +4792,7 @@ inline void AsyncProgressWorker<T>::SendProgress_(const T* data, size_t count) {
 
 template<class T>
 inline void AsyncProgressWorker<T>::Signal() const {
-  this->NonBlockingCall(nullptr);
+  this->NonBlockingCall(static_cast<T*>(nullptr));
 }
 
 template<class T>

--- a/napi.h
+++ b/napi.h
@@ -119,12 +119,9 @@ namespace Napi {
   class Value;
   class Boolean;
   class Number;
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
   class BigInt;
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 #if (NAPI_VERSION > 4)
   class Date;
 #endif
@@ -147,13 +144,10 @@ namespace Napi {
   typedef TypedArrayOf<uint32_t> Uint32Array; ///< Typed-array of unsigned 32-bit integers
   typedef TypedArrayOf<float> Float32Array;   ///< Typed-array of 32-bit floating-point values
   typedef TypedArrayOf<double> Float64Array;  ///< Typed-array of 64-bit floating-point values
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
   typedef TypedArrayOf<int64_t> BigInt64Array;   ///< Typed array of signed 64-bit integers
   typedef TypedArrayOf<uint64_t> BigUint64Array; ///< Typed array of unsigned 64-bit integers
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 
   /// Defines the signature of a N-API C++ module's registration callback (init) function.
   typedef Object (*ModuleRegisterCallback)(Env env, Object exports);
@@ -257,12 +251,9 @@ namespace Napi {
     bool IsNull() const;        ///< Tests if a value is a null JavaScript value.
     bool IsBoolean() const;     ///< Tests if a value is a JavaScript boolean.
     bool IsNumber() const;      ///< Tests if a value is a JavaScript number.
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
     bool IsBigInt() const;      ///< Tests if a value is a JavaScript bigint.
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 #if (NAPI_VERSION > 4)
     bool IsDate() const;        ///< Tests if a value is a JavaScript date.
 #endif
@@ -335,10 +326,7 @@ namespace Napi {
     double DoubleValue() const;   ///< Converts a Number value to a 64-bit floating-point value.
   };
 
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
   /// A JavaScript bigint value.
   class BigInt : public Value {
   public:
@@ -377,7 +365,7 @@ namespace Napi {
     /// be needed to store this BigInt (i.e. the return value of `WordCount()`).
     void ToWords(int* sign_bit, size_t* word_count, uint64_t* words);
   };
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
 
 #if (NAPI_VERSION > 4)
   /// A JavaScript date value.
@@ -859,13 +847,10 @@ namespace Napi {
         : std::is_same<T, uint32_t>::value ? napi_uint32_array
         : std::is_same<T, float>::value ? napi_float32_array
         : std::is_same<T, double>::value ? napi_float64_array
-// Currently experimental guard with the definition of NAPI_EXPERIMENTAL.
-// Once it is no longer experimental guard with the NAPI_VERSION in which it is
-// released instead.
-#ifdef NAPI_EXPERIMENTAL
+#if NAPI_VERSION > 5
         : std::is_same<T, int64_t>::value ? napi_bigint64_array
         : std::is_same<T, uint64_t>::value ? napi_biguint64_array
-#endif  // NAPI_EXPERIMENTAL
+#endif  // NAPI_VERSION > 5
         : unknown_array_type;
     }
     /// !endcond

--- a/test/bigint.cc
+++ b/test/bigint.cc
@@ -1,7 +1,4 @@
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
 
 #define NAPI_EXPERIMENTAL
 #include "napi.h"

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -17,7 +17,7 @@ Object InitBasicTypesValue(Env env);
 // Currently experimental guard with NODE_MAJOR_VERISION in which it was
 // released. Once it is no longer experimental guard with the NAPI_VERSION
 // in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
 Object InitBigInt(Env env);
 #endif
 Object InitBuffer(Env env);
@@ -73,7 +73,7 @@ Object Init(Env env, Object exports) {
 // Currently experimental guard with NODE_MAJOR_VERISION in which it was
 // released. Once it is no longer experimental guard with the NAPI_VERSION
 // in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
   exports.Set("bigint", InitBigInt(env));
 #endif
 #if (NAPI_VERSION > 4)

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -1,9 +1,3 @@
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
-#define NAPI_EXPERIMENTAL
-#endif
 #include "napi.h"
 
 using namespace Napi;
@@ -70,10 +64,7 @@ Value CreateTypedArray(const CallbackInfo& info) {
       NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length, napi_float64_array) :
       NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length, buffer, bufferOffset,
                                  napi_float64_array);
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
   } else if (arrayType == "bigint64") {
     return buffer.IsUndefined() ?
       NAPI_TYPEDARRAY_NEW(BigInt64Array, info.Env(), length, napi_bigint64_array) :
@@ -107,10 +98,7 @@ Value GetTypedArrayType(const CallbackInfo& info) {
     case napi_uint32_array: return String::New(info.Env(), "uint32");
     case napi_float32_array: return String::New(info.Env(), "float32");
     case napi_float64_array: return String::New(info.Env(), "float64");
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
     case napi_bigint64_array: return String::New(info.Env(), "bigint64");
     case napi_biguint64_array: return String::New(info.Env(), "biguint64");
 #endif
@@ -150,10 +138,7 @@ Value GetTypedArrayElement(const CallbackInfo& info) {
       return Number::New(info.Env(), array.As<Float32Array>()[index]);
     case napi_float64_array:
       return Number::New(info.Env(), array.As<Float64Array>()[index]);
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
     case napi_bigint64_array:
       return BigInt::New(info.Env(), array.As<BigInt64Array>()[index]);
     case napi_biguint64_array:
@@ -197,10 +182,7 @@ void SetTypedArrayElement(const CallbackInfo& info) {
     case napi_float64_array:
       array.As<Float64Array>()[index] = value.DoubleValue();
       break;
-// Currently experimental guard with NODE_MAJOR_VERISION in which it was
-// released. Once it is no longer experimental guard with the NAPI_VERSION
-// in which it is released instead.
-#if (NODE_MAJOR_VERSION >= 10)
+#if (NAPI_VERSION > 5)
     case napi_bigint64_array: {
       bool lossless;
       array.As<BigInt64Array>()[index] = value.As<BigInt>().Int64Value(&lossless);


### PR DESCRIPTION
Since we have made the decision that we shall include `BigInt` into
N-API 6, we can change the guards for the `BigInt` wrappers
accordingly.