### PR TITLE
Fix leak of ThreadSafeData in AsyncProgressWorkerBase<DataType>

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4748,6 +4748,7 @@ inline void AsyncProgressWorkerBase<DataType>::OnAsyncWorkProgress(Napi::Env /* 
                                 void* data) {
   ThreadSafeData* tsd = static_cast<ThreadSafeData*>(data);
   tsd->asyncprogressworker()->OnWorkProgress(tsd->data());
+  delete tsd;
 }
 
 template <typename DataType>


### PR DESCRIPTION
`ThreadSafeData` is allocated in `AsyncProgressWorkerBase<DataType>::NonBlockingCall` to provide context in the `tsfn` callback, but never deleted.