### PR TITLE
src: add __wasm32__ guards

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -137,7 +137,7 @@ struct FinalizeData {
   Hint* hint;
 };
 
-#if (NAPI_VERSION > 3)
+#if (NAPI_VERSION > 3 && !defined(__wasm32__))
 template <typename ContextType=void,
           typename Finalizer=std::function<void(Env, void*, ContextType*)>,
           typename FinalizerDataType=void>
@@ -196,7 +196,7 @@ struct ThreadSafeFinalize {
   FinalizerDataType* data;
   Finalizer callback;
 };
-#endif
+#endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
 
 template <typename Getter, typename Setter>
 struct AccessorCallbackData {
@@ -4295,7 +4295,7 @@ inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
   }
 }
 
-#if (NAPI_VERSION > 3)
+#if (NAPI_VERSION > 3 && !defined(__wasm32__))
 ////////////////////////////////////////////////////////////////////////////////
 // ThreadSafeFunction class
 ////////////////////////////////////////////////////////////////////////////////
@@ -4962,7 +4962,7 @@ template<class T>
 inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Send(const T* data, size_t count) const {
   _worker->SendProgress_(data, count);
 }
-#endif
+#endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Memory Management class

--- a/napi.h
+++ b/napi.h
@@ -2042,7 +2042,7 @@ namespace Napi {
     bool _suppress_destruct;
   };
 
-  #if (NAPI_VERSION > 3)
+  #if (NAPI_VERSION > 3 && !defined(__wasm32__))
   class ThreadSafeFunction {
   public:
     // This API may only be called from the main thread.
@@ -2405,7 +2405,7 @@ namespace Napi {
      void Signal() const;
      void SendProgress_(const T* data, size_t count);
   };
-  #endif
+  #endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
 
   // Memory management.
   class MemoryManagement {


### PR DESCRIPTION
Add guards to the threading apis because they are not supported in wasm32.