### PR TITLE
How are Ref and Unref supposed to work?

### DIFF
--- a/test/binding.cc
+++ b/test/binding.cc
@@ -59,6 +59,7 @@ Object InitTypedThreadSafeFunction(Env env);
 Object InitTypedArray(Env env);
 Object InitObjectWrap(Env env);
 Object InitObjectWrapConstructorException(Env env);
+Object InitObjectWrapRef(Env env);
 Object InitObjectWrapRemoveWrap(Env env);
 Object InitObjectWrapMultipleInheritance(Env env);
 Object InitObjectReference(Env env);
@@ -131,6 +132,7 @@ Object Init(Env env, Object exports) {
   exports.Set("objectwrap", InitObjectWrap(env));
   exports.Set("objectwrapConstructorException",
       InitObjectWrapConstructorException(env));
+  exports.Set("objectwrap_ref", InitObjectWrapRef(env));
   exports.Set("objectwrap_removewrap", InitObjectWrapRemoveWrap(env));
   exports.Set("objectwrap_multiple_inheritance", InitObjectWrapMultipleInheritance(env));
   exports.Set("objectreference", InitObjectReference(env));

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -51,6 +51,7 @@
         'typedarray.cc',
         'objectwrap.cc',
         'objectwrap_constructor_exception.cc',
+        'objectwrap_ref.cc',
         'objectwrap-removewrap.cc',
         'objectwrap_multiple_inheritance.cc',
         'objectreference.cc',

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,7 @@ let testModules = [
   'typedarray-bigint',
   'objectwrap',
   'objectwrap_constructor_exception',
+  'objectwrap_ref',
   'objectwrap-removewrap',
   'objectwrap_multiple_inheritance',
   'objectwrap_worker_thread',

--- a/test/objectwrap_ref.cc
+++ b/test/objectwrap_ref.cc
@@ -1,0 +1,34 @@
+#include <napi.h>
+
+class ObjectWrapRef : public Napi::ObjectWrap<ObjectWrapRef> {
+ public:
+  ObjectWrapRef(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<ObjectWrapRef>(info) {}
+
+  Napi::Value DoRef(const Napi::CallbackInfo& info) {
+    auto count = this->Ref();
+    return Napi::Number::New(info.Env(), count);
+  }
+
+  Napi::Value DoUnref(const Napi::CallbackInfo& info) {
+    auto count = this->Unref();
+    return Napi::Number::New(info.Env(), count);
+  }
+
+  static void Initialize(Napi::Env env, Napi::Object exports) {
+    const char* name = "ObjectWrapRef";
+    exports.Set(
+        name,
+        DefineClass(
+            env,
+            name,
+            {InstanceMethod("ref", &ObjectWrapRef::DoRef, napi_default),
+             InstanceMethod("unref", &ObjectWrapRef::DoUnref, napi_default)}));
+  }
+};
+
+Napi::Object InitObjectWrapRef(Napi::Env env) {
+  Napi::Object exports = Napi::Object::New(env);
+  ObjectWrapRef::Initialize(env, exports);
+  return exports;
+}

--- a/test/objectwrap_ref.js
+++ b/test/objectwrap_ref.js
@@ -1,0 +1,21 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+const testUtil = require('./testUtil');
+
+function test(binding) {
+  return testUtil.runGCTests([
+    'objectwrap ref',
+    () => {
+      const { ObjectWrapRef } = binding.objectwrap_ref;
+      const objectWrapRef = new ObjectWrapRef();
+      assert.equal(objectWrapRef.ref(), 1);
+      // assert.equal(objectWrapRef.unref(), 0);
+    },
+    // Do on gc before returning.
+    () => {}
+  ]);
+}
+
+module.exports = test(require(`./build/${buildType}/binding.node`))
+  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));


### PR DESCRIPTION
I've landed a little test for ObjectWrap, `Ref`, and `Unref` in order to try and understand some behavior I'm seeing. Is it expected that failing to call `Unref` should lead to a "pointer being freed was not allocated" error? In the test I've added, un-commenting the call to `unref` causes the test to pass. Is it wrong to expect that Node.js should remain running so long as the reference count is non-zero?

```
% ~/src/node/node_g -v
v15.5.0
```

```
% lldb -e ~/src/node/node_g
(lldb) target create "/Users/mark/src/node/node_g"
Current executable set to '/Users/mark/src/node/node_g' (x86_64).
(lldb) run --expose-gc test/objectwrap_ref.js
Process 28088 launched: '/Users/mark/src/node/node_g' (x86_64)
node_g(28088,0x10737fe00) malloc: *** error for object 0x107439860: pointer being freed was not allocated
node_g(28088,0x10737fe00) malloc: *** set a breakpoint in malloc_error_break to debug
Process 28088 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00007fff202e2462 libsystem_kernel.dylib`__pthread_kill + 10
libsystem_kernel.dylib`__pthread_kill:
->  0x7fff202e2462 <+10>: jae    0x7fff202e246c            ; <+20>
    0x7fff202e2464 <+12>: movq   %rax, %rdi
    0x7fff202e2467 <+15>: jmp    0x7fff202dc6a1            ; cerror_nocancel
    0x7fff202e246c <+20>: retq   
Target 0: (node_g) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fff202e2462 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff20310610 libsystem_pthread.dylib`pthread_kill + 263
    frame #2: 0x00007fff20263720 libsystem_c.dylib`abort + 120
    frame #3: 0x00007fff20144430 libsystem_malloc.dylib`malloc_vreport + 548
    frame #4: 0x00007fff201474c8 libsystem_malloc.dylib`malloc_report + 151
    frame #5: 0x000000010010f198 node_g`v8impl::(anonymous namespace)::RefBase::~RefBase(this=0x0000000107439860) at js_native_api_v8.cc:223:22
    frame #6: 0x0000000100109659 node_g`v8impl::(anonymous namespace)::RefBase::Delete(reference=0x0000000107439860)::RefBase*) at js_native_api_v8.cc:248:7
    frame #7: 0x000000010010f02e node_g`v8impl::(anonymous namespace)::RefBase::Finalize(this=0x0000000107439860, is_env_teardown=true) at js_native_api_v8.cc:281:7
    frame #8: 0x00000001001409c1 node_g`v8impl::RefTracker::FinalizeAll(list=0x0000000107428258) at js_native_api_v8.h:43:20
    frame #9: 0x0000000100140925 node_g`napi_env__::~napi_env__(this=0x0000000107428220) at js_native_api_v8.h:66:5
    frame #10: 0x0000000100140b48 node_g`node_napi_env__::~node_napi_env__(this=0x0000000107428220) at node_api.cc:17:8
    frame #11: 0x00000001001405f5 node_g`node_napi_env__::~node_napi_env__(this=0x0000000107428220) at node_api.cc:17:8
    frame #12: 0x000000010014061c node_g`node_napi_env__::~node_napi_env__(this=0x0000000107428220) at node_api.cc:17:8
    frame #13: 0x000000010010f311 node_g`napi_env__::Unref(this=0x0000000107428220) at js_native_api_v8.h:77:43
    frame #14: 0x000000010014379c node_g`v8impl::(anonymous namespace)::NewEnv(this=0x0000000107428220, arg=0x0000000107428220)::'lambda'(void*)::operator()(void*) const at node_api.cc:103:37
    frame #15: 0x0000000100143775 node_g`v8impl::(anonymous namespace)::NewEnv(arg=0x0000000107428220)::'lambda'(void*)::__invoke(void*) at node_api.cc:102:7
    frame #16: 0x00000001000b0343 node_g`node::Environment::RunCleanup(this=0x000000010803c200) at env.cc:669:7
    frame #17: 0x000000010000ffaa node_g`node::FreeEnvironment(env=0x000000010803c200) at environment.cc:387:10
    frame #18: 0x000000010000d079 node_g`node::FunctionDeleter<node::Environment, &(node::FreeEnvironment(node::Environment*))>::operator(this=0x00007ffeefbff5e0, pointer=0x000000010803c200)(node::Environment*) const at util.h:636:39
    frame #19: 0x000000010024eadf node_g`std::__1::unique_ptr<node::Environment, node::FunctionDeleter<node::Environment, &(node::FreeEnvironment(node::Environment*))> >::reset(this=0x00007ffeefbff5e0, __p=0x0000000000000000) at memory:2623:7
    frame #20: 0x0000000100250ac9 node_g`std::__1::unique_ptr<node::Environment, node::FunctionDeleter<node::Environment, &(node::FreeEnvironment(node::Environment*))> >::~unique_ptr(this=0x00007ffeefbff5e0) at memory:2577:19
    frame #21: 0x000000010024e9d5 node_g`std::__1::unique_ptr<node::Environment, node::FunctionDeleter<node::Environment, &(node::FreeEnvironment(node::Environment*))> >::~unique_ptr(this=0x00007ffeefbff5e0) at memory:2577:17
    frame #22: 0x000000010024e2e0 node_g`node::NodeMainInstance::Run(this=0x00007ffeefbff670, env_info=0x000000010491bb38) at node_main_instance.cc:168:1
    frame #23: 0x000000010013017a node_g`node::Start(argc=3, argv=0x00007ffeefbff828) at node.cc:1123:38
    frame #24: 0x0000000101cf015e node_g`main(argc=3, argv=0x00007ffeefbff828) at node_main.cc:127:10
    frame #25: 0x00007fff2032b621 libdyld.dylib`start + 1
    frame #26: 0x00007fff2032b621 libdyld.dylib`start + 1
```