### PR TITLE
Cannot Ref and throw exception in ObjectWrap constructor

### DIFF
--- a/test/objectwrap_constructor_exception.cc
+++ b/test/objectwrap_constructor_exception.cc
@@ -5,6 +5,7 @@ class ConstructorExceptionTest :
 public:
   ConstructorExceptionTest(const Napi::CallbackInfo& info) :
     Napi::ObjectWrap<ConstructorExceptionTest>(info) {
+    this->Ref();
     Napi::Error error = Napi::Error::New(info.Env(), "an exception");
 #ifdef NAPI_DISABLE_CPP_EXCEPTIONS
     error.ThrowAsJavaScriptException();


### PR DESCRIPTION
I noticed that you cannot `Ref` in an ObjectWrap instance's constructor and then throw an exception. This produces a segfault, as demonstrated by running `npm test` on this branch:

```
Running test 'objectwrap_constructor_exception'
node(99930,0x111f5ce00) malloc: *** error for object 0x10abb1060: pointer being freed was not allocated
node(99930,0x111f5ce00) malloc: *** set a breakpoint in malloc_error_break to debug
```

If I add a call to `Unref` before throwing the exception, things work just fine; however, I think we should be able to handle this automatically in ObjectWrap's destructor.