### PR TITLE
Bug fix: ensure include and gyp paths are relative to process working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const path = require('path');
 
+const include = path.relative('.', __dirname);
+
 module.exports = {
-  include: `"${__dirname}"`,
-  gyp: path.join(__dirname, 'node_api.gyp:nothing'),
+  include: include,
+  gyp: path.join(include, 'node_api.gyp:nothing'),
   isNodeApiBuiltin: true,
   needsFlag: false
 };


### PR DESCRIPTION
Hello, modules that depend on `node-addon-api` cannot currently be installed into a parent directory containing whitespace.

To reproduce:
```sh
mkdir "/tmp/fail me"
cd "/tmp/fail me"
npm install --build-from-source --verbose sharp
```
...fails with:
```
g++: error: me/node_modules/node-addon-api: No such file or directory
make: *** [sharp.target.mk:139: Release/obj.target/sharp/src/common.o] Error 1
make: Leaving directory '/tmp/fail me/node_modules/sharp/build'
```

The change in this PR allows the use of parent paths that contain whitespace characters, plus keeps the approach consistent with that previously used and battle-tested by `nan` - see https://github.com/nodejs/nan/blob/master/include_dirs.js

Originally reported at https://github.com/lovell/sharp/issues/2279
