### PR TITLE
create a HandleScope in FinalizeCallback

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3977,6 +3977,8 @@ inline napi_value ObjectWrap<T>::StaticSetterCallbackWrapper(
 
 template <typename T>
 inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hint*/) {
+  HandleScope scope(env);
+
   T* instance = static_cast<T*>(data);
   instance->Finalize(Napi::Env(env));
   delete instance;

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3978,7 +3978,6 @@ inline napi_value ObjectWrap<T>::StaticSetterCallbackWrapper(
 template <typename T>
 inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hint*/) {
   HandleScope scope(env);
-
   T* instance = static_cast<T*>(data);
   instance->Finalize(Napi::Env(env));
   delete instance;


### PR DESCRIPTION
Seems like FinalizeCallback needs to create a HandleScope since it calls ObjectWrap<T>::~ObjectWrap() which might need to create a temporary Object handle here https://github.com/nodejs/node-addon-api/blob/master/napi-inl.h#L3558

at Realm (https://github.com/realm/realm-js) we have crashes with stacktrace at this location.


