### PR TITLE
Fix ObjectWrap destructor from env exit under node_g

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,7 @@ let testModules = [
   'objectwrap_constructor_exception',
   'objectwrap-removewrap',
   'objectwrap_multiple_inheritance',
+  'objectwrap_worker_thread',
   'objectreference',
   'reference',
   'version_management'

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,10 @@ if (napiVersion < 6) {
   testModules.splice(testModules.indexOf('typedarray-bigint'), 1);
 }
 
+if (majorNodeVersion < 12) {
+  testModules.splice(testModules.indexOf('objectwrap_worker_thread'), 1);
+}
+
 if (typeof global.gc === 'function') {
   (async function() {
   console.log(`Testing with N-API Version '${napiVersion}'.`);

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -40,6 +40,14 @@ public:
     info.This().As<Napi::Object>().DefineProperty(
         Napi::PropertyDescriptor::Accessor<OwnPropertyGetter>("ownPropertyT",
                                                               napi_enumerable, this));
+
+    bufref_ = Napi::Persistent(Napi::Buffer<uint8_t>::New(
+        Env(),
+        static_cast<uint8_t*>(malloc(1)),
+        1,
+        [](Napi::Env, uint8_t* bufaddr) {
+            free(bufaddr);
+        }));
   }
 
   static Napi::Value OwnPropertyGetter(const Napi::CallbackInfo& info) {
@@ -183,6 +191,8 @@ private:
   Napi::FunctionReference finalizeCb_;
 
   static std::string s_staticMethodText;
+
+  Napi::Reference<Napi::Buffer<uint8_t>> bufref_;
 };
 
 std::string Test::s_staticMethodText;

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -1,0 +1,14 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+    new Worker(__filename);
+} else {
+    const test = binding => {
+        new binding.objectwrap.Test();
+    };
+
+    test(require(`./build/${buildType}/binding.node`));
+    test(require(`./build/${buildType}/binding_noexcept.node`));
+}


### PR DESCRIPTION
Only fails under debug buildtype (node_g)

Update: Also fails using release 12.16.3

#722 
