### PR TITLE
Mark methods of wrapper classes const

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -57,7 +57,7 @@ Returns a `bool` indicating if an exception is pending in the environment.
 ### GetAndClearPendingException
 
 ```cpp
-Napi::Error Napi::Env::GetAndClearPendingException();
+Napi::Error Napi::Env::GetAndClearPendingException() const;
 ```
 
 Returns an `Napi::Error` object representing the environment's pending exception, if any.
@@ -65,7 +65,7 @@ Returns an `Napi::Error` object representing the environment's pending exception
 ### RunScript
 
 ```cpp
-Napi::Value Napi::Env::RunScript(____ script);
+Napi::Value Napi::Env::RunScript(____ script) const;
 ```
 - `[in] script`: A string containing JavaScript code to execute.
 
@@ -78,7 +78,7 @@ The `script` can be any of the following types:
 
 ### GetInstanceData
 ```cpp
-template <typename T> T* GetInstanceData();
+template <typename T> T* GetInstanceData() const;
 ```
 
 Returns the instance data that was previously associated with the environment,
@@ -89,7 +89,7 @@ or `nullptr` if none was associated.
 ```cpp
 template <typename T> using Finalizer = void (*)(Env, T*);
 template <typename T, Finalizer<T> fini = Env::DefaultFini<T>>
-void SetInstanceData(T* data);
+void SetInstanceData(T* data) const;
 ```
 
 - `[template] fini`: A function to call when the instance data is to be deleted.
@@ -112,7 +112,7 @@ template <typename DataType,
           typename HintType,
           FinalizerWithHint<DataType, HintType> fini =
             Env::DefaultFiniWithHint<DataType, HintType>>
-void SetInstanceData(DataType* data, HintType* hint);
+void SetInstanceData(DataType* data, HintType* hint) const;
 ```
 
 - `[template] fini`: A function to call when the instance data is to be deleted.

--- a/doc/object.md
+++ b/doc/object.md
@@ -273,13 +273,7 @@ indexed property or array element.
 Napi::Object::iterator Napi::Object::begin() const;
 ```
 
-Returns a constant iterator to the beginning of the object.
-
-```cpp
-Napi::Object::iterator Napi::Object::begin();
-```
-
-Returns a non constant iterator to the beginning of the object.
+Returns an iterator to the beginning of the object.
 
 ### end()
 
@@ -287,13 +281,7 @@ Returns a non constant iterator to the beginning of the object.
 Napi::Object::iterator Napi::Object::end() const;
 ```
 
-Returns a constant iterator to the end of the object.
-
-```cpp
-Napi::Object::iterator Napi::Object::end();
-```
-
-Returns a non constant iterator to the end of the object.
+Returns an iterator to the end of the object.
 
 ## Iterator
 
@@ -303,63 +291,7 @@ Iterators expose an `std::pair<...>`, where the `first` property is a
 holds the currently iterated value. Iterators are only available if C++
 exceptions are enabled (by defining `NAPI_CPP_EXCEPTIONS` during the build).
 
-### Constant Iterator
-
-In constant iterators, the iterated values are immutable.
-
-#### operator++()
-
-```cpp
-inline Napi::Object::const_iterator& Napi::Object::const_iterator::operator++();
-```
-
-Moves the iterator one step forward.
-
-#### operator==
-
-```cpp
-inline bool Napi::Object::const_iterator::operator==(const Napi::Object::const_iterator& other) const;
-```
-- `[in] other`: Another iterator to compare the current iterator to.
-
-Returns whether both iterators are at the same index.
-
-#### operator!=
-
-```cpp
-inline bool Napi::Object::const_iterator::operator!=(const Napi::Object::const_iterator& other) const;
-```
-- `[in] other`: Another iterator to compare the current iterator to.
-
-Returns whether both iterators are at different indices.
-
-#### operator*()
-
-```cpp
-inline const std::pair<Napi::Value, Napi::Object::PropertyLValue<Napi::Value>> Napi::Object::const_iterator::operator*() const;
-```
-
-Returns the currently iterated key and value.
-
-#### Example
-```cpp
-Value Sum(const CallbackInfo& info) {
-  Object object = info[0].As<Object>();
-  int64_t sum = 0;
-
-  for (const auto& e : object) {
-    sum += static_cast<Value>(e.second).As<Number>().Int64Value();
-  }
-
-  return Number::New(info.Env(), sum);
-}
-```
-
-### Non Constant Iterator
-
-In non constant iterators, the iterated values are mutable.
-
-#### operator++()
+### operator++()
 
 ```cpp
 inline Napi::Object::iterator& Napi::Object::iterator::operator++();
@@ -367,7 +299,7 @@ inline Napi::Object::iterator& Napi::Object::iterator::operator++();
 
 Moves the iterator one step forward.
 
-#### operator==
+### operator==
 
 ```cpp
 inline bool Napi::Object::iterator::operator==(const Napi::Object::iterator& other) const;
@@ -376,7 +308,7 @@ inline bool Napi::Object::iterator::operator==(const Napi::Object::iterator& oth
 
 Returns whether both iterators are at the same index.
 
-#### operator!=
+### operator!=
 
 ```cpp
 inline bool Napi::Object::iterator::operator!=(const Napi::Object::iterator& other) const;
