### PR TITLE
src: add Addon<T> class

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The oldest Node.js version supported by the current version of node-addon-api is
 
 The following is the documentation for node-addon-api.
 
+ - [Addon Structure](doc/addon.md)
  - [Basic Types](doc/basic_types.md)
     - [Array](doc/basic_types.md#array)
     - [Symbol](doc/symbol.md)

--- a/benchmark/function_args.cc
+++ b/benchmark/function_args.cc
@@ -78,6 +78,66 @@ static void FourArgFunction(const Napi::CallbackInfo& info) {
   Napi::Value argv3 = info[3]; (void) argv3;
 }
 
+#if NAPI_VERSION > 5
+class FunctionArgsBenchmark : public Napi::Addon<FunctionArgsBenchmark> {
+ public:
+  FunctionArgsBenchmark(Napi::Env env, Napi::Object exports) {
+    DefineAddon(exports, {
+      InstanceValue("addon", DefineProperties(Napi::Object::New(env), {
+        InstanceMethod("noArgFunction", &FunctionArgsBenchmark::NoArgFunction),
+        InstanceMethod("oneArgFunction",
+                       &FunctionArgsBenchmark::OneArgFunction),
+        InstanceMethod("twoArgFunction",
+                       &FunctionArgsBenchmark::TwoArgFunction),
+        InstanceMethod("threeArgFunction",
+                       &FunctionArgsBenchmark::ThreeArgFunction),
+        InstanceMethod("fourArgFunction",
+                       &FunctionArgsBenchmark::FourArgFunction),
+      }), napi_enumerable),
+      InstanceValue("addon_templated",
+        DefineProperties(Napi::Object::New(env), {
+          InstanceMethod<&FunctionArgsBenchmark::NoArgFunction>(
+                                                            "noArgFunction"),
+          InstanceMethod<&FunctionArgsBenchmark::OneArgFunction>(
+                                                            "oneArgFunction"),
+          InstanceMethod<&FunctionArgsBenchmark::TwoArgFunction>(
+                                                            "twoArgFunction"),
+          InstanceMethod<&FunctionArgsBenchmark::ThreeArgFunction>(
+                                                            "threeArgFunction"),
+          InstanceMethod<&FunctionArgsBenchmark::FourArgFunction>(
+                                                            "fourArgFunction"),
+        }), napi_enumerable),
+    });
+  }
+ private:
+  void NoArgFunction(const Napi::CallbackInfo& info) {
+    (void) info;
+  }
+
+  void OneArgFunction(const Napi::CallbackInfo& info) {
+    Napi::Value argv0 = info[0]; (void) argv0;
+  }
+
+  void TwoArgFunction(const Napi::CallbackInfo& info) {
+    Napi::Value argv0 = info[0]; (void) argv0;
+    Napi::Value argv1 = info[1]; (void) argv1;
+  }
+
+  void ThreeArgFunction(const Napi::CallbackInfo& info) {
+    Napi::Value argv0 = info[0]; (void) argv0;
+    Napi::Value argv1 = info[1]; (void) argv1;
+    Napi::Value argv2 = info[2]; (void) argv2;
+  }
+
+  void FourArgFunction(const Napi::CallbackInfo& info) {
+    Napi::Value argv0 = info[0]; (void) argv0;
+    Napi::Value argv1 = info[1]; (void) argv1;
+    Napi::Value argv2 = info[2]; (void) argv2;
+    Napi::Value argv3 = info[3]; (void) argv3;
+  }
+};
+#endif  // NAPI_VERSION > 5
+
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   napi_value no_arg_function, one_arg_function, two_arg_function,
       three_arg_function, four_arg_function;
@@ -146,6 +206,10 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   templated["threeArgFunction"] = Napi::Function::New<ThreeArgFunction>(env);
   templated["fourArgFunction"] = Napi::Function::New<FourArgFunction>(env);
   exports["templated"] = templated;
+
+#if NAPI_VERSION > 5
+  FunctionArgsBenchmark::Init(env, exports);
+#endif  // NAPI_VERSION > 5
 
   return exports;
 }

