### PR TITLE
doc: fix spelling of "targeted" and "targeting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ npm install
 npm test --disable-deprecated
 ```
 
-To run the tests targetting a specific version of N-API run
+To run the tests targeting a specific version of N-API run
 ```
 npm install
 export NAPI_VERSION=X

--- a/doc/typed_threadsafe_function.md
+++ b/doc/typed_threadsafe_function.md
@@ -87,15 +87,15 @@ New(napi_env env,
 
 Returns a non-empty `Napi::TypedThreadSafeFunction` instance.
 
-Depending on the targetted `NAPI_VERSION`, the API has different implementations
+Depending on the targeted `NAPI_VERSION`, the API has different implementations
 for `CallbackType callback`.
 
-When targetting version 4, `callback` may be:
+When targeting version 4, `callback` may be:
 - of type `const Function&`
 - not provided as a parameter, in which case the API creates a new no-op
   `Function`
 
-When targetting version 5+, `callback` may be:
+When targeting version 5+, `callback` may be:
 - of type `const Function&`
 - of type `std::nullptr_t`
 - not provided as a parameter, in which case the API passes `std::nullptr`


### PR DESCRIPTION
From what I've been told, `targetted` and `targetting` are uncommon at best, and considered wrong in most contexts. (I am not a native English speaker, though.)