### PR TITLE
test: remove outdated V8 flag

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const majorNodeVersion = process.versions.node.split('.')[0];
 
 if (typeof global.gc !== 'function') {
   // Construct the correct (version-dependent) command-line args.
-  let args = ['--expose-gc', '--no-concurrent-array-buffer-freeing'];
+  let args = ['--expose-gc'];
   if (majorNodeVersion >= 14) {
     args.push('--no-concurrent-array-buffer-sweeping');
   }

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,10 @@ const majorNodeVersion = process.versions.node.split('.')[0];
 if (typeof global.gc !== 'function') {
   // Construct the correct (version-dependent) command-line args.
   let args = ['--expose-gc'];
+  const majorV8Version = process.versions.v8.split('.')[0];
+  if (majorV8Version < 9) {
+    args.push('--no-concurrent-array-buffer-freeing');
+  }
   if (majorNodeVersion >= 14) {
     args.push('--no-concurrent-array-buffer-sweeping');
   }


### PR DESCRIPTION
The `--concurrent-array-buffer-freeing` flag is going to be removed
upstream in V8 9.0.

Refs: https://github.com/v8/v8/commit/0a480c30d553c1b8dddb0dddcbdec5fb6f3101ff