### PR TITLE
tools: fix error detection

### DIFF
--- a/tools/clang-format.js
+++ b/tools/clang-format.js
@@ -21,8 +21,8 @@ function main(args) {
     ...filesToCheck
   ], { encoding: 'utf-8' });
 
-  if (result.error) {
-    console.error('Error running git-clang-format:', result.error);
+  if (result.stderr) {
+    console.error('Error running git-clang-format:', result.stderr);
     return 2;
   }
 


### PR DESCRIPTION
The `ChildProces` object `result` does not have an `error` property. We
should use `stderr` instead.