### PR TITLE
src: fix AsyncProgressQueueWorker compilation

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4792,7 +4792,7 @@ inline void AsyncProgressWorker<T>::SendProgress_(const T* data, size_t count) {
 
 template<class T>
 inline void AsyncProgressWorker<T>::Signal() const {
-  this->NonBlockingCall(nullptr);
+  this->NonBlockingCall(static_cast<T*>(nullptr));
 }
 
 template<class T>


### PR DESCRIPTION
We need to cast the `nullptr` to the templated type of the
`AsyncProgressQueueWorker`.