### PR TITLE
doc: BigInt::ToWords docs not consistent with implementation

### DIFF
--- a/doc/bigint.md
+++ b/doc/bigint.md
@@ -79,7 +79,7 @@ Returns the number of words needed to store this `BigInt` value.
 ### ToWords
 
 ```cpp
-void Napi::BigInt::ToWords(size_t* word_count, int* sign_bit, uint64_t* words);
+void Napi::BigInt::ToWords(int* sign_bit, size_t* word_count, uint64_t* words);
 ```
 
  - `[out] sign_bit`: Integer representing if the JavaScript `BigInt` is positive


### PR DESCRIPTION
Fixes: issue **[745](https://github.com/nodejs/node-addon-api/issues/745)**