### PR TITLE
build: add incremental clang-format checks

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,23 @@
+name: Style Checks
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        node-version: [14.x]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: git branch -a
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: CLANG_FORMAT_START=refs/remotes/origin/master npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
   # Travis CI sets NVM_NODEJS_ORG_MIRROR, but it makes node-gyp fail to download headers for nightly builds.
   - unset NVM_NODEJS_ORG_MIRROR
 
-  - npm run lint
   - npm test
 after_success:
   - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test


### PR DESCRIPTION
git-clang-format only check lines modified between two refs.

Fixes: https://github.com/nodejs/node-addon-api/issues/543