### PR TITLE
src: reset the NAPI_VERSION by fixing compiler error with NAPI_EXPERIMENTAL

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -9,6 +9,12 @@
 #include <string>
 #include <vector>
 
+// Reset the NAPI_VERSION which is set by some versions of node_api.h
+// See: https://github.com/nodejs/node/commit/8476053c132fd9613aab547aba165190f8064254
+#if defined(NAPI_EXPERIMENTAL) && NAPI_VERSION == 2147483647
+#undef NAPI_VERSION
+#endif
+
 // VS2015 RTM has bugs with constexpr, so require min of VS2015 Update 3 (known good version)
 #if !defined(_MSC_VER) || _MSC_FULL_VER >= 190024210
 #define NAPI_HAS_CONSTEXPR 1


### PR DESCRIPTION
This fixes a compiler error like this:

```shell
/Users/yorkie/workspace/pipcook/packages/boa/node_modules/node-addon-api/napi-inl.h:405:24: error: use of undeclared identifier 'napi_is_date'; did you mean 'napi_is_dataview'?
  napi_status status = napi_is_date(_env, _value, &result);
                       ^~~~~~~~~~~~
                       napi_is_dataview
```

This is because on 10.15.x, the Node.js will automatically define NAPI_VERSION to be a big value when NAPI_EXPERIMENTAL is defined, so it makes a mistake on resolving the `NAPI_VERSION > 4`.

The following commit introduces a pre-define which sets NAPI_VERSION to a magic number when NAPI_EXPERIMENTAL, this may cause an error when enabling NAPI_EXPERIMENTAL on an
actual napi3,4.

Node.js Commit: https://github.com/nodejs/node/commit/8476053c132fd9613aab547aba165190f8064254.

Now Node.js has removed that at the later commit, too. So let's #undef it.