@@ -385,15 +317,15 @@ inline bool Napi::Object::iterator::operator!=(const Napi::Object::iterator& oth
 
 Returns whether both iterators are at different indices.
 
-#### operator*()
+### operator*()
 
 ```cpp
-inline std::pair<Napi::Value, Napi::Object::PropertyLValue<Napi::Value>> Napi::Object::iterator::operator*();
+inline std::pair<Napi::Value, Napi::Object::PropertyLValue<Napi::Value>> Napi::Object::iterator::operator*() const;
 ```
 
 Returns the currently iterated key and value.
 
-#### Example
+### Example
 ```cpp
 void Increment(const CallbackInfo& info) {
   Env env = info.Env();

--- a/doc/object.md
+++ b/doc/object.md
@@ -72,7 +72,7 @@ Creates a new `Napi::Object` value.
 ### Set()
 
 ```cpp
-bool Napi::Object::Set (____ key, ____ value);
+bool Napi::Object::Set (____ key, ____ value) const;
 ```
 - `[in] key`: The name for the property being assigned.
 - `[in] value`: The value being assigned to the property.
@@ -91,7 +91,7 @@ The `value` can be of any type that is accepted by [`Napi::Value::From`][].
 ### Delete()
 
 ```cpp
-bool Napi::Object::Delete(____ key);
+bool Napi::Object::Delete(____ key) const;
 ```
 - `[in] key`: The name of the property to delete.
 
@@ -143,7 +143,7 @@ Note: This is equivalent to the JavaScript instanceof operator.
 ### AddFinalizer()
 ```cpp
 template <typename Finalizer, typename T>
-inline void AddFinalizer(Finalizer finalizeCallback, T* data);
+inline void AddFinalizer(Finalizer finalizeCallback, T* data) const;
 ```
 
 - `[in] finalizeCallback`: The function to call when the object is garbage-collected.
@@ -161,7 +161,7 @@ where `data` is the pointer that was passed into the call to `AddFinalizer()`.
 template <typename Finalizer, typename T, typename Hint>
 inline void AddFinalizer(Finalizer finalizeCallback,
                          T* data,
-                         Hint* finalizeHint);
+                         Hint* finalizeHint) const;
 ```
 
 - `[in] data`: The data to associate with the object.
@@ -184,7 +184,7 @@ The properties whose key is a `Symbol` will not be included.
 
 ### HasOwnProperty()
 ```cpp
-bool Napi::Object::HasOwnProperty(____ key); const
+bool Napi::Object::HasOwnProperty(____ key) const;
 ```
 - `[in] key` The name of the property to check.
 
@@ -200,7 +200,7 @@ The key can be any of the following types:
 ### DefineProperty()
 
 ```cpp
-bool Napi::Object::DefineProperty (const Napi::PropertyDescriptor& property);
+bool Napi::Object::DefineProperty (const Napi::PropertyDescriptor& property) const;
 ```
 - `[in] property`: A [`Napi::PropertyDescriptor`](property_descriptor.md).
 
@@ -209,7 +209,7 @@ Define a property on the object.
 ### DefineProperties()
 
 ```cpp
-bool Napi::Object::DefineProperties (____ properties)
+bool Napi::Object::DefineProperties (____ properties) const;
 ```
 - `[in] properties`: A list of [`Napi::PropertyDescriptor`](property_descriptor.md). Can be one of the following types:
   - const std::initializer_list<Napi::PropertyDescriptor>&
@@ -220,7 +220,7 @@ Defines properties on the object.
 ### Freeze()
 
 ```cpp
-void Napi::Object::Freeze()
+void Napi::Object::Freeze() const;
 ```
 
 The `Napi::Object::Freeze()` method freezes an object. A frozen object can no
@@ -233,7 +233,7 @@ freezing an object also prevents its prototype from being changed.
 ### Seal()
 
 ```cpp
-void Napi::Object::Seal()
+void Napi::Object::Seal() const;
 ```
 
 The `Napi::Object::Seal()` method seals an object, preventing new properties
@@ -244,7 +244,7 @@ writable.
 ### operator\[\]()
 
 ```cpp
-Napi::PropertyLValue<std::string> Napi::Object::operator[] (const char* utf8name);
+Napi::PropertyLValue<std::string> Napi::Object::operator[] (const char* utf8name) const;
 ```
 - `[in] utf8name`: UTF-8 encoded null-terminated property name.
 
@@ -252,7 +252,7 @@ Returns a [`Napi::Object::PropertyLValue`](propertylvalue.md) as the named
 property or sets the named property.
 
 ```cpp
-Napi::PropertyLValue<std::string> Napi::Object::operator[] (const std::string& utf8name);
+Napi::PropertyLValue<std::string> Napi::Object::operator[] (const std::string& utf8name) const;
 ```
 - `[in] utf8name`: UTF-8 encoded property name.
 
@@ -260,33 +260,12 @@ Returns a [`Napi::Object::PropertyLValue`](propertylvalue.md) as the named
 property or sets the named property.
 
 ```cpp
-Napi::PropertyLValue<uint32_t> Napi::Object::operator[] (uint32_t index);
+Napi::PropertyLValue<uint32_t> Napi::Object::operator[] (uint32_t index) const;
 ```
 - `[in] index`: Element index.
 
 Returns a [`Napi::Object::PropertyLValue`](propertylvalue.md) or sets an
 indexed property or array element.
-
-```cpp
-Napi::Value Napi::Object::operator[] (const char* utf8name) const;
-```
-- `[in] utf8name`: UTF-8 encoded null-terminated property name.
-
-Returns the named property as a [`Napi::Value`](value.md).
-
-```cpp
-Napi::Value Napi::Object::operator[] (const std::string& utf8name) const;
-```
-- `[in] utf8name`: UTF-8 encoded property name.
-
-Returns the named property as a [`Napi::Value`](value.md).
-
-```cpp
-Napi::Value Napi::Object::operator[] (uint32_t index) const;
-```
-- `[in] index`: Element index.
-
-Returns an indexed property or array element as a [`Napi::Value`](value.md).
 
 ### begin()
 

--- a/doc/object_reference.md
+++ b/doc/object_reference.md
@@ -103,7 +103,7 @@ The `value` can be any of the following types:
 ### Get
 
 ```cpp
-Napi::Value Napi::ObjectReference::Get(___ key);
+Napi::Value Napi::ObjectReference::Get(___ key) const;
 ```
 
 * `[in] key`: The name of the property to return the value for.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -69,7 +69,7 @@ Returns the value held by the `Napi::Reference`.
 ### Ref
 
 ```cpp
-uint32_t Napi::Reference::Ref();
+uint32_t Napi::Reference::Ref() const;
 ```
 
 Increments the reference count for the `Napi::Reference` and returns the resulting reference count. Throws an error if the increment fails.
@@ -77,7 +77,7 @@ Increments the reference count for the `Napi::Reference` and returns the resulti
 ### Unref
 
 ```cpp
-uint32_t Napi::Reference::Unref();
+uint32_t Napi::Reference::Unref() const;
 ```
 
 Decrements the reference count for the `Napi::Reference` and returns the resulting reference count. Throws an error if the decrement fails.

--- a/doc/threadsafe_function.md
+++ b/doc/threadsafe_function.md
@@ -83,7 +83,7 @@ Add a thread to this thread-safe function object, indicating that a new thread
 will start making use of the thread-safe function.
 
 ```cpp
-napi_status Napi::ThreadSafeFunction::Acquire()
+napi_status Napi::ThreadSafeFunction::Acquire() const
 ```
 
 Returns one of:
@@ -100,7 +100,7 @@ thread-safe function. Using any thread-safe APIs after having called this API
 has undefined results in the current thread, as it may have been destroyed.
 
 ```cpp
-napi_status Napi::ThreadSafeFunction::Release()
+napi_status Napi::ThreadSafeFunction::Release() const
 ```
 
 Returns one of:
@@ -122,7 +122,7 @@ make no further use of the thread-safe function because it is no longer
 guaranteed to be allocated.
 
 ```cpp
-napi_status Napi::ThreadSafeFunction::Abort()
+napi_status Napi::ThreadSafeFunction::Abort() const
 ```
 
 Returns one of:

--- a/doc/typed_threadsafe_function.md
+++ b/doc/typed_threadsafe_function.md
@@ -124,7 +124,7 @@ has undefined results in the current thread, as the thread-safe function may
 have been destroyed.
 
 ```cpp
-napi_status Napi::TypedThreadSafeFunction<ContextType, DataType, Callback>::Release()
+napi_status Napi::TypedThreadSafeFunction<ContextType, DataType, Callback>::Release() const
 ```
 
 Returns one of:
@@ -146,7 +146,7 @@ function call a thread must make no further use of the thread-safe function
 because it is no longer guaranteed to be allocated.
 
 ```cpp
-napi_status Napi::TypedThreadSafeFunction<ContextType, DataType, Callback>::Abort()
+napi_status Napi::TypedThreadSafeFunction<ContextType, DataType, Callback>::Abort() const
 ```
 
 Returns one of:

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1527,57 +1527,18 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
 }
 
 #ifdef NAPI_CPP_EXCEPTIONS
