### PR TITLE
WIP: add safer unwrap

### DIFF
--- a/test/binding.cc
+++ b/test/binding.cc
@@ -51,6 +51,7 @@ Object InitThreadSafeFunction(Env env);
 #endif
 Object InitTypedArray(Env env);
 Object InitObjectWrap(Env env);
+Object InitObjectWrapSaferUnwrap(Env env);
 Object InitObjectWrapConstructorException(Env env);
 Object InitObjectWrapRemoveWrap(Env env);
 Object InitObjectReference(Env env);
@@ -108,6 +109,7 @@ Object Init(Env env, Object exports) {
 #endif
   exports.Set("typedarray", InitTypedArray(env));
   exports.Set("objectwrap", InitObjectWrap(env));
+  exports.Set("objectwrapSaferUnwrap", InitObjectWrapSaferUnwrap(env));
   exports.Set("objectwrapConstructorException",
       InitObjectWrapConstructorException(env));
   exports.Set("objectwrap_removewrap", InitObjectWrapRemoveWrap(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -45,6 +45,7 @@
         'objectwrap.cc',
         'objectwrap_constructor_exception.cc',
         'objectwrap-removewrap.cc',
+        'objectwrap-saferunwrap.cc',
         'objectreference.cc',
         'version_management.cc',
         'thunking_manual.cc',

--- a/test/objectwrap-saferunwrap.cc
+++ b/test/objectwrap-saferunwrap.cc
@@ -1,0 +1,54 @@
+#define NAPI_UNSAFER_UNWRAP
+#include <napi.h>
+
+class TestSub {
+public:
+  virtual ~TestSub() {}
+  virtual int Get1() { return 1; }
+};
+
+class Test : public Napi::ObjectWrap<Test>, public TestSub {
+public:
+  Test(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Test>(info) {
+
+  }
+
+  static void Initialize(Napi::Env env, Napi::Object exports) {
+    exports.Set("Test", DefineClass(env, "Test", {}));
+  }
+};
+
+class TestReceiver : public Napi::ObjectWrap<TestReceiver> {
+public:
+  TestReceiver(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TestReceiver>(info) {
+
+  }
+
+  Napi::Value Unwrap(const Napi::CallbackInfo& info) {
+    
+    // This is okay => reinterpret_cast of the same type is valid
+    int n = Napi::ObjectWrap<Test>::Unwrap(info[0].ToObject())->Get1();
+
+    // This should fail => reinterpret_cast of a subclass (or any other type) is possible but NOT allowed
+    // If you're lucky you get a segfault. If not, you may get a stacktrace invoking `->A()`, but invoked `->B()` or any other method.
+    n = Napi::ObjectWrap<TestSub>::Unwrap(info[0].ToObject())->Get1();
+
+    // => do we have "should not compile" tests?
+    // without the fix, this will compile and you'll spend lot of time debugging :(
+
+    return Napi::Number::New(info.Env(), n);
+  }
+
+  static void Initialize(Napi::Env env, Napi::Object exports) {
+    exports.Set("TestReceiver", DefineClass(env, "TestReceiver", {
+      InstanceMethod("unwrap", &TestReceiver::Unwrap),
+    }));
+  }
+};
+
+
+Napi::Object InitObjectWrapSaferUnwrap(Napi::Env env) {
+  Napi::Object exports = Napi::Object::New(env);
+  Test::Initialize(env, exports);
+  return exports;
+}


### PR DESCRIPTION
Hello,

this PR prevents that `ObjectWrap::Unwrap` can be used with any type. It has to be a type having `ObjectWrap<T>` as sub class.

I spend some time finding a bug in my appliction, which did not segfault, because I did something like this [test/objectwrap-saferunwrap.cc](https://github.com/nodejs/node-addon-api/compare/master...DaAitch:feature/safer-objectwrap-unwrap?expand=1#diff-a71d3d02039e2af6cf01c920dbf97ae4) and it compiles and the reason I found out something is really going wrong is, that the stacktrace shows calling a method `->A()` actually called `->B()`. Then I realized, that it might be is a vtable pointer fixup problem and understand that of course it's possible, but not allowed to reinterpret cast `void *` to any type but the the original one.

So to prevent that s.o. tries to seductively unwrap an `ObjectWrap<Car>` or `ObjectWrap<Truck>` to any sub class like `IVehicle` (which obviously is not a ObjectWrap) it should not compile.

What do you think?

If this has a chance to land, we my need "should not compile" tests.