### PR TITLE
[wip]: Fixes issue 841.

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -179,8 +179,8 @@ TemplatedInstanceVoidCallback(napi_env env,
 
 template <typename T, typename Finalizer, typename Hint = void>
 struct FinalizeData {
-  static inline void Wrapper(napi_env env, 
-                             void* data, 
+  static inline void Wrapper(napi_env env,
+                             void* data,
                              void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
@@ -189,8 +189,8 @@ struct FinalizeData {
     });
   }
 
-  static inline void WrapperWithHint(napi_env env, 
-                                     void* data, 
+  static inline void WrapperWithHint(napi_env env,
+                                     void* data,
                                      void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -179,8 +179,9 @@ TemplatedInstanceVoidCallback(napi_env env,
 
 template <typename T, typename Finalizer, typename Hint = void>
 struct FinalizeData {
-  static inline
-  void Wrapper(napi_env env, void* data, void* finalizeHint) NAPI_NOEXCEPT {
+  static inline void Wrapper(napi_env env, 
+                             void* data, 
+                             void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data));
@@ -188,8 +189,9 @@ struct FinalizeData {
     });
   }
 
-  static inline
-  void WrapperWithHint(napi_env env, void* data, void* finalizeHint) NAPI_NOEXCEPT {
+  static inline void WrapperWithHint(napi_env env, 
+                                     void* data, 
+                                     void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data), finalizeData->hint);
@@ -3523,7 +3525,8 @@ inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
 
 template <typename T>
 template <typename InstanceWrap<T>::InstanceSetterCallback method>
-inline napi_value InstanceWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+inline napi_value InstanceWrap<T>::WrappedMethod(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -3985,7 +3988,8 @@ inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hi
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticSetterCallback method>
-inline napi_value ObjectWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+inline napi_value ObjectWrap<T>::WrappedMethod(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     method(cbInfo, cbInfo[0]);

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -180,7 +180,7 @@ TemplatedInstanceVoidCallback(napi_env env,
 template <typename T, typename Finalizer, typename Hint = void>
 struct FinalizeData {
   static inline
-  void Wrapper(napi_env env, void* data, void* finalizeHint) noexcept {
+  void Wrapper(napi_env env, void* data, void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data));
@@ -189,7 +189,7 @@ struct FinalizeData {
   }
 
   static inline
-  void WrapperWithHint(napi_env env, void* data, void* finalizeHint) noexcept {
+  void WrapperWithHint(napi_env env, void* data, void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data), finalizeData->hint);
@@ -3523,7 +3523,7 @@ inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
 
 template <typename T>
 template <typename InstanceWrap<T>::InstanceSetterCallback method>
-inline napi_value InstanceWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) noexcept {
+inline napi_value InstanceWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -3985,7 +3985,7 @@ inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hi
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticSetterCallback method>
-inline napi_value ObjectWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) noexcept {
+inline napi_value ObjectWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     method(cbInfo, cbInfo[0]);

--- a/napi.h
+++ b/napi.h
@@ -1752,13 +1752,18 @@ namespace Napi {
     static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
 
     template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT;
+    static napi_value WrappedMethod(napi_env env, 
+                                    napi_callback_info info) NAPI_NOEXCEPT;
 
     template <InstanceSetterCallback setter> struct SetterTag {};
 
     template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT { return nullptr; }
+    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT { 
+      return &This::WrappedMethod<setter>; 
+    }
+    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT { 
+      return nullptr; 
+    }
   };
 
   /// Base class to be extended by C++ classes exposed to JavaScript; each C++ class instance gets
@@ -1891,13 +1896,20 @@ namespace Napi {
                                  StaticSetterCallback> StaticAccessorCallbackData;
 
     template <StaticSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT;
+    static napi_value WrappedMethod(napi_env env, 
+                                    napi_callback_info info) NAPI_NOEXCEPT;
 
     template <StaticSetterCallback setter> struct StaticSetterTag {};
 
     template <StaticSetterCallback setter>
-    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) NAPI_NOEXCEPT { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) NAPI_NOEXCEPT { return nullptr; }
+    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) 
+      NAPI_NOEXCEPT { 
+        return &This::WrappedMethod<setter>; 
+    }
+    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) 
+      NAPI_NOEXCEPT { 
+      return nullptr; 
+    }
 
     bool _construction_failed = true;
   };

--- a/napi.h
+++ b/napi.h
@@ -1752,17 +1752,17 @@ namespace Napi {
     static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
 
     template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, 
+    static napi_value WrappedMethod(napi_env env,
                                     napi_callback_info info) NAPI_NOEXCEPT;
 
     template <InstanceSetterCallback setter> struct SetterTag {};
 
     template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT { 
-      return &This::WrappedMethod<setter>; 
+    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT {
+      return &This::WrappedMethod<setter>;
     }
-    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT { 
-      return nullptr; 
+    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT {
+      return nullptr;
     }
   };
 
@@ -1896,19 +1896,19 @@ namespace Napi {
                                  StaticSetterCallback> StaticAccessorCallbackData;
 
     template <StaticSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, 
+    static napi_value WrappedMethod(napi_env env,
                                     napi_callback_info info) NAPI_NOEXCEPT;
 
     template <StaticSetterCallback setter> struct StaticSetterTag {};
 
     template <StaticSetterCallback setter>
-    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) 
-      NAPI_NOEXCEPT { 
-        return &This::WrappedMethod<setter>; 
+    static napi_callback WrapStaticSetter(StaticSetterTag<setter>)
+        NAPI_NOEXCEPT {
+      return &This::WrappedMethod<setter>;
     }
-    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) 
-      NAPI_NOEXCEPT { 
-      return nullptr; 
+    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>)
+        NAPI_NOEXCEPT {
+      return nullptr;
     }
 
     bool _construction_failed = true;

--- a/napi.h
+++ b/napi.h
@@ -34,6 +34,11 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
   #endif
 #endif
 
+// VS2013 does not support noexcept
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+#define _NOEXCEPT
+#endif
+
 #ifdef _NOEXCEPT
   #define NAPI_NOEXCEPT _NOEXCEPT
 #else
@@ -1747,13 +1752,13 @@ namespace Napi {
     static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
 
     template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    static napi_value WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT;
 
     template <InstanceSetterCallback setter> struct SetterTag {};
 
     template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapSetter(SetterTag<nullptr>) noexcept { return nullptr; }
+    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT { return &This::WrappedMethod<setter>; }
+    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT { return nullptr; }
   };
 
   /// Base class to be extended by C++ classes exposed to JavaScript; each C++ class instance gets
@@ -1886,13 +1891,13 @@ namespace Napi {
                                  StaticSetterCallback> StaticAccessorCallbackData;
 
     template <StaticSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    static napi_value WrappedMethod(napi_env env, napi_callback_info info) NAPI_NOEXCEPT;
 
     template <StaticSetterCallback setter> struct StaticSetterTag {};
 
     template <StaticSetterCallback setter>
-    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) noexcept { return nullptr; }
+    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) NAPI_NOEXCEPT { return &This::WrappedMethod<setter>; }
+    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) NAPI_NOEXCEPT { return nullptr; }
 
     bool _construction_failed = true;
   };


### PR DESCRIPTION
Visual Sudio 13 does not support `noexcept`.
This PR should fix the compilation problem reported in the issue **https://github.com/nodejs/node-addon-api/issues/841**.