-inline Object::const_iterator::const_iterator(const Object* object,
-                                              const Type type) {
+inline Object::iterator::iterator(const Object* object, const Type type) {
   _object = object;
   _keys = object->GetPropertyNames();
   _index = type == Type::BEGIN ? 0 : _keys.Length();
 }
 
-inline Object::const_iterator Napi::Object::begin() const {
-  const_iterator it(this, Object::const_iterator::Type::BEGIN);
-  return it;
-}
-
-inline Object::const_iterator Napi::Object::end() const {
-  const_iterator it(this, Object::const_iterator::Type::END);
-  return it;
-}
-
-inline Object::const_iterator& Object::const_iterator::operator++() {
-  ++_index;
-  return *this;
-}
-
-inline bool Object::const_iterator::operator==(
-    const const_iterator& other) const {
-  return _index == other._index;
-}
-
-inline bool Object::const_iterator::operator!=(
-    const const_iterator& other) const {
-  return _index != other._index;
-}
-
-inline const std::pair<Value, Object::PropertyLValue<Value>>
-Object::const_iterator::operator*() const {
-  const Value key = _keys[_index];
-  const PropertyLValue<Value> value = (*_object)[key];
-  return {key, value};
-}
-
-inline Object::iterator::iterator(Object* object, const Type type) {
-  _object = object;
-  _keys = object->GetPropertyNames();
-  _index = type == Type::BEGIN ? 0 : _keys.Length();
-}
-
-inline Object::iterator Napi::Object::begin() {
+inline Object::iterator Napi::Object::begin() const {
   iterator it(this, Object::iterator::Type::BEGIN);
   return it;
 }
 
-inline Object::iterator Napi::Object::end() {
+inline Object::iterator Napi::Object::end() const {
   iterator it(this, Object::iterator::Type::END);
   return it;
 }
@@ -1596,7 +1557,7 @@ inline bool Object::iterator::operator!=(const iterator& other) const {
 }
 
 inline std::pair<Value, Object::PropertyLValue<Value>>
-Object::iterator::operator*() {
+Object::iterator::operator*() const {
   Value key = _keys[_index];
   PropertyLValue<Value> value = (*_object)[key];
   return {key, value};

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -483,7 +483,7 @@ inline bool Env::IsExceptionPending() const {
   return result;
 }
 
-inline Error Env::GetAndClearPendingException() {
+inline Error Env::GetAndClearPendingException() const {
   napi_value value;
   napi_status status = napi_get_and_clear_last_exception(_env, &value);
   if (status != napi_ok) {
@@ -493,16 +493,16 @@ inline Error Env::GetAndClearPendingException() {
   return Error(_env, value);
 }
 
-inline MaybeOrValue<Value> Env::RunScript(const char* utf8script) {
+inline MaybeOrValue<Value> Env::RunScript(const char* utf8script) const {
   String script = String::New(_env, utf8script);
   return RunScript(script);
 }
 
-inline MaybeOrValue<Value> Env::RunScript(const std::string& utf8script) {
+inline MaybeOrValue<Value> Env::RunScript(const std::string& utf8script) const {
   return RunScript(utf8script.c_str());
 }
 
-inline MaybeOrValue<Value> Env::RunScript(String script) {
+inline MaybeOrValue<Value> Env::RunScript(String script) const {
   napi_value result;
   napi_status status = napi_run_script(_env, script, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(
@@ -531,7 +531,7 @@ void Env::CleanupHook<Hook, Arg>::WrapperWithArg(void* data) NAPI_NOEXCEPT {
 
 #if NAPI_VERSION > 5
 template <typename T, Env::Finalizer<T> fini>
-inline void Env::SetInstanceData(T* data) {
+inline void Env::SetInstanceData(T* data) const {
   napi_status status =
     napi_set_instance_data(_env, data, [](napi_env env, void* data, void*) {
       fini(env, static_cast<T*>(data));
@@ -542,7 +542,7 @@ inline void Env::SetInstanceData(T* data) {
 template <typename DataType,
           typename HintType,
           Napi::Env::FinalizerWithHint<DataType, HintType> fini>
-inline void Env::SetInstanceData(DataType* data, HintType* hint) {
+inline void Env::SetInstanceData(DataType* data, HintType* hint) const {
   napi_status status =
     napi_set_instance_data(_env, data,
       [](napi_env env, void* data, void* hint) {
@@ -552,7 +552,7 @@ inline void Env::SetInstanceData(DataType* data, HintType* hint) {
 }
 
 template <typename T>
-inline T* Env::GetInstanceData() {
+inline T* Env::GetInstanceData() const {
   void* data = nullptr;
 
   napi_status status = napi_get_instance_data(_env, &data);
@@ -1294,37 +1294,23 @@ inline Object::Object() : Value() {
 inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
 }
 
-inline Object::PropertyLValue<std::string> Object::operator [](const char* utf8name) {
+inline Object::PropertyLValue<std::string> Object::operator[](
+    const char* utf8name) const {
   return PropertyLValue<std::string>(*this, utf8name);
 }
 
-inline Object::PropertyLValue<std::string> Object::operator [](const std::string& utf8name) {
+inline Object::PropertyLValue<std::string> Object::operator[](
+    const std::string& utf8name) const {
   return PropertyLValue<std::string>(*this, utf8name);
 }
 
-inline Object::PropertyLValue<uint32_t> Object::operator [](uint32_t index) {
+inline Object::PropertyLValue<uint32_t> Object::operator[](
+    uint32_t index) const {
   return PropertyLValue<uint32_t>(*this, index);
-}
-
-inline Object::PropertyLValue<Value> Object::operator[](Value index) {
-  return PropertyLValue<Value>(*this, index);
 }
 
 inline Object::PropertyLValue<Value> Object::operator[](Value index) const {
   return PropertyLValue<Value>(*this, index);
-}
-
-inline MaybeOrValue<Value> Object::operator[](const char* utf8name) const {
-  return Get(utf8name);
-}
-
-inline MaybeOrValue<Value> Object::operator[](
-    const std::string& utf8name) const {
-  return Get(utf8name);
-}
-
-inline MaybeOrValue<Value> Object::operator[](uint32_t index) const {
-  return Get(index);
 }
 
 inline MaybeOrValue<bool> Object::Has(napi_value key) const {
@@ -1396,14 +1382,15 @@ inline MaybeOrValue<Value> Object::Get(const std::string& utf8name) const {
 }
 
 template <typename ValueType>
-inline MaybeOrValue<bool> Object::Set(napi_value key, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(napi_value key,
+                                      const ValueType& value) const {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
-inline MaybeOrValue<bool> Object::Set(Value key, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(Value key, const ValueType& value) const {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
@@ -1411,7 +1398,7 @@ inline MaybeOrValue<bool> Object::Set(Value key, const ValueType& value) {
 
 template <typename ValueType>
 inline MaybeOrValue<bool> Object::Set(const char* utf8name,
-                                      const ValueType& value) {
+                                      const ValueType& value) const {
   napi_status status =
       napi_set_named_property(_env, _value, utf8name, Value::From(_env, value));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
@@ -1419,27 +1406,27 @@ inline MaybeOrValue<bool> Object::Set(const char* utf8name,
 
 template <typename ValueType>
 inline MaybeOrValue<bool> Object::Set(const std::string& utf8name,
-                                      const ValueType& value) {
+                                      const ValueType& value) const {
   return Set(utf8name.c_str(), value);
 }
 
-inline MaybeOrValue<bool> Object::Delete(napi_value key) {
+inline MaybeOrValue<bool> Object::Delete(napi_value key) const {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline MaybeOrValue<bool> Object::Delete(Value key) {
+inline MaybeOrValue<bool> Object::Delete(Value key) const {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline MaybeOrValue<bool> Object::Delete(const char* utf8name) {
+inline MaybeOrValue<bool> Object::Delete(const char* utf8name) const {
   return Delete(String::New(_env, utf8name));
 }
 
-inline MaybeOrValue<bool> Object::Delete(const std::string& utf8name) {
+inline MaybeOrValue<bool> Object::Delete(const std::string& utf8name) const {
   return Delete(String::New(_env, utf8name));
 }
 
@@ -1456,13 +1443,14 @@ inline MaybeOrValue<Value> Object::Get(uint32_t index) const {
 }
 
 template <typename ValueType>
-inline MaybeOrValue<bool> Object::Set(uint32_t index, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(uint32_t index,
+                                      const ValueType& value) const {
   napi_status status =
       napi_set_element(_env, _value, index, Value::From(_env, value));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline MaybeOrValue<bool> Object::Delete(uint32_t index) {
+inline MaybeOrValue<bool> Object::Delete(uint32_t index) const {
   bool result;
   napi_status status = napi_delete_element(_env, _value, index, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
@@ -1475,21 +1463,21 @@ inline MaybeOrValue<Array> Object::GetPropertyNames() const {
 }
 
 inline MaybeOrValue<bool> Object::DefineProperty(
-    const PropertyDescriptor& property) {
+    const PropertyDescriptor& property) const {
   napi_status status = napi_define_properties(_env, _value, 1,
     reinterpret_cast<const napi_property_descriptor*>(&property));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
-    const std::initializer_list<PropertyDescriptor>& properties) {
+    const std::initializer_list<PropertyDescriptor>& properties) const {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.begin()));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
-    const std::vector<PropertyDescriptor>& properties) {
+    const std::vector<PropertyDescriptor>& properties) const {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.data()));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
@@ -1503,7 +1491,7 @@ inline MaybeOrValue<bool> Object::InstanceOf(
 }
 
 template <typename Finalizer, typename T>
-inline void Object::AddFinalizer(Finalizer finalizeCallback, T* data) {
+inline void Object::AddFinalizer(Finalizer finalizeCallback, T* data) const {
   details::FinalizeData<T, Finalizer>* finalizeData =
       new details::FinalizeData<T, Finalizer>(
           {std::move(finalizeCallback), nullptr});
@@ -1522,7 +1510,7 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback, T* data) {
 template <typename Finalizer, typename T, typename Hint>
 inline void Object::AddFinalizer(Finalizer finalizeCallback,
                                  T* data,
-                                 Hint* finalizeHint) {
+                                 Hint* finalizeHint) const {
   details::FinalizeData<T, Finalizer, Hint>* finalizeData =
       new details::FinalizeData<T, Finalizer, Hint>(
           {std::move(finalizeCallback), finalizeHint});
@@ -1616,12 +1604,12 @@ Object::iterator::operator*() {
 #endif  // NAPI_CPP_EXCEPTIONS
 
 #if NAPI_VERSION >= 8
-inline MaybeOrValue<bool> Object::Freeze() {
+inline MaybeOrValue<bool> Object::Freeze() const {
   napi_status status = napi_object_freeze(_env, _value);
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline MaybeOrValue<bool> Object::Seal() {
+inline MaybeOrValue<bool> Object::Seal() const {
   napi_status status = napi_object_seal(_env, _value);
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
@@ -2930,7 +2918,7 @@ inline T Reference<T>::Value() const {
 }
 
 template <typename T>
-inline uint32_t Reference<T>::Ref() {
+inline uint32_t Reference<T>::Ref() const {
   uint32_t result;
   napi_status status = napi_reference_ref(_env, _ref, &result);
   NAPI_THROW_IF_FAILED(_env, status, 0);
@@ -2938,7 +2926,7 @@ inline uint32_t Reference<T>::Ref() {
 }
 
 template <typename T>
-inline uint32_t Reference<T>::Unref() {
+inline uint32_t Reference<T>::Unref() const {
   uint32_t result;
   napi_status status = napi_reference_unref(_env, _ref, &result);
   NAPI_THROW_IF_FAILED(_env, status, 0);
@@ -3064,61 +3052,61 @@ inline MaybeOrValue<Napi::Value> ObjectReference::Get(
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
-                                               napi_value value) {
+                                               napi_value value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
-                                               Napi::Value value) {
+                                               Napi::Value value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
-                                               const char* utf8value) {
+                                               const char* utf8value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
-                                               bool boolValue) {
+                                               bool boolValue) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
-                                               double numberValue) {
+                                               double numberValue) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, numberValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               napi_value value) {
+                                               napi_value value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               Napi::Value value) {
+                                               Napi::Value value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               std::string& utf8value) {
+                                               std::string& utf8value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               bool boolValue) {
+                                               bool boolValue) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               double numberValue) {
+                                               double numberValue) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, numberValue);
 }
@@ -3140,36 +3128,37 @@ inline MaybeOrValue<Napi::Value> ObjectReference::Get(uint32_t index) const {
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
-                                               napi_value value) {
+                                               napi_value value) const {
   HandleScope scope(_env);
   return Value().Set(index, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
-                                               Napi::Value value) {
+                                               Napi::Value value) const {
   HandleScope scope(_env);
   return Value().Set(index, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
-                                               const char* utf8value) {
+                                               const char* utf8value) const {
+  HandleScope scope(_env);
+  return Value().Set(index, utf8value);
+}
+
+inline MaybeOrValue<bool> ObjectReference::Set(
+    uint32_t index, const std::string& utf8value) const {
   HandleScope scope(_env);
   return Value().Set(index, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
-                                               const std::string& utf8value) {
-  HandleScope scope(_env);
-  return Value().Set(index, utf8value);
-}
-
-inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index, bool boolValue) {
+                                               bool boolValue) const {
   HandleScope scope(_env);
   return Value().Set(index, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
-                                               double numberValue) {
+                                               double numberValue) const {
   HandleScope scope(_env);
   return Value().Set(index, numberValue);
 }
@@ -5323,7 +5312,7 @@ template <typename ContextType,
           typename DataType,
           void (*CallJs)(Napi::Env, Napi::Function, ContextType*, DataType*)>
 inline napi_status
-TypedThreadSafeFunction<ContextType, DataType, CallJs>::Release() {
+TypedThreadSafeFunction<ContextType, DataType, CallJs>::Release() const {
   return napi_release_threadsafe_function(_tsfn, napi_tsfn_release);
 }
 
@@ -5331,7 +5320,7 @@ template <typename ContextType,
           typename DataType,
           void (*CallJs)(Napi::Env, Napi::Function, ContextType*, DataType*)>
 inline napi_status
-TypedThreadSafeFunction<ContextType, DataType, CallJs>::Abort() {
+TypedThreadSafeFunction<ContextType, DataType, CallJs>::Abort() const {
   return napi_release_threadsafe_function(_tsfn, napi_tsfn_abort);
 }
 
@@ -5661,11 +5650,11 @@ inline napi_status ThreadSafeFunction::Acquire() const {
   return napi_acquire_threadsafe_function(_tsfn);
 }
 
-inline napi_status ThreadSafeFunction::Release() {
+inline napi_status ThreadSafeFunction::Release() const {
   return napi_release_threadsafe_function(_tsfn, napi_tsfn_release);
 }
 
-inline napi_status ThreadSafeFunction::Abort() {
+inline napi_status ThreadSafeFunction::Abort() const {
   return napi_release_threadsafe_function(_tsfn, napi_tsfn_abort);
 }
 

--- a/napi.h
+++ b/napi.h
@@ -286,11 +286,11 @@ namespace Napi {
     Value Null() const;
 
     bool IsExceptionPending() const;
-    Error GetAndClearPendingException();
+    Error GetAndClearPendingException() const;
 
-    MaybeOrValue<Value> RunScript(const char* utf8script);
-    MaybeOrValue<Value> RunScript(const std::string& utf8script);
-    MaybeOrValue<Value> RunScript(String script);
+    MaybeOrValue<Value> RunScript(const char* utf8script) const;
+    MaybeOrValue<Value> RunScript(const std::string& utf8script) const;
+    MaybeOrValue<Value> RunScript(String script) const;
 
 #if NAPI_VERSION > 2
     template <typename Hook>
@@ -301,19 +301,20 @@ namespace Napi {
 #endif  // NAPI_VERSION > 2
 
 #if NAPI_VERSION > 5
-    template <typename T> T* GetInstanceData();
+    template <typename T>
+    T* GetInstanceData() const;
 
     template <typename T> using Finalizer = void (*)(Env, T*);
     template <typename T, Finalizer<T> fini = Env::DefaultFini<T>>
-    void SetInstanceData(T* data);
+    void SetInstanceData(T* data) const;
 
     template <typename DataType, typename HintType>
     using FinalizerWithHint = void (*)(Env, DataType*, HintType*);
     template <typename DataType,
               typename HintType,
               FinalizerWithHint<DataType, HintType> fini =
-                Env::DefaultFiniWithHint<DataType, HintType>>
-    void SetInstanceData(DataType* data, HintType* hint);
+                  Env::DefaultFiniWithHint<DataType, HintType>>
+    void SetInstanceData(DataType* data, HintType* hint) const;
 #endif  // NAPI_VERSION > 5
 
   private:
@@ -727,40 +728,22 @@ namespace Napi {
            napi_value value);  ///< Wraps a Node-API value primitive.
 
     /// Gets or sets a named property.
-    PropertyLValue<std::string> operator [](
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
-    );
-
-    /// Gets or sets a named property.
-    PropertyLValue<std::string> operator [](
-      const std::string& utf8name ///< UTF-8 encoded property name
-    );
-
-    /// Gets or sets an indexed property or array element.
-    PropertyLValue<uint32_t> operator [](
-      uint32_t index /// Property / element index
-    );
-
-    /// Gets or sets an indexed property or array element.
-    PropertyLValue<Value> operator[](Value index  /// Property / element index
-    );
-
-    /// Gets or sets an indexed property or array element.
-    PropertyLValue<Value> operator[](Value index  /// Property / element index
-    ) const;
-
-    /// Gets a named property.
-    MaybeOrValue<Value> operator[](
+    PropertyLValue<std::string> operator[](
         const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
-    /// Gets a named property.
-    MaybeOrValue<Value> operator[](
+    /// Gets or sets a named property.
+    PropertyLValue<std::string> operator[](
         const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
-    /// Gets an indexed property or array element.
-    MaybeOrValue<Value> operator[](uint32_t index  ///< Property / element index
+    /// Gets or sets an indexed property or array element.
+    PropertyLValue<uint32_t> operator[](
+        uint32_t index  /// Property / element index
+    ) const;
+
+    /// Gets or sets an indexed property or array element.
+    PropertyLValue<Value> operator[](Value index  /// Property / element index
     ) const;
 
     /// Checks whether a property is present.
@@ -822,44 +805,44 @@ namespace Napi {
     template <typename ValueType>
     MaybeOrValue<bool> Set(napi_value key,         ///< Property key primitive
                            const ValueType& value  ///< Property value primitive
-    );
+    ) const;
 
     /// Sets a property.
     template <typename ValueType>
     MaybeOrValue<bool> Set(Value key,              ///< Property key
                            const ValueType& value  ///< Property value
-    );
+    ) const;
 
     /// Sets a named property.
     template <typename ValueType>
     MaybeOrValue<bool> Set(
         const char* utf8name,  ///< UTF-8 encoded null-terminated property name
-        const ValueType& value);
+        const ValueType& value) const;
 
     /// Sets a named property.
     template <typename ValueType>
     MaybeOrValue<bool> Set(
         const std::string& utf8name,  ///< UTF-8 encoded property name
         const ValueType& value        ///< Property value primitive
-    );
+    ) const;
 
     /// Delete property.
     MaybeOrValue<bool> Delete(napi_value key  ///< Property key primitive
-    );
+    ) const;
 
     /// Delete property.
     MaybeOrValue<bool> Delete(Value key  ///< Property key
-    );
+    ) const;
 
     /// Delete property.
     MaybeOrValue<bool> Delete(
         const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    );
+    ) const;
 
     /// Delete property.
     MaybeOrValue<bool> Delete(
         const std::string& utf8name  ///< UTF-8 encoded property name
-    );
+    ) const;
 
     /// Checks whether an indexed property is present.
     MaybeOrValue<bool> Has(uint32_t index  ///< Property / element index
@@ -873,11 +856,11 @@ namespace Napi {
     template <typename ValueType>
     MaybeOrValue<bool> Set(uint32_t index,         ///< Property / element index
                            const ValueType& value  ///< Property value primitive
-    );
+    ) const;
 
     /// Deletes an indexed property or array element.
     MaybeOrValue<bool> Delete(uint32_t index  ///< Property / element index
-    );
+    ) const;
 
     /// This operation can fail in case of Proxy.[[OwnPropertyKeys]] and
     /// Proxy.[[GetOwnProperty]] calling into JavaScript. See:
@@ -895,7 +878,7 @@ namespace Napi {
     MaybeOrValue<bool> DefineProperty(
         const PropertyDescriptor&
             property  ///< Descriptor for the property to be defined
-    );
+    ) const;
 
     /// Defines properties on the object.
     ///
@@ -905,7 +888,7 @@ namespace Napi {
     MaybeOrValue<bool> DefineProperties(
         const std::initializer_list<PropertyDescriptor>& properties
         ///< List of descriptors for the properties to be defined
-    );
+    ) const;
 
     /// Defines properties on the object.
     ///
@@ -915,7 +898,7 @@ namespace Napi {
     MaybeOrValue<bool> DefineProperties(
         const std::vector<PropertyDescriptor>& properties
         ///< Vector of descriptors for the properties to be defined
-    );
+    ) const;
 
     /// Checks if an object is an instance created by a constructor function.
     ///
@@ -930,12 +913,12 @@ namespace Napi {
     ) const;
 
     template <typename Finalizer, typename T>
-    inline void AddFinalizer(Finalizer finalizeCallback, T* data);
+    inline void AddFinalizer(Finalizer finalizeCallback, T* data) const;
 
     template <typename Finalizer, typename T, typename Hint>
     inline void AddFinalizer(Finalizer finalizeCallback,
                              T* data,
-                             Hint* finalizeHint);
+                             Hint* finalizeHint) const;
 
 #ifdef NAPI_CPP_EXCEPTIONS
     class const_iterator;
@@ -956,12 +939,12 @@ namespace Napi {
     /// JavaScript.
     /// See
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
-    MaybeOrValue<bool> Freeze();
+    MaybeOrValue<bool> Freeze() const;
     /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
     /// JavaScript.
     /// See
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
-    MaybeOrValue<bool> Seal();
+    MaybeOrValue<bool> Seal() const;
 #endif  // NAPI_VERSION >= 8
   };
 
@@ -1462,8 +1445,8 @@ namespace Napi {
     // within a HandleScope so that the value handle gets cleaned up efficiently.
     T Value() const;
 
-    uint32_t Ref();
-    uint32_t Unref();
+    uint32_t Ref() const;
+    uint32_t Unref() const;
     void Reset();
     void Reset(const T& value, uint32_t refcount = 0);
 
@@ -1500,24 +1483,27 @@ namespace Napi {
 
     MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
     MaybeOrValue<Napi::Value> Get(const std::string& utf8name) const;
-    MaybeOrValue<bool> Set(const char* utf8name, napi_value value);
-    MaybeOrValue<bool> Set(const char* utf8name, Napi::Value value);
-    MaybeOrValue<bool> Set(const char* utf8name, const char* utf8value);
-    MaybeOrValue<bool> Set(const char* utf8name, bool boolValue);
-    MaybeOrValue<bool> Set(const char* utf8name, double numberValue);
-    MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value);
-    MaybeOrValue<bool> Set(const std::string& utf8name, Napi::Value value);
-    MaybeOrValue<bool> Set(const std::string& utf8name, std::string& utf8value);
-    MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue);
-    MaybeOrValue<bool> Set(const std::string& utf8name, double numberValue);
+    MaybeOrValue<bool> Set(const char* utf8name, napi_value value) const;
+    MaybeOrValue<bool> Set(const char* utf8name, Napi::Value value) const;
+    MaybeOrValue<bool> Set(const char* utf8name, const char* utf8value) const;
+    MaybeOrValue<bool> Set(const char* utf8name, bool boolValue) const;
+    MaybeOrValue<bool> Set(const char* utf8name, double numberValue) const;
+    MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value) const;
+    MaybeOrValue<bool> Set(const std::string& utf8name,
+                           Napi::Value value) const;
+    MaybeOrValue<bool> Set(const std::string& utf8name,
+                           std::string& utf8value) const;
+    MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue) const;
+    MaybeOrValue<bool> Set(const std::string& utf8name,
+                           double numberValue) const;
 
     MaybeOrValue<Napi::Value> Get(uint32_t index) const;
-    MaybeOrValue<bool> Set(uint32_t index, const napi_value value);
-    MaybeOrValue<bool> Set(uint32_t index, const Napi::Value value);
-    MaybeOrValue<bool> Set(uint32_t index, const char* utf8value);
-    MaybeOrValue<bool> Set(uint32_t index, const std::string& utf8value);
-    MaybeOrValue<bool> Set(uint32_t index, bool boolValue);
-    MaybeOrValue<bool> Set(uint32_t index, double numberValue);
+    MaybeOrValue<bool> Set(uint32_t index, const napi_value value) const;
+    MaybeOrValue<bool> Set(uint32_t index, const Napi::Value value) const;
+    MaybeOrValue<bool> Set(uint32_t index, const char* utf8value) const;
+    MaybeOrValue<bool> Set(uint32_t index, const std::string& utf8value) const;
+    MaybeOrValue<bool> Set(uint32_t index, bool boolValue) const;
+    MaybeOrValue<bool> Set(uint32_t index, double numberValue) const;
 
    protected:
     ObjectReference(const ObjectReference&);
@@ -2553,10 +2539,10 @@ namespace Napi {
     napi_status Acquire() const;
 
     // This API may be called from any thread.
-    napi_status Release();
+    napi_status Release() const;
 
     // This API may be called from any thread.
-    napi_status Abort();
+    napi_status Abort() const;
 
     struct ConvertibleContext
     {
@@ -2752,10 +2738,10 @@ namespace Napi {
     napi_status Acquire() const;
 
     // This API may be called from any thread.
-    napi_status Release();
+    napi_status Release() const;
 
     // This API may be called from any thread.
-    napi_status Abort();
+    napi_status Abort() const;
 
     // This API may be called from any thread.
     ContextType* GetContext() const;

--- a/napi.h
+++ b/napi.h
@@ -921,17 +921,11 @@ namespace Napi {
                              Hint* finalizeHint) const;
 
 #ifdef NAPI_CPP_EXCEPTIONS
-    class const_iterator;
-
-    inline const_iterator begin() const;
-
-    inline const_iterator end() const;
-
     class iterator;
 
-    inline iterator begin();
+    inline iterator begin() const;
 
-    inline iterator end();
+    inline iterator end() const;
 #endif  // NAPI_CPP_EXCEPTIONS
 
 #if NAPI_VERSION >= 8
@@ -983,35 +977,11 @@ namespace Napi {
   };
 
 #ifdef NAPI_CPP_EXCEPTIONS
-  class Object::const_iterator {
-   private:
-    enum class Type { BEGIN, END };
-
-    inline const_iterator(const Object* object, const Type type);
-
-   public:
-    inline const_iterator& operator++();
-
-    inline bool operator==(const const_iterator& other) const;
-
-    inline bool operator!=(const const_iterator& other) const;
-
-    inline const std::pair<Value, Object::PropertyLValue<Value>> operator*()
-        const;
-
-   private:
-    const Napi::Object* _object;
-    Array _keys;
-    uint32_t _index;
-
-    friend class Object;
-  };
-
   class Object::iterator {
    private:
     enum class Type { BEGIN, END };
 
-    inline iterator(Object* object, const Type type);
+    inline iterator(const Object* object, const Type type);
 
    public:
     inline iterator& operator++();
@@ -1020,10 +990,10 @@ namespace Napi {
 
     inline bool operator!=(const iterator& other) const;
 
-    inline std::pair<Value, Object::PropertyLValue<Value>> operator*();
+    inline std::pair<Value, Object::PropertyLValue<Value>> operator*() const;
 
    private:
-    Napi::Object* _object;
+    const Napi::Object* _object;
     Array _keys;
     uint32_t _index;
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node-addon-api/issues/870.

Some const methods weren't documented as const, so I think it makes sense to separate this into two commits.

Are there any other methods that should fall under this change?