### PR TITLE
test: use async/await for gc

### DIFF
--- a/test/addon_data.js
+++ b/test/addon_data.js
@@ -5,29 +5,37 @@ const { spawn } = require('child_process');
 const readline = require('readline');
 const path = require('path');
 
-test(path.resolve(__dirname, `./build/${buildType}/binding.node`));
-test(path.resolve(__dirname, `./build/${buildType}/binding_noexcept.node`));
+module.exports =
+  test(path.resolve(__dirname, `./build/${buildType}/binding.node`))
+  .then(() =>
+    test(path.resolve(__dirname,
+                      `./build/${buildType}/binding_noexcept.node`)));
 
 // Make sure the instance data finalizer is called at process exit. If the hint
 // is non-zero, it will be printed out by the child process.
 function testFinalizer(bindingName, hint, expected) {
-  bindingName = bindingName.split('\\').join('\\\\');
-  const child = spawn(process.execPath, [
-    '-e',
-    `require('${bindingName}').addon_data(${hint}).verbose = true;`
-  ]);
-  const actual = [];
-  readline
-    .createInterface({ input: child.stderr })
-    .on('line', (line) => {
-      if (expected.indexOf(line) >= 0) {
-        actual.push(line);
-      }
-    })
-    .on('close', () => assert.deepStrictEqual(expected, actual));
+  return new Promise((resolve) => {
+    bindingName = bindingName.split('\\').join('\\\\');
+    const child = spawn(process.execPath, [
+      '-e',
+      `require('${bindingName}').addon_data(${hint}).verbose = true;`
+    ]);
+    const actual = [];
+    readline
+      .createInterface({ input: child.stderr })
+      .on('line', (line) => {
+        if (expected.indexOf(line) >= 0) {
+          actual.push(line);
+        }
+      })
+      .on('close', () => {
+        assert.deepStrictEqual(expected, actual);
+        resolve();
+      });
+  });
 }
 
