### PR TITLE
fix testEnumerables on ObjectWrap

### DIFF
--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -108,11 +108,11 @@ const test = (binding) => {
         keys.push(key);
       }
 
-      assert(keys.length = 4);
-      assert(obj.testGetSet);
-      assert(obj.testGetter);
-      assert(obj.testValue);
-      assert(obj.testMethod);
+      assert(keys.length == 6);
+      assert(keys.includes("testGetSet"));
+      assert(keys.includes("testGetter"));
+      assert(keys.includes("testValue"));
+      assert(keys.includes("testMethod"));
     }
   };
 

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -109,10 +109,14 @@ const test = (binding) => {
       }
 
       assert(keys.length == 6);
+      // on prototype
       assert(keys.includes("testGetSet"));
       assert(keys.includes("testGetter"));
       assert(keys.includes("testValue"));
       assert(keys.includes("testMethod"));
+      // on object only
+      assert(keys.includes("ownProperty"));
+      assert(keys.includes("ownPropertyT"));
     }
   };
 


### PR DESCRIPTION
The assertion on key length is broken. It's an assignment instead of a bool expression.
Also changes the tests for properties to the same style as the tests for "own properties."