### PR TITLE
src: fix a crashing issue in Error::ThrowAsJavaScriptException

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2373,6 +2373,11 @@ inline void Error::ThrowAsJavaScriptException() const {
 
     napi_status status = napi_throw(_env, Value());
 
+    if (status == napi_pending_exception) {
+      // The environment could be terminating.
+      return;
+    }
+
 #ifdef NAPI_CPP_EXCEPTIONS
     if (status != napi_ok) {
       throw Error::New(_env);

--- a/test/error_terminating_environment.js
+++ b/test/error_terminating_environment.js
@@ -1,0 +1,88 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+
+// These tests ensure that Error types can be used in a terminating
+// environment without triggering any fatal errors.
+
+if (process.argv[2] === 'runInChildProcess') {
+  const binding_path = process.argv[3];
+  const index_for_test_case = Number(process.argv[4]);
+
+  const binding = require(binding_path);
+
+  // Use C++ promises to ensure the worker thread is terminated right
+  // before running the testable code in the binding.
+
+  binding.error.resetPromises()
+
+  const { Worker } = require('worker_threads');
+
+  const worker = new Worker(
+    __filename,
+    {
+      argv: [
+        'runInWorkerThread',
+        binding_path,
+        index_for_test_case,
+      ]
+    }
+  );
+
+  binding.error.waitForWorkerThread()
+
+  worker.terminate();
+
+  binding.error.releaseWorkerThread()
+
+  return;
+}
+
+if (process.argv[2] === 'runInWorkerThread') {
+  const binding_path = process.argv[3];
+  const index_for_test_case = Number(process.argv[4]);
+
+  const binding = require(binding_path);
+
+  switch (index_for_test_case) {
+    case 0:
+      binding.error.throwJSError('test', true);
+      break;
+    case 1:
+      binding.error.throwTypeError('test', true);
+      break;
+    case 2:
+      binding.error.throwRangeError('test', true);
+      break;
+    case 3:
+      binding.error.throwDefaultError(false, true);
+      break;
+    case 4:
+      binding.error.throwDefaultError(true, true);
+      break;
+    default: assert.fail('Invalid index');
+  }
+
+  assert.fail('This should not be reachable');
+}
+
+test(`./build/${buildType}/binding.node`);
+test(`./build/${buildType}/binding_noexcept.node`);
+
+function test(bindingPath) {
+  const number_of_test_cases = 5;
+
+  for (let i = 0; i < number_of_test_cases; ++i) {
+    const child_process = require('./napi_child').spawnSync(
+      process.execPath,
+      [
+        __filename,
+        'runInChildProcess',
+        bindingPath,
+        i,
+      ]
+    );
+
+    assert(child_process.status === 0, `Test case ${i} failed`);
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,7 @@ if (napiVersion < 6) {
 
 if (majorNodeVersion < 12) {
   testModules.splice(testModules.indexOf('objectwrap_worker_thread'), 1);
+  testModules.splice(testModules.indexOf('error_terminating_environment'), 1);
 }
 
 (async function() {


### PR DESCRIPTION
When terminating an environment (e.g., by calling `worker.terminate`), `napi_throw`, which is called by `Error::ThrowAsJavaScriptException`, returns `napi_pending_exception`, which is then incorrectly treated as a fatal error resulting in a crash.

This is relatively easy to trigger with a native addon that runs a long synchronous operation, which then throws a JavaScript exception, but not before the environment has begun to terminate.

The other instances where errors are treated fatal in node-addon-api are unlikely to cause similar issues. Unlike `napi_throw`, none of the respective napi functions use `NAPI_PREAMBLE` macro (which returns `napi_pending_exception` in a terminating environment), and the few functions that handle V8 maybe types are tested with the test cases I added.