-function test(bindingName) {
+async function test(bindingName) {
   const binding = require(bindingName).addon_data(0);
 
   // Make sure it is possible to get/set instance data.
@@ -37,6 +45,7 @@ function test(bindingName) {
   binding.verbose = false;
   assert.strictEqual(binding.verbose.verbose, false);
 
-  testFinalizer(bindingName, 0, ['addon_data: Addon::~Addon']);
-  testFinalizer(bindingName, 42, ['addon_data: Addon::~Addon', 'hint: 42']);
+  await testFinalizer(bindingName, 0, ['addon_data: Addon::~Addon']);
+  await testFinalizer(bindingName, 42,
+                      ['addon_data: Addon::~Addon', 'hint: 42']);
 }

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -3,11 +3,11 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  testUtil.runGCTests([
+async function test(binding) {
+  await testUtil.runGCTests([
     'Internal ArrayBuffer',
     () => {
       const test = binding.arraybuffer.createBuffer();
@@ -25,10 +25,8 @@ function test(binding) {
       assert.ok(test instanceof ArrayBuffer);
       assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
     },
-    () => {
-      global.gc();
-      assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
-    },
+
+    () => assert.strictEqual(0, binding.arraybuffer.getFinalizeCount()),
 
     'External ArrayBuffer with finalizer',
     () => {
@@ -37,12 +35,8 @@ function test(binding) {
       assert.ok(test instanceof ArrayBuffer);
       assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
     },
-    () => {
-      global.gc();
-    },
-    () => {
-      assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
-    },
+
+    () => assert.strictEqual(1, binding.arraybuffer.getFinalizeCount()),
 
     'External ArrayBuffer with finalizer hint',
     () => {
@@ -51,12 +45,8 @@ function test(binding) {
       assert.ok(test instanceof ArrayBuffer);
       assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
     },
-    () => {
-      global.gc();
-    },
-    () => {
-      assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
-    },
+
+    () => assert.strictEqual(1, binding.arraybuffer.getFinalizeCount()),
 
     'ArrayBuffer with constructor',
     () => {

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -6,8 +6,8 @@ const testUtil = require('./testUtil');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'Internal ArrayBuffer',
     () => {
       const test = binding.arraybuffer.createBuffer();

--- a/test/asyncprogressqueueworker.cc
+++ b/test/asyncprogressqueueworker.cc
@@ -37,14 +37,6 @@ public:
     worker->Queue();
   }
 
-  static void CancelWork(const CallbackInfo& info) {
-    auto wrap = info[0].As<Napi::External<TestWorker>>();
-    auto worker = wrap.Data();
-    // We cannot cancel a worker if it got started. So we have to do a quick cancel.
-    worker->Queue();
-    worker->Cancel();
-  }
-
 protected:
   void Execute(const ExecutionProgress& progress) override {
     using namespace std::chrono_literals;
@@ -89,7 +81,6 @@ Object InitAsyncProgressQueueWorker(Env env) {
   Object exports = Object::New(env);
   exports["createWork"] = Function::New(env, TestWorker::CreateWork);
   exports["queueWork"] = Function::New(env, TestWorker::QueueWork);
-  exports["cancelWork"] = Function::New(env, TestWorker::CancelWork);
   return exports;
 }
 

--- a/test/asyncprogressqueueworker.js
+++ b/test/asyncprogressqueueworker.js
@@ -10,7 +10,6 @@ module.exports = test(require(`./build/${buildType}/binding.node`))
 async function test({ asyncprogressqueueworker }) {
   await success(asyncprogressqueueworker);
   await fail(asyncprogressqueueworker);
-  await cancel(asyncprogressqueueworker);
 }
 
 function success(binding) {
@@ -45,26 +44,5 @@ function fail(binding) {
       common.mustNotCall()
     );
     binding.queueWork(worker);
-  });
-}
-
-function cancel(binding) {
-  return new Promise((resolve, reject) => {
-    // make sure the work we are going to cancel will not be
-    // able to start by using all the threads in the pool.
-    for (let i = 0; i < os.cpus().length; ++i) {
-      const worker = binding.createWork(-1, () => {}, () => {});
-      binding.queueWork(worker);
-    }
-    const worker = binding.createWork(-1,
-      () => {
-        assert.fail('unexpected callback');
-      },
-      () => {
-        assert.fail('unexpected progress report');
-      }
-    );
-    binding.cancelWork(worker);
-    resolve();
   });
 }

--- a/test/asyncprogressqueueworker.js
+++ b/test/asyncprogressqueueworker.js
@@ -4,60 +4,67 @@ const common = require('./common')
 const assert = require('assert');
 const os = require('os');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test({ asyncprogressqueueworker }) {
-  success(asyncprogressqueueworker);
-  fail(asyncprogressqueueworker);
-  cancel(asyncprogressqueueworker);
-  return;
+async function test({ asyncprogressqueueworker }) {
+  await success(asyncprogressqueueworker);
+  await fail(asyncprogressqueueworker);
+  await cancel(asyncprogressqueueworker);
 }
 
 function success(binding) {
-  const expected = [0, 1, 2, 3];
-  const actual = [];
-  const worker = binding.createWork(expected.length,
-    common.mustCall((err) => {
-      if (err) {
-        assert.fail(err);
-      }
-      // All queued items shall be invoked before complete callback.
-      assert.deepEqual(actual, expected);
-    }),
-    common.mustCall((_progress) => {
-      actual.push(_progress);
-    }, expected.length)
-  );
-  binding.queueWork(worker);
+  return new Promise((resolve, reject) => {
+    const expected = [0, 1, 2, 3];
+    const actual = [];
+    const worker = binding.createWork(expected.length,
+      common.mustCall((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          // All queued items shall be invoked before complete callback.
+          assert.deepEqual(actual, expected);
+          resolve();
+        }
+      }),
+      common.mustCall((_progress) => {
+        actual.push(_progress);
+      }, expected.length)
+    );
+    binding.queueWork(worker);
+  });
 }
 
 function fail(binding) {
-  const worker = binding.createWork(-1,
-    common.mustCall((err) => {
-      assert.throws(() => { throw err }, /test error/)
-    }),
-    () => {
-      assert.fail('unexpected progress report');
-    }
-  );
-  binding.queueWork(worker);
+  return new Promise((resolve, reject) => {
+    const worker = binding.createWork(-1,
+      common.mustCall((err) => {
+        assert.throws(() => { throw err }, /test error/);
+        resolve();
+      }),
+      common.mustNotCall()
+    );
+    binding.queueWork(worker);
+  });
 }
 
 function cancel(binding) {
-  // make sure the work we are going to cancel will not be
-  // able to start by using all the threads in the pool.
-  for (let i = 0; i < os.cpus().length; ++i) {
-    const worker = binding.createWork(-1, () => {}, () => {});
-    binding.queueWork(worker);
-  }
-  const worker = binding.createWork(-1,
-    () => {
-      assert.fail('unexpected callback');
-    },
-    () => {
-      assert.fail('unexpected progress report');
+  return new Promise((resolve, reject) => {
+    // make sure the work we are going to cancel will not be
+    // able to start by using all the threads in the pool.
+    for (let i = 0; i < os.cpus().length; ++i) {
+      const worker = binding.createWork(-1, () => {}, () => {});
+      binding.queueWork(worker);
     }
-  );
-  binding.cancelWork(worker);
+    const worker = binding.createWork(-1,
+      () => {
+        assert.fail('unexpected callback');
+      },
+      () => {
+        assert.fail('unexpected progress report');
+      }
+    );
+    binding.cancelWork(worker);
+    resolve();
+  });
 }

--- a/test/asyncprogressworker.js
+++ b/test/asyncprogressworker.js
@@ -33,7 +33,7 @@ function success(binding) {
 }
 
 function fail(binding) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     binding.doWork(-1,
       common.mustCall((err) => {
         assert.throws(() => { throw err }, /test error/)

--- a/test/asyncprogressworker.js
+++ b/test/asyncprogressworker.js
@@ -3,40 +3,43 @@ const buildType = process.config.target_defaults.default_configuration;
 const common = require('./common')
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test({ asyncprogressworker }) {
-  success(asyncprogressworker);
-  fail(asyncprogressworker);
-  return;
+async function test({ asyncprogressworker }) {
+  await success(asyncprogressworker);
+  await fail(asyncprogressworker);
 }
 
 function success(binding) {
-  const expected = [0, 1, 2, 3];
-  const actual = [];
-  binding.doWork(expected.length,
-    common.mustCall((err) => {
-      if (err) {
-        assert.fail(err);
-      }
-    }),
-    common.mustCall((_progress) => {
-      actual.push(_progress);
-      if (actual.length === expected.length) {
-        assert.deepEqual(actual, expected);
-      }
-    }, expected.length)
-  );
+  return new Promise((resolve, reject) => {
+    const expected = [0, 1, 2, 3];
+    const actual = [];
+    binding.doWork(expected.length,
+      common.mustCall((err) => {
+        if (err) {
+          reject(err);
+        }
+      }),
+      common.mustCall((_progress) => {
+        actual.push(_progress);
+        if (actual.length === expected.length) {
+          assert.deepEqual(actual, expected);
+          resolve();
+        }
+      }, expected.length)
+    );
+  });
 }
 
 function fail(binding) {
-  binding.doWork(-1,
-    common.mustCall((err) => {
-      assert.throws(() => { throw err }, /test error/)
-    }),
-    () => {
-      assert.fail('unexpected progress report');
-    }
-  );
+  return new Promise((resolve, reject) => {
+    binding.doWork(-1,
+      common.mustCall((err) => {
+        assert.throws(() => { throw err }, /test error/)
+        resolve();
+      }),
+      common.mustNotCall()
+    );
+  });
 }

--- a/test/asyncworker-nocallback.js
+++ b/test/asyncworker-nocallback.js
@@ -2,14 +2,13 @@
 const buildType = process.config.target_defaults.default_configuration;
 const common = require('./common');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  const resolving = binding.asyncworker.doWorkNoCallback(true, {});
-  resolving.then(common.mustCall()).catch(common.mustNotCall());
+async function test(binding) {
+  await binding.asyncworker.doWorkNoCallback(true, {})
+    .then(common.mustCall()).catch(common.mustNotCall());
 
-  const rejecting = binding.asyncworker.doWorkNoCallback(false, {});
-  rejecting.then(common.mustNotCall()).catch(common.mustCall());
-  return;
+  await binding.asyncworker.doWorkNoCallback(false, {})
+    .then(common.mustNotCall()).catch(common.mustCall());
 }

--- a/test/asyncworker-persistent.js
+++ b/test/asyncworker-persistent.js
@@ -21,7 +21,7 @@ function test(binding, succeed) {
     }));
 }
 
-test(binding.persistentasyncworker, false)
+module.exports = test(binding.persistentasyncworker, false)
   .then(() => test(binding.persistentasyncworker, true))
   .then(() => test(noexceptBinding.persistentasyncworker, false))
   .then(() => test(noexceptBinding.persistentasyncworker, true));

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 const testUtil = require('./testUtil');
 const safeBuffer = require('safe-buffer');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  testUtil.runGCTests([
+async function test(binding) {
+  await testUtil.runGCTests([
     'Internal Buffer',
     () => {
       const test = binding.buffer.createBuffer();

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -7,8 +7,8 @@ const safeBuffer = require('safe-buffer');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'Internal Buffer',
     () => {
       const test = binding.buffer.createBuffer();

--- a/test/external.js
+++ b/test/external.js
@@ -3,11 +3,11 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  testUtil.runGCTests([
+async function test(binding) {
+  await testUtil.runGCTests([
     'External without finalizer',
     () => {
       const test = binding.external.createExternal();

--- a/test/external.js
+++ b/test/external.js
@@ -6,8 +6,8 @@ const testUtil = require('./testUtil');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'External without finalizer',
     () => {
       const test = binding.external.createExternal();

--- a/test/index.js
+++ b/test/index.js
@@ -91,17 +91,21 @@ if (napiVersion < 6) {
 }
 
 if (typeof global.gc === 'function') {
+  (async function() {
   console.log(`Testing with N-API Version '${napiVersion}'.`);
 
   console.log('Starting test suite\n');
 
   // Requiring each module runs tests in the module.
-  testModules.forEach(name => {
+  for (const name of testModules) {
     console.log(`Running test '${name}'`);
-    require('./' + name);
-  });
+    await require('./' + name);
+  };
 
   console.log('\nAll tests passed!');
+  })().catch((error) => {
+    console.log(error);
+  });
 } else {
   // Construct the correct (version-dependent) command-line args.
   let args = ['--expose-gc', '--no-concurrent-array-buffer-freeing'];

--- a/test/index.js
+++ b/test/index.js
@@ -105,6 +105,7 @@ if (typeof global.gc === 'function') {
   console.log('\nAll tests passed!');
   })().catch((error) => {
     console.log(error);
+    process.exit(1);
   });
 } else {
   // Construct the correct (version-dependent) command-line args.

--- a/test/object/finalizer.js
+++ b/test/object/finalizer.js
@@ -2,20 +2,32 @@
 
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
+const testUtil = require('../testUtil');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`../build/${buildType}/binding.node`))
+  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
 
 function createWeakRef(binding, bindingToTest) {
   return binding.object[bindingToTest]({});
 }
 
-function test(binding) {
-  const obj1 = createWeakRef(binding, 'addFinalizer');
-  global.gc();
-  assert.deepStrictEqual(obj1, { finalizerCalled: true });
-
-  const obj2 = createWeakRef(binding, 'addFinalizerWithHint');
-  global.gc();
-  assert.deepStrictEqual(obj2, { finalizerCalledWithCorrectHint: true });
+async function test(binding) {
+  let obj1;
+  let obj2;
+  await testUtil.runGCTests([
+    'addFinalizer',
+    () => {
+      obj1 = createWeakRef(binding, 'addFinalizer');
+    },
+    () => {
+      assert.deepStrictEqual(obj1, { finalizerCalled: true });
+    },
+    'addFinalizerWithHint',
+    () => {
+      obj2 = createWeakRef(binding, 'addFinalizerWithHint');
+    },
+    () => {
+      assert.deepStrictEqual(obj2, { finalizerCalledWithCorrectHint: true });
+    }
+  ]);
 }

--- a/test/object/finalizer.js
+++ b/test/object/finalizer.js
@@ -11,23 +11,20 @@ function createWeakRef(binding, bindingToTest) {
   return binding.object[bindingToTest]({});
 }
 
-async function test(binding) {
+function test(binding) {
   let obj1;
   let obj2;
-  await testUtil.runGCTests([
+  return testUtil.runGCTests([
     'addFinalizer',
     () => {
       obj1 = createWeakRef(binding, 'addFinalizer');
     },
-    () => {
-      assert.deepStrictEqual(obj1, { finalizerCalled: true });
-    },
+    () => assert.deepStrictEqual(obj1, { finalizerCalled: true }),
+
     'addFinalizerWithHint',
     () => {
       obj2 = createWeakRef(binding, 'addFinalizerWithHint');
     },
-    () => {
-      assert.deepStrictEqual(obj2, { finalizerCalledWithCorrectHint: true });
-    }
+    () => assert.deepStrictEqual(obj2, { finalizerCalledWithCorrectHint: true })
   ]);
 }

--- a/test/objectreference.js
+++ b/test/objectreference.js
@@ -17,7 +17,7 @@ const testUtil = require('./testUtil');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
+function test(binding) {
   function testCastedEqual(testToCompare) {
     var compare_test = ["hello", "world", "!"];
     if (testToCompare instanceof Array) {
@@ -29,7 +29,7 @@ async function test(binding) {
     }
   }
 
-  await testUtil.runGCTests([
+  return testUtil.runGCTests([
     'Weak Casted Array',
     () => {
       binding.objectreference.setCastedObjects();

--- a/test/objectreference.js
+++ b/test/objectreference.js
@@ -14,10 +14,10 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
+async function test(binding) {
   function testCastedEqual(testToCompare) {
     var compare_test = ["hello", "world", "!"];
     if (testToCompare instanceof Array) {
@@ -29,7 +29,7 @@ function test(binding) {
     }
   }
 
-  testUtil.runGCTests([
+  await testUtil.runGCTests([
     'Weak Casted Array',
     () => {
       binding.objectreference.setCastedObjects();

--- a/test/objectwrap-removewrap.js
+++ b/test/objectwrap-removewrap.js
@@ -10,8 +10,8 @@ const assert = require('assert');
 const { spawnSync } = require('child_process');
 const testUtil = require('./testUtil');
 
-async function test(bindingName) {
-  await testUtil.runGCTests([
+function test(bindingName) {
+  return testUtil.runGCTests([
     'objectwrap removewrap test',
     () => {
       const binding = require(bindingName);

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -3,8 +3,8 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'objectwrap constructor exception',
     () => {
       const { ConstructorExceptionTest } = binding.objectwrapConstructorException;

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -1,12 +1,19 @@
 'use strict';
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
+const testUtil = require('./testUtil');
 
-const test = (binding) => {
-  const { ConstructorExceptionTest } = binding.objectwrapConstructorException;
-  assert.throws(() => (new ConstructorExceptionTest()), /an exception/);
-  global.gc();
+async function test(binding) {
+  await testUtil.runGCTests([
+    'objectwrap constructor exception',
+    () => {
+      const { ConstructorExceptionTest } = binding.objectwrapConstructorException;
+      assert.throws(() => (new ConstructorExceptionTest()), /an exception/);
+    },
+    // Do on gc before returning.
+    () => {}
+  ]);
 }
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));

--- a/test/promise.js
+++ b/test/promise.js
@@ -3,17 +3,17 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const common = require('./common');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
+async function test(binding) {
   assert.strictEqual(binding.promise.isPromise({}), false);
 
   const resolving = binding.promise.resolvePromise('resolved');
-  assert.strictEqual(binding.promise.isPromise(resolving), true);
+  await assert.strictEqual(binding.promise.isPromise(resolving), true);
   resolving.then(common.mustCall()).catch(common.mustNotCall());
 
   const rejecting = binding.promise.rejectPromise('error');
-  assert.strictEqual(binding.promise.isPromise(rejecting), true);
+  await assert.strictEqual(binding.promise.isPromise(rejecting), true);
   rejecting.then(common.mustNotCall()).catch(common.mustCall());
 }

--- a/test/reference.js
+++ b/test/reference.js
@@ -5,11 +5,13 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  binding.reference.createWeakArray();
-  global.gc();
-  assert.strictEqual(true, binding.reference.accessWeakArrayEmpty());
+async function test(binding) {
+  await testUtil.runGCTests([
+    'test reference',
+    () => binding.reference.createWeakArray(),
+    () => assert.strictEqual(true, binding.reference.accessWeakArrayEmpty())
+  ]);
 };

--- a/test/reference.js
+++ b/test/reference.js
@@ -8,8 +8,8 @@ const testUtil = require('./testUtil');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'test reference',
     () => binding.reference.createWeakArray(),
     () => assert.strictEqual(true, binding.reference.accessWeakArrayEmpty())

--- a/test/run_script.js
+++ b/test/run_script.js
@@ -3,11 +3,11 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-function test(binding) {
-  testUtil.runGCTests([
+async function test(binding) {
+  await testUtil.runGCTests([
     'Plain C string',
     () => {
       const sum = binding.run_script.plainString();

--- a/test/run_script.js
+++ b/test/run_script.js
@@ -6,8 +6,8 @@ const testUtil = require('./testUtil');
 module.exports = test(require(`./build/${buildType}/binding.node`))
   .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
 
-async function test(binding) {
-  await testUtil.runGCTests([
+function test(binding) {
+  return testUtil.runGCTests([
     'Plain C string',
     () => {
       const sum = binding.run_script.plainString();

--- a/test/testUtil.js
+++ b/test/testUtil.js
@@ -1,38 +1,51 @@
 // Run each test function in sequence,
 // with an async delay and GC call between each.
 
-function tick(x, cb) {
-  function ontick() {
-    if (--x === 0) {
-      if (typeof cb === 'function') cb();
-    } else {
-      setImmediate(ontick);
-    }
-  }
-  setImmediate(ontick);
+function tick(x) {
+  return new Promise((resolve) => {
+    setImmediate(function ontick() {
+      if (--x === 0) {
+        resolve();
+      } else {
+        setImmediate(ontick);
+      }
+    });
+  });
 };
 
-function runGCTests(tests, i, title) {
-  if (!i) {
-    i = 0;
+async function runGCTests(tests) {
+  // Break up test list into a list of lists of the form
+  // [ [ 'test name', function() {}, ... ], ..., ].
+  const testList = [];
+  let currentTest;
+  for (const item of tests) {
+    if (typeof item === 'string') {
+      currentTest = [];
+      testList.push(currentTest);
+    }
+    currentTest.push(item);
   }
 
-  if (tests[i]) {
-    if (typeof tests[i] === 'string') {
-      title = tests[i];
-      runGCTests(tests, i + 1, title);
-    } else {
-      try {
-        tests[i]();
-      } catch (e) {
-        console.error('Test failed: ' + title);
-        throw e;
+  for (const test of testList) {
+    await (async function(test) {
+      let title;
+      for (let i = 0; i < test.length; i++) {
+        if (i === 0) {
+          title = test[i];
+        } else {
+          try {
+            test[i]();
+          } catch (e) {
+            console.error('Test failed: ' + title);
+            throw e;
+          }
+          if (i < tests.length - 1) {
+            global.gc();
+            await tick(10);
+          }
+        }
       }
-      setImmediate(() => {
-        global.gc();
-        tick(10, runGCTests(tests, i + 1, title));
-      });
-    }
+    })(test);
   }
 }
 

--- a/test/threadsafe_function/threadsafe_function.js
+++ b/test/threadsafe_function/threadsafe_function.js
@@ -4,8 +4,8 @@ const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const common = require('../common');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = test(require(`../build/${buildType}/binding.node`))
+  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
 
 function test(binding) {
   const expectedArray = (function(arrayLength) {
@@ -43,7 +43,7 @@ function test(binding) {
     });
   }
 
-  new Promise(function testWithoutJSMarshaller(resolve) {
+  return new Promise(function testWithoutJSMarshaller(resolve) {
     let callCount = 0;
     binding.threadsafe_function.startThreadNoNative(function testCallback() {
       callCount++;

--- a/test/threadsafe_function/threadsafe_function_ctx.js
+++ b/test/threadsafe_function/threadsafe_function_ctx.js
@@ -3,10 +3,8 @@
 const assert = require('assert');
 const buildType = process.config.target_defaults.default_configuration;
 
-module.exports = Promise.all[
-  test(require(`../build/${buildType}/binding.node`)),
-  test(require(`../build/${buildType}/binding_noexcept.node`))
-];
+module.exports = test(require(`../build/${buildType}/binding.node`))
+  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
 
 async function test(binding) {
   const ctx = { };

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.js
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.js
@@ -4,10 +4,8 @@ const assert = require('assert');
 
 const buildType = process.config.target_defaults.default_configuration;
 
-module.exports = Promise.all([
-  test(require(`../build/${buildType}/binding.node`)),
-  test(require(`../build/${buildType}/binding_noexcept.node`))
-]);
+module.exports = test(require(`../build/${buildType}/binding.node`))
+  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
 
 async function test(binding) {
   const testCall = binding.threadsafe_function_existing_tsfn.testCall;

--- a/test/threadsafe_function/threadsafe_function_sum.js
+++ b/test/threadsafe_function/threadsafe_function_sum.js
@@ -29,10 +29,8 @@ const buildType = process.config.target_defaults.default_configuration;
 const THREAD_COUNT = 5;
 const EXPECTED_SUM = (THREAD_COUNT - 1) * (THREAD_COUNT) / 2;
 
-module.exports = Promise.all([
-  test(require(`../build/${buildType}/binding.node`)),
-  test(require(`../build/${buildType}/binding_noexcept.node`))
-]);
+module.exports = test(require(`../build/${buildType}/binding.node`))
+  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
 
 /** @param {number[]} N */
 const sum = (N) => N.reduce((sum, n) => sum + n, 0);
@@ -57,9 +55,7 @@ function test(binding) {
     assert.equal(sum(calls), EXPECTED_SUM);
   }
 
-  return Promise.all([
-    check(binding.threadsafe_function_sum.testDelayedTSFN),
-    check(binding.threadsafe_function_sum.testWithTSFN),
-    checkAcquire()
-  ]);
+  return check(binding.threadsafe_function_sum.testDelayedTSFN)
+    .then(() => check(binding.threadsafe_function_sum.testWithTSFN))
+    .then(() => checkAcquire());
 }


### PR DESCRIPTION
Convert tests that gc into async functions that await 10 ticks after
each gc. This is because gc has become async and because references
will soon be deleted via a native `SetImmediate()`.

Re: https://github.com/nodejs/node/pull/34386