### PR TITLE
doc: Added required return to example

### DIFF
--- a/doc/function.md
+++ b/doc/function.md
@@ -30,6 +30,7 @@ Value Fn(const CallbackInfo& info) {
 
 Object Init(Env env, Object exports) {
   exports.Set(String::New(env, "fn"), Function::New<Fn>(env));
+  return exports;
 }
 
 NODE_API_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
Added required `return` only for the sake of completeness. 

When current example was compiled, it was returning the following error: "Error C4716: 'Init': must return a value". Now it is fixed.