--- a/benchmark/function_args.js
+++ b/benchmark/function_args.js
@@ -4,16 +4,22 @@ const addonName = path.basename(__filename, '.js');
 
 [ addonName, addonName + '_noexcept' ]
   .forEach((addonName) => {
-    const rootAddon = require(`./build/Release/${addonName}`);
+    const rootAddon = require('bindings')({
+      bindings: addonName,
+      module_root: __dirname
+    });
+    delete rootAddon.path;
     const implems = Object.keys(rootAddon);
+    const maxNameLength =
+      implems.reduce((soFar, value) => Math.max(soFar, value.length), 0);
     const anObject = {};
 
-    console.log(`${addonName}: `);
+    console.log(`\n${addonName}: `);
 
     console.log('no arguments:');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].noArgFunction;
-      return suite.add(implem, () => fn());
+      return suite.add(implem.padStart(maxNameLength, ' '), () => fn());
     }, new Benchmark.Suite)
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
@@ -21,7 +27,7 @@ const addonName = path.basename(__filename, '.js');
     console.log('one argument:');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].oneArgFunction;
-      return suite.add(implem, () => fn('x'));
+      return suite.add(implem.padStart(maxNameLength, ' '), () => fn('x'));
     }, new Benchmark.Suite)
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
@@ -29,7 +35,7 @@ const addonName = path.basename(__filename, '.js');
     console.log('two arguments:');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].twoArgFunction;
-      return suite.add(implem, () => fn('x', 12));
+      return suite.add(implem.padStart(maxNameLength, ' '), () => fn('x', 12));
     }, new Benchmark.Suite)
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
@@ -37,7 +43,8 @@ const addonName = path.basename(__filename, '.js');
     console.log('three arguments:');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].threeArgFunction;
-      return suite.add(implem, () => fn('x', 12, true));
+      return suite.add(implem.padStart(maxNameLength, ' '),
+        () => fn('x', 12, true));
     }, new Benchmark.Suite)
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
@@ -45,7 +52,8 @@ const addonName = path.basename(__filename, '.js');
     console.log('four arguments:');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].fourArgFunction;
-      return suite.add(implem, () => fn('x', 12, true, anObject));
+      return suite.add(implem.padStart(maxNameLength, ' '),
+        () => fn('x', 12, true, anObject));
     }, new Benchmark.Suite)
       .on('cycle', (event) => console.log(String(event.target)))
       .run();

--- a/benchmark/property_descriptor.cc
+++ b/benchmark/property_descriptor.cc
@@ -26,6 +26,33 @@ static void Setter(const Napi::CallbackInfo& info) {
   (void) info[0];
 }
 
+#if NAPI_VERSION > 5
+class PropDescBenchmark : public Napi::Addon<PropDescBenchmark> {
+ public:
+  PropDescBenchmark(Napi::Env, Napi::Object exports) {
+    DefineAddon(exports, {
+      InstanceAccessor("addon",
+                       &PropDescBenchmark::Getter,
+                       &PropDescBenchmark::Setter,
+                       napi_enumerable),
+      InstanceAccessor<&PropDescBenchmark::Getter,
+                       &PropDescBenchmark::Setter>("addon_templated",
+                                                   napi_enumerable),
+    });
+  }
+
+ private:
+  Napi::Value Getter(const Napi::CallbackInfo& info) {
+    return Napi::Number::New(info.Env(), 42);
+  }
+
+  void Setter(const Napi::CallbackInfo& info, const Napi::Value& val) {
+    (void) info[0];
+    (void) val;
+  }
+};
+#endif  // NAPI_VERSION > 5
+
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   napi_status status;
   napi_property_descriptor core_prop = {
@@ -53,6 +80,10 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.DefineProperty(
       Napi::PropertyDescriptor::Accessor<Getter, Setter>("templated",
                                                          napi_enumerable));
+
+#if NAPI_VERSION > 5
+  PropDescBenchmark::Init(env, exports);
+#endif  // NAPI_VERSION > 5
 
   return exports;
 }

