### PR TITLE
src: remove unnecessary symbol exposure

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -344,12 +344,11 @@ struct AccessorCallbackData {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Register an add-on based on an initializer function.
-#define NODE_API_MODULE(modname, regfunc)                 \
-  static napi_value __napi_ ## regfunc(napi_env env,      \
-                                napi_value exports) {     \
-    return Napi::RegisterModule(env, exports, regfunc);   \
-  }                                                       \
-  NAPI_MODULE(modname, __napi_ ## regfunc)
+#define NODE_API_MODULE(modname, regfunc)                                      \
+  static napi_value __napi_##regfunc(napi_env env, napi_value exports) {       \
+    return Napi::RegisterModule(env, exports, regfunc);                        \
+  }                                                                            \
+  NAPI_MODULE(modname, __napi_##regfunc)
 
 // Register an add-on based on a subclass of `Addon<T>` with a custom Node.js
 // module name.

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -345,7 +345,7 @@ struct AccessorCallbackData {
 
 // Register an add-on based on an initializer function.
 #define NODE_API_MODULE(modname, regfunc)                 \
-  napi_value __napi_ ## regfunc(napi_env env,             \
+  static napi_value __napi_ ## regfunc(napi_env env,      \
                                 napi_value exports) {     \
     return Napi::RegisterModule(env, exports, regfunc);   \
   }                                                       \


### PR DESCRIPTION
The symbol generated by `NODE_API_MODULE()` is exposed unnecessarily.
It is sufficient for it to be a local symbol because it is passed
around as a function pointer. Furthermore, making it `static` fixes a
warning.

Fixes: https://github.com/nodejs/node-addon-api/issues/888