### PR TITLE
test: fix buildType bug objectwrap_worker_thread

### DIFF
--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -1,14 +1,16 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
-const { Worker, isMainThread } = require('worker_threads');
+const { Worker, isMainThread, workerData } = require('worker_threads');
 
 if (isMainThread) {
-    new Worker(__filename);
+    const buildType = process.config.target_defaults.default_configuration;
+    new Worker(__filename, { workerData: buildType });
 } else {
     const test = binding => {
         new binding.objectwrap.Test();
     };
 
+    const buildType = workerData;
     test(require(`./build/${buildType}/binding.node`));
     test(require(`./build/${buildType}/binding_noexcept.node`));
 }
+


### PR DESCRIPTION
Since worker threads inherit non-process-specific options by
default, the configuration needs to be shared via workerData.

Fixes: https://github.com/nodejs/node-addon-api/issues/834