### PR TITLE
script: fix complains that js files are not supported on npm run lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
     "dev:incremental": "node test",
     "doc": "doxygen doc/Doxyfile",
     "lint": "node tools/clang-format.js",
-    "lint:fix": "git-clang-format"
+    "lint:fix": "git-clang-format '*.h', '*.cc'"
   },
   "pre-commit": "lint",
   "version": "3.0.2",


### PR DESCRIPTION
Fixes complains like this:

```javascript
$ npm run lint:fix
Configuration file(s) do(es) not support JavaScript: /workspace/node-addon-api/.clang-format
```