### PR TITLE
doc: Update GitHub URL references from 'master' to 'HEAD'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 env:
   global:
-    # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+    # https://github.com/jasongin/nvs/blob/HEAD/doc/CI.md
     - NVS_VERSION=1.4.2
   matrix:
     - NODEJS_VERSION=node/10

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
 The Node.js Code of Conduct, which applies to this project, can be found at
-https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md.
+https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md.

--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ The following is the documentation for node-addon-api.
 
 Are you new to **node-addon-api**? Take a look at our **[examples](https://github.com/nodejs/node-addon-examples)**
 
-- **[Hello World](https://github.com/nodejs/node-addon-examples/tree/master/1_hello_world/node-addon-api)**
-- **[Pass arguments to a function](https://github.com/nodejs/node-addon-examples/tree/master/2_function_arguments/node-addon-api)**
-- **[Callbacks](https://github.com/nodejs/node-addon-examples/tree/master/3_callbacks/node-addon-api)**
-- **[Object factory](https://github.com/nodejs/node-addon-examples/tree/master/4_object_factory/node-addon-api)**
-- **[Function factory](https://github.com/nodejs/node-addon-examples/tree/master/5_function_factory/node-addon-api)**
-- **[Wrapping C++ Object](https://github.com/nodejs/node-addon-examples/tree/master/6_object_wrap/node-addon-api)**
-- **[Factory of wrapped object](https://github.com/nodejs/node-addon-examples/tree/master/7_factory_wrap/node-addon-api)**
-- **[Passing wrapped object around](https://github.com/nodejs/node-addon-examples/tree/master/8_passing_wrapped/node-addon-api)**
+- **[Hello World](https://github.com/nodejs/node-addon-examples/tree/HEAD/1_hello_world/node-addon-api)**
+- **[Pass arguments to a function](https://github.com/nodejs/node-addon-examples/tree/HEAD/2_function_arguments/node-addon-api)**
+- **[Callbacks](https://github.com/nodejs/node-addon-examples/tree/HEAD/3_callbacks/node-addon-api)**
+- **[Object factory](https://github.com/nodejs/node-addon-examples/tree/HEAD/4_object_factory/node-addon-api)**
+- **[Function factory](https://github.com/nodejs/node-addon-examples/tree/HEAD/5_function_factory/node-addon-api)**
+- **[Wrapping C++ Object](https://github.com/nodejs/node-addon-examples/tree/HEAD/6_object_wrap/node-addon-api)**
+- **[Factory of wrapped object](https://github.com/nodejs/node-addon-examples/tree/HEAD/7_factory_wrap/node-addon-api)**
+- **[Passing wrapped object around](https://github.com/nodejs/node-addon-examples/tree/HEAD/8_passing_wrapped/node-addon-api)**
 
 <a name="tests"></a>
 
@@ -201,7 +201,7 @@ If you want faster build, you might use the following option:
 npm run-script dev:incremental
 ```
 
-Take a look and get inspired by our **[test suite](https://github.com/nodejs/node-addon-api/tree/master/test)**
+Take a look and get inspired by our **[test suite](https://github.com/nodejs/node-addon-api/tree/HEAD/test)**
 
 ### **Benchmarks**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  # https://github.com/jasongin/nvs/blob/master/doc/CI.md
+  # https://github.com/jasongin/nvs/blob/HEAD/doc/CI.md
   NVS_VERSION: 1.4.2
   matrix:
     - NODEJS_VERSION: node/10

--- a/doc/array.md
+++ b/doc/array.md
@@ -9,7 +9,7 @@ around `napi_value` representing a JavaScript Array.
 types such as [`Napi::Int32Array`][] and [`Napi::ArrayBuffer`][], respectively,
 that can be used for transferring large amounts of data from JavaScript to the
 native side. An example illustrating the use of a JavaScript-provided
-`ArrayBuffer` in native code is available [here](https://github.com/nodejs/node-addon-examples/tree/master/array_buffer_to_native/node-addon-api).
+`ArrayBuffer` in native code is available [here](https://github.com/nodejs/node-addon-examples/tree/HEAD/array_buffer_to_native/node-addon-api).
 
 ## Constructor
 ```cpp

--- a/doc/cmake-js.md
+++ b/doc/cmake-js.md
@@ -51,7 +51,7 @@ If your N-API native add-on uses the optional [**node-addon-api**](https://githu
 
 ## Example
 
-A working example of an N-API native addon built using CMake.js can be found on the [node-addon-examples repository](https://github.com/nodejs/node-addon-examples/tree/master/build_with_cmake#building-n-api-addons-using-cmakejs).
+A working example of an N-API native addon built using CMake.js can be found on the [node-addon-examples repository](https://github.com/nodejs/node-addon-examples/tree/HEAD/build_with_cmake#building-n-api-addons-using-cmakejs).
 
 ## **CMake** Reference
 

--- a/doc/property_descriptor.md
+++ b/doc/property_descriptor.md
@@ -282,5 +282,5 @@ The name of the property can be any of the following types:
 - napi\_writable,
 - napi\_enumerable,
 - napi\_configurable
-For more information on the flags and on napi\_property\_attributes, please read the documentation [here](https://github.com/nodejs/node/blob/master/doc/api/n-api.md#napi_property_attributes).
+For more information on the flags and on napi\_property\_attributes, please read the documentation [here](https://github.com/nodejs/node/blob/HEAD/doc/api/n-api.md#napi_property_attributes).
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -33,7 +33,7 @@ To use **N-API** in a native module:
      The base ABI-stable C APIs do not throw or handle C++ exceptions, but the
      N-API C++ wrapper classes may _optionally_
      [integrate C++ and JavaScript exception-handling
-     ](https://nodejs.github.io/node-addon-api/class_napi_1_1_error.html).
+     ](https://github.com/nodejs/node-addon-api/blob/HEAD/doc/error_handling.md).
      To enable that capability, C++ exceptions must be enabled in `binding.gyp`:
 
 ```gyp


### PR DESCRIPTION
URL references to GitHub resources with `HEAD` in the path will resolve to the correct default branch whether it's `master` or `main`. 

This PR should complete the repo's migration from the default branch of `master` to `main`. 

See https://github.com/nodejs/abi-stable-node/issues/421