### PR TITLE
src:  use NAPI_NOEXCEPT macro instead of noexcept.

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -179,8 +179,9 @@ TemplatedInstanceVoidCallback(napi_env env,
 
 template <typename T, typename Finalizer, typename Hint = void>
 struct FinalizeData {
-  static inline
-  void Wrapper(napi_env env, void* data, void* finalizeHint) noexcept {
+  static inline void Wrapper(napi_env env,
+                             void* data,
+                             void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data));
@@ -188,8 +189,9 @@ struct FinalizeData {
     });
   }
 
-  static inline
-  void WrapperWithHint(napi_env env, void* data, void* finalizeHint) noexcept {
+  static inline void WrapperWithHint(napi_env env,
+                                     void* data,
+                                     void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(Env(env), static_cast<T*>(data), finalizeData->hint);
@@ -3562,7 +3564,8 @@ inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
 
 template <typename T>
 template <typename InstanceWrap<T>::InstanceSetterCallback method>
-inline napi_value InstanceWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) noexcept {
+inline napi_value InstanceWrap<T>::WrappedMethod(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -4024,7 +4027,8 @@ inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hi
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticSetterCallback method>
-inline napi_value ObjectWrap<T>::WrappedMethod(napi_env env, napi_callback_info info) noexcept {
+inline napi_value ObjectWrap<T>::WrappedMethod(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     method(cbInfo, cbInfo[0]);

--- a/napi.h
+++ b/napi.h
@@ -1747,13 +1747,18 @@ namespace Napi {
     static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
 
     template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    static napi_value WrappedMethod(napi_env env,
+                                    napi_callback_info info) NAPI_NOEXCEPT;
 
     template <InstanceSetterCallback setter> struct SetterTag {};
 
     template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapSetter(SetterTag<nullptr>) noexcept { return nullptr; }
+    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT {
+      return &This::WrappedMethod<setter>;
+    }
+    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT {
+      return nullptr;
+    }
   };
 
   /// Base class to be extended by C++ classes exposed to JavaScript; each C++ class instance gets
@@ -1886,13 +1891,20 @@ namespace Napi {
                                  StaticSetterCallback> StaticAccessorCallbackData;
 
     template <StaticSetterCallback method>
-    static napi_value WrappedMethod(napi_env env, napi_callback_info info) noexcept;
+    static napi_value WrappedMethod(napi_env env,
+                                    napi_callback_info info) NAPI_NOEXCEPT;
 
     template <StaticSetterCallback setter> struct StaticSetterTag {};
 
     template <StaticSetterCallback setter>
-    static napi_callback WrapStaticSetter(StaticSetterTag<setter>) noexcept { return &This::WrappedMethod<setter>; }
-    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>) noexcept { return nullptr; }
+    static napi_callback WrapStaticSetter(StaticSetterTag<setter>)
+        NAPI_NOEXCEPT {
+      return &This::WrappedMethod<setter>;
+    }
+    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>)
+        NAPI_NOEXCEPT {
+      return nullptr;
+    }
 
     bool _construction_failed = true;
   };


### PR DESCRIPTION
This PR substitute the `noexcept` operator with the `NAPI_NOEXCEPT` to be consistent to all rest of the code in the library.