### PR TITLE
doc: avoid directing users to HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ APIs exposed by node-addon-api are generally used to create and
 manipulate JavaScript values. Concepts and operations generally map
 to ideas specified in the **ECMA262 Language Specification**.
 
-The [N-API Resource](http://nodejs.github.io/node-addon-examples/) offers an 
-excellent orientation and tips for developers just getting started with N-API 
+The [N-API Resource](https://nodejs.github.io/node-addon-examples/) offers an
+excellent orientation and tips for developers just getting started with N-API
 and node-addon-api.
 
 - **[Setup](#setup)**

--- a/doc/error.md
+++ b/doc/error.md
@@ -117,4 +117,4 @@ Returns a pointer to a null-terminated string that is used to identify the
 exception. This method can be used only if the exception mechanism is enabled.
 
 [`Napi::ObjectReference`]: ./object_reference.md
-[`std::exception`]: http://cplusplus.com/reference/exception/exception/
+[`std::exception`]: https://cplusplus.com/reference/exception/exception/

--- a/doc/hierarchy.md
+++ b/doc/hierarchy.md
@@ -88,4 +88,4 @@
 [`Napi::Uint8Array`]: ./typed_array_of.md
 [`Napi::Value`]: ./value.md
 [`Napi::VersionManagement`]: ./version_management.md
-[`std::exception`]: http://cplusplus.com/reference/exception/exception/
+[`std::exception`]: https://cplusplus.com/reference/exception/exception/


### PR DESCRIPTION
There is no reason to use plain HTTP, it only makes things easier to track/hijack for ISPs and other untrustworthy entities.