### PR TITLE
src: fix use of Reference with typed arrays

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1740,8 +1740,14 @@ inline TypedArrayOf<T>::TypedArrayOf() : TypedArray(), _data(nullptr) {
 template <typename T>
 inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
   : TypedArray(env, value), _data(nullptr) {
-  napi_status status = napi_get_typedarray_info(
-    _env, _value, &_type, &_length, reinterpret_cast<void**>(&_data), nullptr, nullptr);
+  napi_status status = napi_ok;
+  if (value != nullptr) {
+    status = napi_get_typedarray_info(
+      _env, _value, &_type, &_length, reinterpret_cast<void**>(&_data), nullptr, nullptr);
+  } else {
+    _type = TypedArrayTypeForPrimitiveType<T>();
+    _length = 0;
+  }
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -54,6 +54,7 @@ Object InitObjectWrap(Env env);
 Object InitObjectWrapConstructorException(Env env);
 Object InitObjectWrapRemoveWrap(Env env);
 Object InitObjectReference(Env env);
+Object InitReference(Env env);
 Object InitVersionManagement(Env env);
 Object InitThunkingManual(Env env);
 
@@ -112,6 +113,7 @@ Object Init(Env env, Object exports) {
       InitObjectWrapConstructorException(env));
   exports.Set("objectwrap_removewrap", InitObjectWrapRemoveWrap(env));
   exports.Set("objectreference", InitObjectReference(env));
+  exports.Set("reference", InitReference(env));
   exports.Set("version_management", InitVersionManagement(env));
   exports.Set("thunking_manual", InitThunkingManual(env));
   return exports;

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -46,6 +46,7 @@
         'objectwrap_constructor_exception.cc',
         'objectwrap-removewrap.cc',
         'objectreference.cc',
+        'reference.cc',
         'version_management.cc',
         'thunking_manual.cc',
       ],

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,7 @@ let testModules = [
   'objectwrap_constructor_exception',
   'objectwrap-removewrap',
   'objectreference',
+  'reference',
   'version_management'
 ];
 

--- a/test/reference.cc
+++ b/test/reference.cc
@@ -1,0 +1,24 @@
+#include "napi.h"
+
+using namespace Napi;
+
+static Reference<Buffer<uint8_t>> weak;
+
+void  CreateWeakArray(const CallbackInfo& info) {
+  weak = Weak(Buffer<uint8_t>::New(info.Env(), 1));
+  weak.SuppressDestruct();
+}
+
+napi_value AccessWeakArrayEmpty(const CallbackInfo& info) {
+  Buffer<uint8_t> value = weak.Value();
+  return Napi::Boolean::New(info.Env(), value.IsEmpty());
+}
+
+Object InitReference(Env env) {
+  Object exports = Object::New(env);
+
+  exports["createWeakArray"] = Function::New(env, CreateWeakArray);
+  exports["accessWeakArrayEmpty"] = Function::New(env, AccessWeakArrayEmpty);
+
+  return exports;
+}

--- a/test/reference.js
+++ b/test/reference.js
@@ -1,0 +1,15 @@
+'use strict';
+
+
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+const testUtil = require('./testUtil');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  binding.reference.createWeakArray();
+  global.gc();
+  assert.strictEqual(true, binding.reference.accessWeakArrayEmpty());
+};


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-addon-api/issues/702

Previously calling Value() on a Reference for a TypedArray
that the enderlying object had been collected would result
in an error due to a failure in creating the return value.

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>