--- a/benchmark/property_descriptor.js
+++ b/benchmark/property_descriptor.js
@@ -4,17 +4,23 @@ const addonName = path.basename(__filename, '.js');
 
 [ addonName, addonName + '_noexcept' ]
   .forEach((addonName) => {
-    const rootAddon = require(`./build/Release/${addonName}`);
+    const rootAddon = require('bindings')({
+      bindings: addonName,
+      module_root: __dirname
+    });
+    delete rootAddon.path;
     const getters = new Benchmark.Suite;
     const setters = new Benchmark.Suite;
+    const maxNameLength = Object.keys(rootAddon)
+      .reduce((soFar, value) => Math.max(soFar, value.length), 0);
 
-    console.log(`${addonName}: `);
+    console.log(`\n${addonName}: `);
 
     Object.keys(rootAddon).forEach((key) => {
-      getters.add(`${key} getter`, () => {
+      getters.add(`${key} getter`.padStart(maxNameLength + 7), () => {
         const x = rootAddon[key];
       });
-      setters.add(`${key} setter`, () => {
+      setters.add(`${key} setter`.padStart(maxNameLength + 7), () => {
         rootAddon[key] = 5;
       })
     });
@@ -22,6 +28,8 @@ const addonName = path.basename(__filename, '.js');
     getters
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
+
+    console.log('');
 
     setters
       .on('cycle', (event) => console.log(String(event.target)))

--- a/doc/addon.md
+++ b/doc/addon.md
@@ -1,0 +1,518 @@
+# Add-on Structure
+
+Creating add-ons that work correctly when loaded multiple times from the same
+source package into multiple Node.js threads and/or multiple times into the same
+Node.js thread requires that all global data they hold be associated with the
+environment in which they run. It is not safe to store global data in static
+variables because doing so does not take into account the fact that an add-on
+may be loaded into multiple threads nor that an add-on may be loaded multiple
+times into a single thread.
+
+The `Napi::Addon` class can be used to define an entire add-on. Instances of
+`Napi::Addon` subclasses become instances of the add-on, stored safely by
+Node.js on its various threads and into its various contexts. Thus, any data
+stored in the instance variables of a `Napi::Addon` subclass instance are stored
+safely by Node.js. Functions exposed to JavaScript using
+`Napi::Addon::InstanceMethod` and/or `Napi::Addon::DefineAddon` are instance
+methods of the `Napi::Addon` subclass and thus have access to data stored inside
+the instance.
+
+`Napi::Addon::DefineProperties` may be used to attach `Napi::Addon` subclass
+instance methods to objects other than the one that will be returned to Node.js
+as the add-on instance.
+
+The `Napi::Addon` class can be used together with the `NODE_API_ADDON()` and
+`NODE_API_NAMED_ADDON()` macros to define add-ons.
+
+## Example
+
+```cpp
+#include <napi.h>
+
+class ExampleAddon : public Napi::Addon<ExampleAddon> {
+ public:
+  ExampleAddon(Napi::Env env, Napi::Object exports) {
+    // In the constructor we declare the functions the add-on makes avaialable
+    // to JavaScript.
+    DefineAddon(exports, {
+      InstanceMethod("increment", &ExampleAddon::Increment),
+
+      // We can also attach plain objects to `exports`, and instance methods as
+      // properties of those sub-objects.
+      InstanceValue("subObject", DefineProperties(Napi::Object::New(), {
+        InstanceMethod("decrement", &ExampleAddon::Decrement
+      })), napi_enumerable)
+    });
+  }
+ private:
+
+  // This method has access to the data stored in the environment because it is
+  // an instance method of `ExampleAddon` and because it was listed among the
+  // property descriptors passed to `DefineAddon()` in the constructor.
+  Napi::Value Increment(const Napi::CallbackInfo& info) {
+    return Napi::Number::New(info.Env(), ++value);
+  }
+
+  // This method has access to the data stored in the environment because it is
+  // an instance method of `ExampleAddon` and because it was exposed to
+  // JavaScript by calling `DefineProperties()` with the object onto which it is
+  // attached.
+  Napi::Value Decrement(const Napi::CallbackInfo& info) {
+    return Napi::Number::New(info.Env(), --value);
+  }
+
+  // Data stored in these variables is unique to each instance of the add-on.
+  uint32_t value = 42;
+};
+
+// The macro announces that instances of the class `ExampleAddon` will be
+// created for each instance of the add-on that must be loaded into Node.js.
+NODE_API_ADDON(ExampleAddon)
+```
+
+The above code can be used from JavaScript as follows:
+
+```js
+'use strict'
+
+const exampleAddon = require('bindings')('example_addon');
+console.log(exampleAddon.increment()); // prints 43
+console.log(exampleAddon.increment()); // prints 44
+consnole.log(exampleAddon.subObject.decrement()); // prints 43
+```
+
+When Node.js loads an instance of the add-on, a new instance of the class is
+created. Its constructor receives the environment `Napi::Env env` and the
+exports object `Napi::Object exports`. It can then use the method `DefineAddon`
+to either attach methods, accessors, and/or values to the `exports` object or to
+create its own `exports` object and attach methods, accessors, and/or values to
+it.
+
+Functions created with `Napi::Function::New()`, accessors created with
+`PropertyDescriptor::Accessor()`, and values can also be attached. If their
+implementation requires the `ExampleAddon` instance, it can be retrieved from
+the `Napi::Env env` with `GetInstanceData()`:
+
+```cpp
+void ExampleBinding(const Napi::CallbackInfo& info) {
+  ExampleAddon* addon = info.Env().GetInstanceData<ExampleAddon>();
+}
+```
+
+## Methods
+
+### Constructor
+
+Creates a new instance of the add-on.
+
+```cpp
+Napi::Addon(Napi::Env env, Napi::Object exports);
+```
+
+- `[in] env`: The environment into which the add-on is being loaded.
+- `[in] exports`: The exports object received from JavaScript.
+
+Typically, the constructor calls `DefineAddon()` to attach methods, accessors,
+and/or values to `exports`. The constructor may also create a new object and
+pass it to `DefineAddon()` as its first parameter if it wishes to replace the
+`exports` object as provided by Node.js.
+
+### DefineAddon
+
+Defines an add-on instance with functions, accessors, and/or values.
+
+```cpp
+void Napi::Addon::DefineAddon(Napi::Object exports,
+                   const std::initializer_list<PropertyDescriptor>& properties);
+```
+
+* `[in] exports`: The object to return to Node.js as an instance of the add-on.
+* `[in] properties`: Initializer list of add-on property descriptors of the
+methods, property accessors, and values that define the add-on. They will be
+set on `exports`.
+See: [`Class property and descriptor`](class_property_descriptor.md).
+
+### DefineProperties
+
+Defines function, accessor, and/or value properties on an object using add-on
+instance methods.
+
+```cpp
+Napi::Object
+Napi::Addon::DefineProperties(Napi::Object object,
+                   const std::initializer_list<PropertyDescriptor>& properties);
+```
+
+* `[in] object`: The object that will receive the new properties.
+* `[in] properties`: Initializer list of property descriptors of the methods,
+property accessors, and values to attach to `object`.
+See: [`Class property and descriptor`](class_property_descriptor.md).
+
+Returns `object`.
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(const char* utf8name,
+                            InstanceVoidMethodCallback method,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+void MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(const char* utf8name,
+                            InstanceMethodCallback method,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+Napi::Value MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(Napi::Symbol name,
+                            InstanceVoidMethodCallback method,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] name`: JavaScript symbol that represents the name of the method provided
+by the add-on.
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+void MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(Napi::Symbol name,
+                            InstanceMethodCallback method,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] name`: JavaScript symbol that represents the name of the method provided
+by the add-on.
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+Napi::Value MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+template <InstanceVoidMethodCallback method>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(const char* utf8name,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+void MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+template <InstanceMethodCallback method>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(const char* utf8name,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+Napi::Value MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+template <InstanceVoidMethodCallback method>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(Napi::Symbol name,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] name`: The `Napi::Symbol` object whose value is used to identify the
+instance method for the class.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+void MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceMethod
+
+Creates a property descriptor that represents a method provided by the add-on.
+
+```cpp
+template <InstanceMethodCallback method>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceMethod(Napi::Symbol name,
+                            napi_property_attributes attributes = napi_default,
+                            void* data = nullptr);
+```
+
+- `[in] method`: The native function that represents a method provided by the
+add-on.
+- `[in] name`: The `Napi::Symbol` object whose value is used to identify the
+instance method for the class.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the method when it is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents a method provided
+by the add-on. The method must be of the form
+
+```cpp
+Napi::Value MethodName(const Napi::CallbackInfo& info);
+```
+
+### InstanceAccessor
+
+Creates a property descriptor that represents an instance accessor property
+provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceAccessor(const char* utf8name,
+                             InstanceGetterCallback getter,
+                             InstanceSetterCallback setter,
+                             napi_property_attributes attributes = napi_default,
+                             void* data = nullptr);
+```
+
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] getter`: The native function to call when a get access to the property
+is performed.
+- `[in] setter`: The native function to call when a set access to the property
+is performed.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the getter or the setter when it
+is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance accessor
+property provided by the add-on.
+
+### InstanceAccessor
+
+Creates a property descriptor that represents an instance accessor property
+provided by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceAccessor(Symbol name,
+                             InstanceGetterCallback getter,
+                             InstanceSetterCallback setter,
+                             napi_property_attributes attributes = napi_default,
+                             void* data = nullptr);
+```
+
+- `[in] name`: The `Napi::Symbol` object whose value is used to identify the
+instance accessor.
+- `[in] getter`: The native function to call when a get access to the property of
+a JavaScript class is performed.
+- `[in] setter`: The native function to call when a set access to the property of
+a JavaScript class is performed.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the getter or the setter when it
+is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance accessor
+property provided by the add-on.
+
+### InstanceAccessor
+
+Creates a property descriptor that represents an instance accessor property
+provided by the add-on.
+
+```cpp
+template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceAccessor(const char* utf8name,
+                             napi_property_attributes attributes = napi_default,
+                             void* data = nullptr);
+```
+
+- `[in] getter`: The native function to call when a get access to the property of
+a JavaScript class is performed.
+- `[in] setter`: The native function to call when a set access to the property of
+a JavaScript class is performed.
+- `[in] utf8name`: Null-terminated string that represents the name of the method
+provided by the add-on.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the getter or the setter when it
+is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance accessor
+property provided by the add-on.
+
+### InstanceAccessor
+
+Creates a property descriptor that represents an instance accessor property
+provided by the add-on.
+
+```cpp
+template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceAccessor(Symbol name,
+                             napi_property_attributes attributes = napi_default,
+                             void* data = nullptr);
+```
+
+- `[in] getter`: The native function to call when a get access to the property of
+a JavaScript class is performed.
+- `[in] setter`: The native function to call when a set access to the property of
+a JavaScript class is performed.
+- `[in] name`: The `Napi::Symbol` object whose value is used to identify the
+instance accessor.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+- `[in] data`: User-provided data passed into the getter or the setter when it
+is invoked.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance accessor
+property provided by the add-on.
+
+### InstanceValue
+
+Creates property descriptor that represents an instance value property provided
+by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceValue(const char* utf8name,
+                           Napi::Value value,
+                           napi_property_attributes attributes = napi_default);
+```
+
+- `[in] utf8name`: Null-terminated string that represents the name of the property.
+- `[in] value`: The value that's retrieved by a get access of the property.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance value
+property of an add-on.
+
+### InstanceValue
+
+Creates property descriptor that represents an instance value property provided
+by the add-on.
+
+```cpp
+static Napi::PropertyDescriptor
+Napi::Addon::InstanceValue(Symbol name,
+                           Napi::Value value,
+                           napi_property_attributes attributes = napi_default);
+```
+
+- `[in] name`: The `Napi::Symbol` object whose value is used to identify the
+name of the property.
+- `[in] value`: The value that's retrieved by a get access of the property.
+- `[in] attributes`: The attributes associated with the property. One or more of
+`napi_property_attributes`.
+
+Returns a `Napi::PropertyDescriptor` object that represents an instance value
+property of an add-on.

--- a/napi.h
+++ b/napi.h
@@ -1647,6 +1647,122 @@ namespace Napi {
     napi_property_descriptor _desc;
   };
 
+  template <typename T, typename TCallback>
+  struct MethodCallbackData {
+    TCallback callback;
+    void* data;
+  };
+
+  template <typename T, typename TGetterCallback, typename TSetterCallback>
+  struct AccessorCallbackData {
+    TGetterCallback getterCallback;
+    TSetterCallback setterCallback;
+    void* data;
+  };
+
+  template <typename T>
+  class InstanceWrap {
+   public:
+
+    typedef void (T::*InstanceVoidMethodCallback)(const CallbackInfo& info);
+    typedef Napi::Value (T::*InstanceMethodCallback)(const CallbackInfo& info);
+    typedef Napi::Value (T::*InstanceGetterCallback)(const CallbackInfo& info);
+    typedef void (T::*InstanceSetterCallback)(const CallbackInfo& info, const Napi::Value& value);
+
+    typedef ClassPropertyDescriptor<T> PropertyDescriptor;
+
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             InstanceVoidMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             InstanceMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(Symbol name,
+                                             InstanceVoidMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceMethod(Symbol name,
+                                             InstanceMethodCallback method,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    template <InstanceVoidMethodCallback method>
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    template <InstanceMethodCallback method>
+    static PropertyDescriptor InstanceMethod(const char* utf8name,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    template <InstanceVoidMethodCallback method>
+    static PropertyDescriptor InstanceMethod(Symbol name,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    template <InstanceMethodCallback method>
+    static PropertyDescriptor InstanceMethod(Symbol name,
+                                             napi_property_attributes attributes = napi_default,
+                                             void* data = nullptr);
+    static PropertyDescriptor InstanceAccessor(const char* utf8name,
+                                               InstanceGetterCallback getter,
+                                               InstanceSetterCallback setter,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
+    static PropertyDescriptor InstanceAccessor(Symbol name,
+                                               InstanceGetterCallback getter,
+                                               InstanceSetterCallback setter,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
+    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
+    static PropertyDescriptor InstanceAccessor(const char* utf8name,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
+    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
+    static PropertyDescriptor InstanceAccessor(Symbol name,
+                                               napi_property_attributes attributes = napi_default,
+                                               void* data = nullptr);
+    static PropertyDescriptor InstanceValue(const char* utf8name,
+                                            Napi::Value value,
+                                            napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor InstanceValue(Symbol name,
+                                            Napi::Value value,
+                                            napi_property_attributes attributes = napi_default);
+
+   protected:
+    static void AttachPropData(napi_env env, napi_value value, const napi_property_descriptor* prop);
+
+   private:
+    using This = InstanceWrap<T>;
+
+    typedef MethodCallbackData<T, InstanceVoidMethodCallback> InstanceVoidMethodCallbackData;
+    typedef MethodCallbackData<T, InstanceMethodCallback> InstanceMethodCallbackData;
+    typedef AccessorCallbackData<T,
+                                 InstanceGetterCallback,
+                                 InstanceSetterCallback> InstanceAccessorCallbackData;
+
+    static napi_value InstanceVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static napi_value InstanceMethodCallbackWrapper(napi_env env, napi_callback_info info);
+    static napi_value InstanceGetterCallbackWrapper(napi_env env, napi_callback_info info);
+    static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
+
+    template <InstanceSetterCallback method>
+    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+
+    template <InstanceGetterCallback getter> struct GetterTag {};
+    template <InstanceSetterCallback setter> struct SetterTag {};
+
+    template <InstanceVoidMethodCallback method>
+    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    template <InstanceMethodCallback method>
+    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    template <InstanceGetterCallback getter>
+    static napi_callback WrapGetter(GetterTag<getter>) noexcept { return &This::WrappedMethod<getter>; }
+    static napi_callback WrapGetter(GetterTag<nullptr>) noexcept { return nullptr; }
+    template <InstanceSetterCallback setter>
+    static napi_callback WrapSetter(SetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
+    static napi_callback WrapSetter(SetterTag<nullptr>) noexcept { return nullptr; }
+  };
+
   /// Base class to be extended by C++ classes exposed to JavaScript; each C++ class instance gets
   /// "wrapped" by a JavaScript object that is managed by this class.
   ///
@@ -1673,7 +1789,7 @@ namespace Napi {
   ///         Napi::Value DoSomething(const Napi::CallbackInfo& info);
   ///     }
   template <typename T>
-  class ObjectWrap : public Reference<Object> {
+  class ObjectWrap : public InstanceWrap<T>, public Reference<Object> {
   public:
     ObjectWrap(const CallbackInfo& callbackInfo);
     virtual ~ObjectWrap();
@@ -1685,10 +1801,6 @@ namespace Napi {
     typedef Napi::Value (*StaticMethodCallback)(const CallbackInfo& info);
     typedef Napi::Value (*StaticGetterCallback)(const CallbackInfo& info);
     typedef void (*StaticSetterCallback)(const CallbackInfo& info, const Napi::Value& value);
-    typedef void (T::*InstanceVoidMethodCallback)(const CallbackInfo& info);
-    typedef Napi::Value (T::*InstanceMethodCallback)(const CallbackInfo& info);
-    typedef Napi::Value (T::*InstanceGetterCallback)(const CallbackInfo& info);
-    typedef void (T::*InstanceSetterCallback)(const CallbackInfo& info, const Napi::Value& value);
 
     typedef ClassPropertyDescriptor<T> PropertyDescriptor;
 
@@ -1750,68 +1862,12 @@ namespace Napi {
     static PropertyDescriptor StaticAccessor(Symbol name,
                                              napi_property_attributes attributes = napi_default,
                                              void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             InstanceVoidMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             InstanceMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             InstanceVoidMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             InstanceMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceVoidMethodCallback method>
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceMethodCallback method>
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceVoidMethodCallback method>
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceMethodCallback method>
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceAccessor(const char* utf8name,
-                                               InstanceGetterCallback getter,
-                                               InstanceSetterCallback setter,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    static PropertyDescriptor InstanceAccessor(Symbol name,
-                                               InstanceGetterCallback getter,
-                                               InstanceSetterCallback setter,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
-    static PropertyDescriptor InstanceAccessor(const char* utf8name,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
-    static PropertyDescriptor InstanceAccessor(Symbol name,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
     static PropertyDescriptor StaticValue(const char* utf8name,
                                           Napi::Value value,
                                           napi_property_attributes attributes = napi_default);
     static PropertyDescriptor StaticValue(Symbol name,
                                           Napi::Value value,
                                           napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor InstanceValue(const char* utf8name,
-                                            Napi::Value value,
-                                            napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor InstanceValue(Symbol name,
-                                            Napi::Value value,
-                                            napi_property_attributes attributes = napi_default);
     virtual void Finalize(Napi::Env env);
 
   private:
@@ -1822,10 +1878,6 @@ namespace Napi {
     static napi_value StaticMethodCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticGetterCallbackWrapper(napi_env env, napi_callback_info info);
     static napi_value StaticSetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceGetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
     static void FinalizeCallback(napi_env env, void* data, void* hint);
     static Function DefineClass(Napi::Env env,
                                 const char* utf8name,
@@ -1833,26 +1885,12 @@ namespace Napi {
                                 const napi_property_descriptor* props,
                                 void* data = nullptr);
 
-    template <typename TCallback>
-    struct MethodCallbackData {
-      TCallback callback;
-      void* data;
-    };
-    typedef MethodCallbackData<StaticVoidMethodCallback> StaticVoidMethodCallbackData;
-    typedef MethodCallbackData<StaticMethodCallback> StaticMethodCallbackData;
-    typedef MethodCallbackData<InstanceVoidMethodCallback> InstanceVoidMethodCallbackData;
-    typedef MethodCallbackData<InstanceMethodCallback> InstanceMethodCallbackData;
+    typedef MethodCallbackData<T, StaticVoidMethodCallback> StaticVoidMethodCallbackData;
+    typedef MethodCallbackData<T, StaticMethodCallback> StaticMethodCallbackData;
 
-    template <typename TGetterCallback, typename TSetterCallback>
-    struct AccessorCallbackData {
-      TGetterCallback getterCallback;
-      TSetterCallback setterCallback;
-      void* data;
-    };
-    typedef AccessorCallbackData<StaticGetterCallback, StaticSetterCallback>
-      StaticAccessorCallbackData;
-    typedef AccessorCallbackData<InstanceGetterCallback, InstanceSetterCallback>
-      InstanceAccessorCallbackData;
+    typedef AccessorCallbackData<T,
+                                 StaticGetterCallback,
+                                 StaticSetterCallback> StaticAccessorCallbackData;
 
     template <StaticVoidMethodCallback method>
     static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
@@ -1860,22 +1898,11 @@ namespace Napi {
     template <StaticMethodCallback method>
     static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
 
-    template <InstanceVoidMethodCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
-
-    template <InstanceMethodCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
-
     template <StaticSetterCallback method>
     static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
 
-    template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
-
-    template <StaticGetterCallback   getter> struct StaticGetterTag {};
-    template <StaticSetterCallback   setter> struct StaticSetterTag {};
-    template <InstanceGetterCallback getter> struct GetterTag {};
-    template <InstanceSetterCallback setter> struct SetterTag {};
+    template <StaticGetterCallback getter> struct StaticGetterTag {};
+    template <StaticSetterCallback setter> struct StaticSetterTag {};
 
     template <StaticGetterCallback getter>
     static napi_callback WrapStaticGetter(StaticGetterTag<getter>) noexcept { return &This::WrappedMethod<getter>; }
@@ -1884,14 +1911,6 @@ namespace Napi {
     template <StaticSetterCallback setter>
     static napi_callback WrapStaticSetter(StaticSetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
     static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) noexcept { return nullptr; }
-
-    template <InstanceGetterCallback getter>
-    static napi_callback WrapGetter(GetterTag<getter>) noexcept { return &This::WrappedMethod<getter>; }
-    static napi_callback WrapGetter(GetterTag<nullptr>) noexcept { return nullptr; }
-
-    template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapSetter(SetterTag<nullptr>) noexcept { return nullptr; }
 
     bool _construction_failed = true;
   };
@@ -2419,6 +2438,25 @@ namespace Napi {
       static uint32_t GetNapiVersion(Env env);
       static const napi_node_version* GetNodeVersion(Env env);
   };
+
+#if NAPI_VERSION > 5
+  template <typename T>
+  class Addon : public InstanceWrap<T> {
+   public:
+    static inline Object Init(Env env, Object exports);
+    static T* Unwrap(Object wrapper);
+
+   protected:
+    typedef ClassPropertyDescriptor<T> AddonProp;
+    void DefineAddon(Object exports,
+                     const std::initializer_list<AddonProp>& props);
+    Napi::Object DefineProperties(Object object,
+                                 const std::initializer_list<AddonProp>& props);
+
+   private:
+    Object entry_point_;
+  };
+#endif  // NAPI_VERSION > 5
 
 } // namespace Napi
 

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
   "description": "Node.js API (N-API)",
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "bindings": "^1.5.0",
     "safe-buffer": "^5.1.1"
   },
   "directories": {},

--- a/test/addon.cc
+++ b/test/addon.cc
@@ -1,0 +1,36 @@
+#if (NAPI_VERSION > 5)
+#include <stdio.h>
+#include "napi.h"
+
+namespace {
+
+class TestAddon : public Napi::Addon<TestAddon> {
+ public:
+  inline TestAddon(Napi::Env env, Napi::Object exports) {
+    DefineAddon(exports, {
+      InstanceMethod("increment", &TestAddon::Increment),
+      InstanceValue("subObject", DefineProperties(Napi::Object::New(env), {
+        InstanceMethod("decrement", &TestAddon::Decrement)
+      }))
+    });
+  }
+
+ private:
+  Napi::Value Increment(const Napi::CallbackInfo& info) {
+    return Napi::Number::New(info.Env(), ++value);
+  }
+
+  Napi::Value Decrement(const Napi::CallbackInfo& info) {
+    return Napi::Number::New(info.Env(), --value);
+  }
+
+  uint32_t value = 42;
+};
+
+}  // end of anonymous namespace
+
+Napi::Object InitAddon(Napi::Env env) {
+  return TestAddon::Init(env, Napi::Object::New(env));
+}
+
+#endif  // (NAPI_VERSION > 5)

--- a/test/addon.js
+++ b/test/addon.js
@@ -1,0 +1,12 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+
+test(require(`./build/${buildType}/binding.node`));
+test(require(`./build/${buildType}/binding_noexcept.node`));
+
+function test(binding) {
+  assert.strictEqual(binding.addon.increment(), 43);
+  assert.strictEqual(binding.addon.increment(), 44);
+  assert.strictEqual(binding.addon.subObject.decrement(), 43);
+}

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -3,6 +3,7 @@
 using namespace Napi;
 
 #if (NAPI_VERSION > 5)
+Object InitAddon(Env env);
 Object InitAddonData(Env env);
 #endif
 Object InitArrayBuffer(Env env);
@@ -61,6 +62,7 @@ Object InitThunkingManual(Env env);
 
 Object Init(Env env, Object exports) {
 #if (NAPI_VERSION > 5)
+  exports.Set("addon", InitAddon(env));
   exports.Set("addon_data", InitAddonData(env));
 #endif
   exports.Set("arraybuffer", InitArrayBuffer(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -2,6 +2,7 @@
   'target_defaults': {
     'includes': ['../common.gypi'],
     'sources': [
+        'addon.cc',
         'addon_data.cc',
         'arraybuffer.cc',
         'asynccontext.cc',

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ process.config.target_defaults.default_configuration =
 // FIXME: We might need a way to load test modules automatically without
 // explicit declaration as follows.
 let testModules = [
+  'addon',
   'addon_data',
   'arraybuffer',
   'asynccontext',
@@ -83,9 +84,10 @@ if (napiVersion < 5) {
 }
 
 if (napiVersion < 6) {
+  testModules.splice(testModules.indexOf('addon'), 1);
+  testModules.splice(testModules.indexOf('addon_data'), 1);
   testModules.splice(testModules.indexOf('bigint'), 1);
   testModules.splice(testModules.indexOf('typedarray-bigint'), 1);
-  testModules.splice(testModules.indexOf('addon_data'), 1);
 }
 
 if (typeof global.gc === 'function') {


### PR DESCRIPTION
* separate out instance-related APIs from `ObjectWrap<T>` into a new
  class `InstanceWrap<T>` which then becomes a base class for
  `ObjectWrap<T>`.
* ~~Expose new `DefineProperties` overload on `Object` which accepts a
  list of `napi_property_descriptor` and implement the other overloads
  as a call to it.~~
* Add `Addon<T>` class as a subclass of `InstanceWrap<T>`.
* Add macros `NODE_API_ADDON()` and `NODE_API_NAMED_ADDON()` to load an
  add-on from its `Addon<T>` subclass definition.

Bindings created like this perform slightly worse than static ones in
exchange for the benefit of having the context of a class instance as
their C++ `this` object. Static bindings can still be created and
associated with the `exports` object and they can use
`Napi::Env::GetInstanceData()` to retrieve the add-on instance.

Edit: I removed the `DefineProperties` overload, opting instead to have `Addon<T>` provide a `DefineProperties` method to its subclasses.