### PR TITLE
build: add pre-commit package for linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,111 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:      80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
   # Travis CI sets NVM_NODEJS_ORG_MIRROR, but it makes node-gyp fail to download headers for nightly builds.
   - unset NVM_NODEJS_ORG_MIRROR
 
+  - npm run lint
   - npm test
 after_success:
   - cpp-coveralls --gcov-options '\-lp' --build-root test/build --exclude test

--- a/package.json
+++ b/package.json
@@ -267,6 +267,7 @@
     "bindings": "^1.5.0",
     "clang-format": "^1.4.0",
     "fs-extra": "^9.0.1",
+    "pre-commit": "^1.2.2",
     "safe-buffer": "^5.1.1"
   },
   "directories": {},
@@ -305,5 +306,6 @@
     "lint": "node scripts/clang-format.js",
     "lint:fix": "git-clang-format"
   },
+  "pre-commit": "lint",
   "version": "3.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -264,8 +264,9 @@
   "description": "Node.js API (N-API)",
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "fs-extra": "^9.0.1",
     "bindings": "^1.5.0",
+    "clang-format": "^1.4.0",
+    "fs-extra": "^9.0.1",
     "safe-buffer": "^5.1.1"
   },
   "directories": {},
@@ -300,7 +301,9 @@
     "dev": "node test",
     "predev:incremental": "node-gyp configure build -C test --debug",
     "dev:incremental": "node test",
-    "doc": "doxygen doc/Doxyfile"
+    "doc": "doxygen doc/Doxyfile",
+    "lint": "node scripts/clang-format.js",
+    "lint:fix": "git-clang-format"
   },
   "version": "3.0.2"
 }

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const spawn = require('child_process').spawnSync;
+const path = require('path');
+
+const filesToCheck = ['*.h', '*.cc'];
+const CLANG_FORMAT_START = process.env.CLANG_FORMAT_START || 'master';
+
+function main(args) {
+  let clangFormatPath = path.dirname(require.resolve('clang-format'));
+  const options = ['--binary=node_modules/.bin/clang-format', '--style=file'];
+
+  const gitClangFormatPath = path.join(clangFormatPath,
+    'bin/git-clang-format');
+  const result = spawn('python', [
+    gitClangFormatPath,
+    ...options,
+    '--diff',
+    CLANG_FORMAT_START,
+    'HEAD',
+    ...filesToCheck
+  ], { encoding: 'utf-8' });
+
+  if (result.error) {
+    console.error('Error running git-clang-format:', result.error);
+    return 2;
+  }
+
+  const clangFormatOutput = result.stdout.trim();
+  if (clangFormatOutput !== ('no modified files to format') &&
+      clangFormatOutput !== ('clang-format did not modify any files')) {
+    console.error(clangFormatOutput);
+    const fixCmd = '"npm run lint:fix"';
+    console.error(`
+      ERROR: please run ${fixCmd} to format changes in your commit`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}


### PR DESCRIPTION
This extends #819 with a pre-commit hook to run the `lint` task prior to making a git commit. 

For example, after I installed the package and tried to make a commit via:

> git commit -m "build: add pre-commit package for linting"

I received this error, because the linting failed:

```
... output from lint task giving needed code changes ...
+                              0,
+                              1,
+                              testData,
+                              std::function<decltype(AcquireFinalizerCallback)>(
+                                  AcquireFinalizerCallback),
+                              testData);
 
   Object result = Object::New(env);
   result["createThread"] = Function::New( env, CreateThread, "createThread", testData);

      ERROR: please run "npm run lint:fix" to format changes in your commit
pre-commit: 
pre-commit: We've failed to pass the specified git pre-commit hooks as the `lint`
pre-commit: hook returned an exit code (1). If you're feeling adventurous you can
pre-commit: skip the git pre-commit hooks by adding the following flags to your commit:
pre-commit: 
pre-commit:   git commit -n (or --no-verify)
pre-commit: 
pre-commit: This is ill-advised since the commit is broken.
pre-commit: 
```

I was able to forcefully make the commit by adding the `-n` flag as mentioned in the error.

@legendecas we discussed that the linter runs on the CI because of https://github.com/nodejs/node-addon-api/commit/cb0764ae8e4b94916e1e79bd04d9b1d334c084fc#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R57 but i find it odd that your PR #819 succeeded, but my local `lint` task is failing...?