### PR TITLE
src: return Maybe<> on pending exception when cpp exception disabled

### DIFF
--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -17,6 +17,7 @@ error-handling for C++ exceptions and JavaScript exceptions.
 The following sections explain the approach for each case:
 
 - [Handling Errors With C++ Exceptions](#exceptions)
+- [Handling Errors With Maybe Type and C++ Exceptions Disabled](#noexceptions-maybe)
 - [Handling Errors Without C++ Exceptions](#noexceptions)
 
 <a name="exceptions"></a>
@@ -70,7 +71,7 @@ when returning to JavaScript.
 ### Propagating a Node-API C++ exception
 
 ```cpp
-Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
 Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
 // other C++ statements
 // ...
@@ -84,7 +85,7 @@ a JavaScript exception when returning to JavaScript.
 ### Handling a Node-API C++ exception
 
 ```cpp
-Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
 Napi::Value result;
 try {
     result = jsFunctionThatThrows({ arg1, arg2 });
@@ -95,6 +96,69 @@ try {
 
 Since the exception was caught here, it will not be propagated as a JavaScript
 exception.
+
+<a name="noexceptions-maybe"></a>
+
+## Handling Errors With Maybe Type and C++ Exceptions Disabled
+
+If C++ exceptions are disabled (for more info see: [Setup](setup.md)), then the
+`Napi::Error` class does not extend `std::exception`. This means that any calls to
+node-addon-api function do not throw a C++ exceptions. Instead, these node-api
+functions that calling into JavaScript are returning with `Maybe` boxed values.
+In that case, the calling side should convert the `Maybe` boxed values with
+checks to ensure that the call did succeed and therefore no exception is pending.
+If the check fails, that is to say, the returning value is _empty_, the calling
+side should determine what to do with `env.GetAndClearPendingException()` before
+attempting to calling into another node-api (for more info see: [Env](env.md)).
+
+The conversion from `Maybe` boxed values to actual return value is enforced by
+compilers so that the exceptions must be properly handled before continuing.
+
+## Examples with Maybe Type and C++ exceptions disabled
+
+### Throwing a JS exception
+
+```cpp
+Napi::Env env = ...
+Napi::Error::New(env, "Example exception").ThrowAsJavaScriptException();
+return;
+```
+
+After throwing a JavaScript exception, the code should generally return
+immediately from the native callback, after performing any necessary cleanup.
+
+### Propagating a Node-API JS exception
+
+```cpp
+Napi::Env env = ...
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
+Maybe<Napi::Value> maybeResult = jsFunctionThatThrows({ arg1, arg2 });
+Napi::Value result;
+if (!maybeResult.To(&result)) {
+    // The Maybe is empty, calling into js failed, cleaning up...
+    // It is recommended to return an empty Maybe if the procedure failed.
+    return result;
+}
+```
+
+If `maybeResult.To(&result)` returns false a JavaScript exception is pending.
+To let the exception propagate, the code should generally return immediately
+from the native callback, after performing any necessary cleanup.
+
+### Handling a Node-API JS exception
+
+```cpp
+Napi::Env env = ...
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
+Maybe<Napi::Value> maybeResult = jsFunctionThatThrows({ arg1, arg2 });
+if (maybeResult.IsNothing()) {
+    Napi::Error e = env.GetAndClearPendingException();
+    cerr << "Caught JavaScript exception: " + e.Message();
+}
+```
+
+Since the exception was cleared here, it will not be propagated as a JavaScript
+exception after the native callback returns.
 
 <a name="noexceptions"></a>
 
@@ -127,7 +191,7 @@ immediately from the native callback, after performing any necessary cleanup.
 
 ```cpp
 Napi::Env env = ...
-Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
 Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
 if (env.IsExceptionPending()) {
     Error e = env.GetAndClearPendingException();
@@ -143,7 +207,7 @@ the native callback, after performing any necessary cleanup.
 
 ```cpp
 Napi::Env env = ...
-Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+Napi::Function jsFunctionThatThrows = someValue.As<Napi::Function>();
 Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
 if (env.IsExceptionPending()) {
     Napi::Error e = env.GetAndClearPendingException();

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -103,16 +103,17 @@ exception.
 
 If C++ exceptions are disabled (for more info see: [Setup](setup.md)), then the
 `Napi::Error` class does not extend `std::exception`. This means that any calls to
-node-addon-api function do not throw a C++ exceptions. Instead, these node-api
+node-addon-api functions do not throw a C++ exceptions. Instead, these node-api
 functions that call into JavaScript are returning with `Maybe` boxed values.
 In that case, the calling side should convert the `Maybe` boxed values with
 checks to ensure that the call did succeed and therefore no exception is pending.
 If the check fails, that is to say, the returning value is _empty_, the calling
 side should determine what to do with `env.GetAndClearPendingException()` before
-attempting to calling into another node-api (for more info see: [Env](env.md)).
+attempting to call another node-api (for more info see: [Env](env.md)).
 
-The conversion from `Maybe` boxed values to actual return value is enforced by
-compilers so that the exceptions must be properly handled before continuing.
+The conversion from the `Maybe` boxed value to the actual return value is
+enforced by compilers so that the exceptions must be properly handled before
+continuing.
 
 ## Examples with Maybe Type and C++ exceptions disabled
 

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -104,7 +104,7 @@ exception.
 If C++ exceptions are disabled (for more info see: [Setup](setup.md)), then the
 `Napi::Error` class does not extend `std::exception`. This means that any calls to
 node-addon-api function do not throw a C++ exceptions. Instead, these node-api
-functions that calling into JavaScript are returning with `Maybe` boxed values.
+functions that call into JavaScript are returning with `Maybe` boxed values.
 In that case, the calling side should convert the `Maybe` boxed values with
 checks to ensure that the call did succeed and therefore no exception is pending.
 If the check fails, that is to say, the returning value is _empty_, the calling

--- a/doc/maybe.md
+++ b/doc/maybe.md
@@ -1,10 +1,10 @@
 # Maybe (template)
 
-Class `Napi::Maybe<T>` represents an maybe empty value: every `Maybe` is either
-`Just` and contains a value, or `Nothing`, and does not. `Maybe` types are very
-common in node-addon-api code, as they represent the function may throw a
-JavaScript exception and cause the program unable to evaluation any JavaScript
-code until the exception is been handled.
+Class `Napi::Maybe<T>` represents a value that may be empty: every `Maybe` is
+either `Just` and contains a value, or `Nothing`, and does not. `Maybe` types
+are very common in node-addon-api code, as they represent that the function may
+throw a JavaScript exception and cause the program to be unable to evaluate any
+JavaScript code until the exception has been handled.
 
 Typically, the value wrapped in `Napi::Maybe<T>` is [`Napi::Value`] and its
 subclasses.
@@ -58,7 +58,7 @@ template <typename T>
 T Napi::Maybe::UnwrapOr(const T& default_value) const;
 ```
 
-Return the value of type T contained in the Maybe, or using a default
+Return the value of type T contained in the Maybe, or use a default
 value if this Maybe is nothing (empty).
 
 ### UnwrapTo
@@ -69,6 +69,6 @@ bool Napi::Maybe::UnwrapTo() const;
 ```
 
 Converts this Maybe to a value of type `T` in the `out`. If this Maybe is
-nothing (empty), `false` is returned and `out is left untouched.
+nothing (empty), `false` is returned and `out` is left untouched.
 
 [`Napi::Value`]: ./value.md

--- a/doc/maybe.md
+++ b/doc/maybe.md
@@ -1,0 +1,74 @@
+# Maybe (template)
+
+Class `Napi::Maybe<T>` represents an maybe empty value: every `Maybe` is either
+`Just` and contains a value, or `Nothing`, and does not. `Maybe` types are very
+common in node-addon-api code, as they represent the function may throw a
+JavaScript exception and cause the program unable to evaluation any JavaScript
+code until the exception is been handled.
+
+Typically, the value wrapped in `Napi::Maybe<T>` is [`Napi::Value`] and its
+subclasses.
+
+## Methods
+
+### IsNothing
+
+```cpp
+template <typename T>
+bool Napi::Maybe::IsNothing() const;
+```
+
+Returns if the `Maybe` is `Nothing` and does not contain a value.
+
+### IsJust
+
+```cpp
+template <typename T>
+bool Napi::Maybe::IsJust() const;
+```
+
+Returns if the `Maybe` is `Just` and contains a value.
+
+### Check
+
+```cpp
+template <typename T>
+void Napi::Maybe::Check() const;
+```
+
+Short-hand for `Maybe::Unwrap()`, which doesn't return a value. Could be used
+where the actual value of the Maybe is not needed like `Object::Set`.
+If this Maybe is nothing (empty), node-addon-api will crash the
+process.
+
+### Unwrap
+
+```cpp
+template <typename T>
+T Napi::Maybe::Unwrap() const;
+```
+
+Return the value of type `T` contained in the Maybe. If this Maybe is
+nothing (empty), node-addon-api will crash the process.
+
+### UnwrapOr
+
+```cpp
+template <typename T>
+T Napi::Maybe::UnwrapOr(const T& default_value) const;
+```
+
+Return the value of type T contained in the Maybe, or using a default
+value if this Maybe is nothing (empty).
+
+### UnwrapTo
+
+```cpp
+template <typename T>
+bool Napi::Maybe::UnwrapTo() const;
+```
+
+Converts this Maybe to a value of type `T` in the `out`. If this Maybe is
+nothing (empty), `false` is returned and `out is left untouched.
+
+[`Napi::Value`]: ./value.md

--- a/doc/maybe.md
+++ b/doc/maybe.md
@@ -18,7 +18,8 @@ template <typename T>
 bool Napi::Maybe::IsNothing() const;
 ```
 
-Returns if the `Maybe` is `Nothing` and does not contain a value.
+Returns `true` if the `Maybe` is `Nothing` and does not contain a value, and
+`false` otherwise.
 
 ### IsJust
 
@@ -27,7 +28,8 @@ template <typename T>
 bool Napi::Maybe::IsJust() const;
 ```
 
-Returns if the `Maybe` is `Just` and contains a value.
+Returns `true` if the `Maybe` is `Just` and contains a value, and `false`
+otherwise.
 
 ### Check
 
@@ -65,7 +67,7 @@ value if this Maybe is nothing (empty).
 
 ```cpp
 template <typename T>
-bool Napi::Maybe::UnwrapTo() const;
+bool Napi::Maybe::UnwrapTo(T* result) const;
 ```
 
 Converts this Maybe to a value of type `T` in the `out`. If this Maybe is

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -56,7 +56,7 @@ To use **Node-API** in a native module:
 ```
 
   If you decide to use node-addon-api without C++ exceptions enabled, please
-  consider enabling node-addon-api safe API type guards to ensure proper
+  consider enabling node-addon-api safe API type guards to ensure the proper
   exception handling pattern:
 
 ```gyp

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -54,6 +54,15 @@ To use **Node-API** in a native module:
 ```gyp
   'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
 ```
+
+  If you decide to use node-addon-api without C++ exceptions enabled, please
+  consider enabling node-addon-api safe API type guards to ensure proper
+  exception handling pattern:
+
+```gyp
+  'defines': [ 'NODE_ADDON_API_ENABLE_MAYBE' ],
+```
+
   4. If you would like your native addon to support OSX, please also add the
   following settings in the `binding.gyp` file:
 

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -378,6 +378,72 @@ inline napi_value RegisterModule(napi_env env,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Maybe class
+////////////////////////////////////////////////////////////////////////////////
+
+template <class T>
+bool Maybe<T>::IsNothing() const {
+  return !_has_value;
+}
+
+template <class T>
+bool Maybe<T>::IsJust() const {
+  return _has_value;
+}
+
+template <class T>
+void Maybe<T>::Check() const {
+  NAPI_CHECK(IsJust(), "Napi::Maybe::Check", "Maybe value is Nothing.");
+}
+
+template <class T>
+T Maybe<T>::Unwrap() const {
+  NAPI_CHECK(IsJust(), "Napi::Maybe::Unwrap", "Maybe value is Nothing.");
+  return _value;
+}
+
+template <class T>
+T Maybe<T>::UnwrapOr(const T& default_value) const {
+  return _has_value ? _value : default_value;
+}
+
+template <class T>
+bool Maybe<T>::UnwrapTo(T* out) const {
+  if (IsJust()) {
+    *out = _value;
+    return true;
+  };
+  return false;
+}
+
+template <class T>
+bool Maybe<T>::operator==(const Maybe& other) const {
+  return (IsJust() == other.IsJust()) &&
+         (!IsJust() || Unwrap() == other.Unwrap());
+}
+
+template <class T>
+bool Maybe<T>::operator!=(const Maybe& other) const {
+  return !operator==(other);
+}
+
+template <class T>
+Maybe<T>::Maybe() : _has_value(false) {}
+
+template <class T>
+Maybe<T>::Maybe(const T& t) : _has_value(true), _value(t) {}
+
+template <class T>
+inline Maybe<T> Nothing() {
+  return Maybe<T>();
+}
+
+template <class T>
+inline Maybe<T> Just(const T& t) {
+  return Maybe<T>(t);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Env class
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -426,20 +492,20 @@ inline Error Env::GetAndClearPendingException() {
   return Error(_env, value);
 }
 
-inline Value Env::RunScript(const char* utf8script) {
+inline MaybeOrValue<Value> Env::RunScript(const char* utf8script) {
   String script = String::New(_env, utf8script);
   return RunScript(script);
 }
 
-inline Value Env::RunScript(const std::string& utf8script) {
+inline MaybeOrValue<Value> Env::RunScript(const std::string& utf8script) {
   return RunScript(utf8script.c_str());
 }
 
-inline Value Env::RunScript(String script) {
+inline MaybeOrValue<Value> Env::RunScript(String script) {
   napi_value result;
   napi_status status = napi_run_script(_env, script, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Undefined());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
 #if NAPI_VERSION > 5
@@ -658,32 +724,32 @@ inline T Value::As() const {
   return T(_env, _value);
 }
 
-inline Boolean Value::ToBoolean() const {
+inline MaybeOrValue<Boolean> Value::ToBoolean() const {
   napi_value result;
   napi_status status = napi_coerce_to_bool(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Boolean());
-  return Boolean(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Boolean(_env, result), Napi::Boolean);
 }
 
-inline Number Value::ToNumber() const {
+inline MaybeOrValue<Number> Value::ToNumber() const {
   napi_value result;
   napi_status status = napi_coerce_to_number(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Number());
-  return Number(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Number(_env, result), Napi::Number);
 }
 
-inline String Value::ToString() const {
+inline MaybeOrValue<String> Value::ToString() const {
   napi_value result;
   napi_status status = napi_coerce_to_string(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, String());
-  return String(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::String(_env, result), Napi::String);
 }
 
-inline Object Value::ToObject() const {
+inline MaybeOrValue<Object> Value::ToObject() const {
   napi_value result;
   napi_status status = napi_coerce_to_object(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Object());
-  return Object(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Object(_env, result), Napi::Object);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -773,7 +839,10 @@ inline int64_t Number::Int64Value() const {
 }
 
 inline float Number::FloatValue() const {
-  return static_cast<float>(DoubleValue());
+  double result;
+  napi_status status = napi_get_value_double(_env, _value, &result);
+  NAPI_THROW_IF_FAILED(_env, status, 0);
+  return result;
 }
 
 inline double Number::DoubleValue() const {
@@ -994,8 +1063,19 @@ inline Symbol Symbol::New(napi_env env, napi_value description) {
   return Symbol(env, value);
 }
 
-inline Symbol Symbol::WellKnown(napi_env env, const std::string& name) {
+inline MaybeOrValue<Symbol> Symbol::WellKnown(napi_env env,
+                                              const std::string& name) {
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  Value symbol_obj;
+  Value symbol_value;
+  if (Napi::Env(env).Global().Get("Symbol").UnwrapTo(&symbol_obj) &&
+      symbol_obj.As<Object>().Get(name).UnwrapTo(&symbol_value)) {
+    return Just<Symbol>(symbol_value.As<Symbol>());
+  }
+  return Nothing<Symbol>();
+#else
   return Napi::Env(env).Global().Get("Symbol").As<Object>().Get(name).As<Symbol>();
+#endif
 }
 
 inline Symbol::Symbol() : Name() {
@@ -1110,12 +1190,25 @@ String String::From(napi_env env, const T& value) {
 
 template <typename Key>
 inline Object::PropertyLValue<Key>::operator Value() const {
-  return Object(_env, _object).Get(_key);
+  MaybeOrValue<Value> val = Object(_env, _object).Get(_key);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  // TODO: Find a way more intuitive on maybe enabled.
+  return val.Unwrap();
+#else
+  return val;
+#endif
 }
 
 template <typename Key> template <typename ValueType>
 inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(ValueType value) {
-  Object(_env, _object).Set(_key, value);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  MaybeOrValue<bool> result =
+#endif
+      Object(_env, _object).Set(_key, value);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  // TODO: Find a way more intuitive on maybe enabled.
+  result.Unwrap();
+#endif
   return *this;
 }
 
@@ -1148,208 +1241,195 @@ inline Object::PropertyLValue<uint32_t> Object::operator [](uint32_t index) {
   return PropertyLValue<uint32_t>(*this, index);
 }
 
-inline Value Object::operator [](const char* utf8name) const {
+inline MaybeOrValue<Value> Object::operator[](const char* utf8name) const {
   return Get(utf8name);
 }
 
-inline Value Object::operator [](const std::string& utf8name) const {
+inline MaybeOrValue<Value> Object::operator[](
+    const std::string& utf8name) const {
   return Get(utf8name);
 }
 
-inline Value Object::operator [](uint32_t index) const {
+inline MaybeOrValue<Value> Object::operator[](uint32_t index) const {
   return Get(index);
 }
 
-inline bool Object::Has(napi_value key) const {
+inline MaybeOrValue<bool> Object::Has(napi_value key) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::Has(Value key) const {
+inline MaybeOrValue<bool> Object::Has(Value key) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::Has(const char* utf8name) const {
+inline MaybeOrValue<bool> Object::Has(const char* utf8name) const {
   bool result;
   napi_status status = napi_has_named_property(_env, _value, utf8name, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::Has(const std::string& utf8name) const {
+inline MaybeOrValue<bool> Object::Has(const std::string& utf8name) const {
   return Has(utf8name.c_str());
 }
 
-inline bool Object::HasOwnProperty(napi_value key) const {
+inline MaybeOrValue<bool> Object::HasOwnProperty(napi_value key) const {
   bool result;
   napi_status status = napi_has_own_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::HasOwnProperty(Value key) const {
+inline MaybeOrValue<bool> Object::HasOwnProperty(Value key) const {
   bool result;
   napi_status status = napi_has_own_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::HasOwnProperty(const char* utf8name) const {
+inline MaybeOrValue<bool> Object::HasOwnProperty(const char* utf8name) const {
   napi_value key;
   napi_status status = napi_create_string_utf8(_env, utf8name, std::strlen(utf8name), &key);
-  NAPI_THROW_IF_FAILED(_env, status, false);
+  NAPI_MAYBE_THROW_IF_FAILED(_env, status, bool);
   return HasOwnProperty(key);
 }
 
-inline bool Object::HasOwnProperty(const std::string& utf8name) const {
+inline MaybeOrValue<bool> Object::HasOwnProperty(
+    const std::string& utf8name) const {
   return HasOwnProperty(utf8name.c_str());
 }
 
-inline Value Object::Get(napi_value key) const {
+inline MaybeOrValue<Value> Object::Get(napi_value key) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Value(_env, result), Value);
 }
 
-inline Value Object::Get(Value key) const {
+inline MaybeOrValue<Value> Object::Get(Value key) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Value(_env, result), Value);
 }
 
-inline Value Object::Get(const char* utf8name) const {
+inline MaybeOrValue<Value> Object::Get(const char* utf8name) const {
   napi_value result;
   napi_status status = napi_get_named_property(_env, _value, utf8name, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Value(_env, result), Value);
 }
 
-inline Value Object::Get(const std::string& utf8name) const {
+inline MaybeOrValue<Value> Object::Get(const std::string& utf8name) const {
   return Get(utf8name.c_str());
 }
 
 template <typename ValueType>
-inline bool Object::Set(napi_value key, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(napi_value key, const ValueType& value) {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
-inline bool Object::Set(Value key, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(Value key, const ValueType& value) {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
-inline bool Object::Set(const char* utf8name, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(const char* utf8name,
+                                      const ValueType& value) {
   napi_status status =
       napi_set_named_property(_env, _value, utf8name, Value::From(_env, value));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
-inline bool Object::Set(const std::string& utf8name, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(const std::string& utf8name,
+                                      const ValueType& value) {
   return Set(utf8name.c_str(), value);
 }
 
-inline bool Object::Delete(napi_value key) {
+inline MaybeOrValue<bool> Object::Delete(napi_value key) {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::Delete(Value key) {
+inline MaybeOrValue<bool> Object::Delete(Value key) {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline bool Object::Delete(const char* utf8name) {
+inline MaybeOrValue<bool> Object::Delete(const char* utf8name) {
   return Delete(String::New(_env, utf8name));
 }
 
-inline bool Object::Delete(const std::string& utf8name) {
+inline MaybeOrValue<bool> Object::Delete(const std::string& utf8name) {
   return Delete(String::New(_env, utf8name));
 }
 
-inline bool Object::Has(uint32_t index) const {
+inline MaybeOrValue<bool> Object::Has(uint32_t index) const {
   bool result;
   napi_status status = napi_has_element(_env, _value, index, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline Value Object::Get(uint32_t index) const {
+inline MaybeOrValue<Value> Object::Get(uint32_t index) const {
   napi_value value;
   napi_status status = napi_get_element(_env, _value, index, &value);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, value);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, value), Value);
 }
 
 template <typename ValueType>
-inline bool Object::Set(uint32_t index, const ValueType& value) {
+inline MaybeOrValue<bool> Object::Set(uint32_t index, const ValueType& value) {
   napi_status status =
       napi_set_element(_env, _value, index, Value::From(_env, value));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline bool Object::Delete(uint32_t index) {
+inline MaybeOrValue<bool> Object::Delete(uint32_t index) {
   bool result;
   napi_status status = napi_delete_element(_env, _value, index, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline Array Object::GetPropertyNames() const {
+inline MaybeOrValue<Array> Object::GetPropertyNames() {
   napi_value result;
   napi_status status = napi_get_property_names(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Array());
-  return Array(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Array(_env, result), Array);
 }
 
-inline bool Object::DefineProperty(const PropertyDescriptor& property) {
+inline MaybeOrValue<bool> Object::DefineProperty(
+    const PropertyDescriptor& property) {
   napi_status status = napi_define_properties(_env, _value, 1,
     reinterpret_cast<const napi_property_descriptor*>(&property));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline bool Object::DefineProperties(
+inline MaybeOrValue<bool> Object::DefineProperties(
     const std::initializer_list<PropertyDescriptor>& properties) {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.begin()));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline bool Object::DefineProperties(
+inline MaybeOrValue<bool> Object::DefineProperties(
     const std::vector<PropertyDescriptor>& properties) {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.data()));
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline bool Object::InstanceOf(const Function& constructor) const {
+inline MaybeOrValue<bool> Object::InstanceOf(const Function& constructor) {
   bool result;
   napi_status status = napi_instanceof(_env, _value, constructor, &result);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return result;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 template <typename Finalizer, typename T>
@@ -1389,16 +1469,14 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
 }
 
 #if NAPI_VERSION >= 8
-inline bool Object::Freeze() {
+inline MaybeOrValue<bool> Object::Freeze() {
   napi_status status = napi_object_freeze(_env, _value);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline bool Object::Seal() {
+inline MaybeOrValue<bool> Object::Seal() {
   napi_status status = napi_object_seal(_env, _value);
-  NAPI_THROW_IF_FAILED(_env, status, false);
-  return true;
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 #endif  // NAPI_VERSION >= 8
 
@@ -2045,53 +2123,61 @@ inline Function::Function() : Object() {
 inline Function::Function(napi_env env, napi_value value) : Object(env, value) {
 }
 
-inline Value Function::operator ()(const std::initializer_list<napi_value>& args) const {
+inline MaybeOrValue<Value> Function::operator()(
+    const std::initializer_list<napi_value>& args) const {
   return Call(Env().Undefined(), args);
 }
 
-inline Value Function::Call(const std::initializer_list<napi_value>& args) const {
+inline MaybeOrValue<Value> Function::Call(
+    const std::initializer_list<napi_value>& args) const {
   return Call(Env().Undefined(), args);
 }
 
-inline Value Function::Call(const std::vector<napi_value>& args) const {
+inline MaybeOrValue<Value> Function::Call(
+    const std::vector<napi_value>& args) const {
   return Call(Env().Undefined(), args);
 }
 
-inline Value Function::Call(size_t argc, const napi_value* args) const {
+inline MaybeOrValue<Value> Function::Call(size_t argc,
+                                          const napi_value* args) const {
   return Call(Env().Undefined(), argc, args);
 }
 
-inline Value Function::Call(napi_value recv, const std::initializer_list<napi_value>& args) const {
+inline MaybeOrValue<Value> Function::Call(
+    napi_value recv, const std::initializer_list<napi_value>& args) const {
   return Call(recv, args.size(), args.begin());
 }
 
-inline Value Function::Call(napi_value recv, const std::vector<napi_value>& args) const {
+inline MaybeOrValue<Value> Function::Call(
+    napi_value recv, const std::vector<napi_value>& args) const {
   return Call(recv, args.size(), args.data());
 }
 
-inline Value Function::Call(napi_value recv, size_t argc, const napi_value* args) const {
+inline MaybeOrValue<Value> Function::Call(napi_value recv,
+                                          size_t argc,
+                                          const napi_value* args) const {
   napi_value result;
   napi_status status = napi_call_function(
     _env, recv, _value, argc, args, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
-inline Value Function::MakeCallback(
+inline MaybeOrValue<Value> Function::MakeCallback(
     napi_value recv,
     const std::initializer_list<napi_value>& args,
     napi_async_context context) const {
   return MakeCallback(recv, args.size(), args.begin(), context);
 }
 
-inline Value Function::MakeCallback(
+inline MaybeOrValue<Value> Function::MakeCallback(
     napi_value recv,
     const std::vector<napi_value>& args,
     napi_async_context context) const {
   return MakeCallback(recv, args.size(), args.data(), context);
 }
 
-inline Value Function::MakeCallback(
+inline MaybeOrValue<Value> Function::MakeCallback(
     napi_value recv,
     size_t argc,
     const napi_value* args,
@@ -2099,24 +2185,27 @@ inline Value Function::MakeCallback(
   napi_value result;
   napi_status status = napi_make_callback(
     _env, context, recv, _value, argc, args, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Value());
-  return Value(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
-inline Object Function::New(const std::initializer_list<napi_value>& args) const {
+inline MaybeOrValue<Object> Function::New(
+    const std::initializer_list<napi_value>& args) const {
   return New(args.size(), args.begin());
 }
 
-inline Object Function::New(const std::vector<napi_value>& args) const {
+inline MaybeOrValue<Object> Function::New(
+    const std::vector<napi_value>& args) const {
   return New(args.size(), args.data());
 }
 
-inline Object Function::New(size_t argc, const napi_value* args) const {
+inline MaybeOrValue<Object> Function::New(size_t argc,
+                                          const napi_value* args) const {
   napi_value result;
   napi_status status = napi_new_instance(
     _env, _value, argc, args, &result);
-  NAPI_THROW_IF_FAILED(_env, status, Object());
-  return Object(_env, result);
+  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Object(_env, result), Napi::Object);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2388,7 +2477,14 @@ inline const std::string& Error::Message() const NAPI_NOEXCEPT {
       // the std::string::operator=, because this method may not throw.
     }
 #else // NAPI_CPP_EXCEPTIONS
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+    Napi::Value message_val;
+    if (Get("message").UnwrapTo(&message_val)) {
+      _message = message_val.As<String>();
+    }
+#else
     _message = Get("message").As<String>();
+#endif
 #endif // NAPI_CPP_EXCEPTIONS
   }
   return _message;
@@ -2679,102 +2775,96 @@ inline ObjectReference::ObjectReference(const ObjectReference& other)
   : Reference<Object>(other) {
 }
 
-inline Napi::Value ObjectReference::Get(const char* utf8name) const {
-  EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Get(utf8name));
+inline MaybeOrValue<Napi::Value> ObjectReference::Get(
+    const char* utf8name) const {
+  return Value().Get(utf8name);
 }
 
-inline Napi::Value ObjectReference::Get(const std::string& utf8name) const {
-  EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Get(utf8name));
+inline MaybeOrValue<Napi::Value> ObjectReference::Get(
+    const std::string& utf8name) const {
+  return Value().Get(utf8name);
 }
 
-inline bool ObjectReference::Set(const char* utf8name, napi_value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
+                                               napi_value value) {
   return Value().Set(utf8name, value);
 }
 
-inline bool ObjectReference::Set(const char* utf8name, Napi::Value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
+                                               Napi::Value value) {
   return Value().Set(utf8name, value);
 }
 
-inline bool ObjectReference::Set(const char* utf8name, const char* utf8value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
+                                               const char* utf8value) {
   return Value().Set(utf8name, utf8value);
 }
 
-inline bool ObjectReference::Set(const char* utf8name, bool boolValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
+                                               bool boolValue) {
   return Value().Set(utf8name, boolValue);
 }
 
-inline bool ObjectReference::Set(const char* utf8name, double numberValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
+                                               double numberValue) {
   return Value().Set(utf8name, numberValue);
 }
 
-inline bool ObjectReference::Set(const std::string& utf8name,
-                                 napi_value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
+                                               napi_value value) {
   return Value().Set(utf8name, value);
 }
 
-inline bool ObjectReference::Set(const std::string& utf8name,
-                                 Napi::Value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
+                                               Napi::Value value) {
   return Value().Set(utf8name, value);
 }
 
-inline bool ObjectReference::Set(const std::string& utf8name,
-                                 std::string& utf8value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
+                                               std::string& utf8value) {
   return Value().Set(utf8name, utf8value);
 }
 
-inline bool ObjectReference::Set(const std::string& utf8name, bool boolValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
+                                               bool boolValue) {
   return Value().Set(utf8name, boolValue);
 }
 
-inline bool ObjectReference::Set(const std::string& utf8name,
-                                 double numberValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
+                                               double numberValue) {
   return Value().Set(utf8name, numberValue);
 }
 
-inline Napi::Value ObjectReference::Get(uint32_t index) const {
-  EscapableHandleScope scope(_env);
-  return scope.Escape(Value().Get(index));
+inline MaybeOrValue<Napi::Value> ObjectReference::Get(uint32_t index) const {
+  return Value().Get(index);
 }
 
-inline bool ObjectReference::Set(uint32_t index, napi_value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
+                                               napi_value value) {
   return Value().Set(index, value);
 }
 
-inline bool ObjectReference::Set(uint32_t index, Napi::Value value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
+                                               Napi::Value value) {
   return Value().Set(index, value);
 }
 
-inline bool ObjectReference::Set(uint32_t index, const char* utf8value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
+                                               const char* utf8value) {
   return Value().Set(index, utf8value);
 }
 
-inline bool ObjectReference::Set(uint32_t index, const std::string& utf8value) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
+                                               const std::string& utf8value) {
   return Value().Set(index, utf8value);
 }
 
-inline bool ObjectReference::Set(uint32_t index, bool boolValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index, bool boolValue) {
   return Value().Set(index, boolValue);
 }
 
-inline bool ObjectReference::Set(uint32_t index, double numberValue) {
-  HandleScope scope(_env);
+inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
+                                               double numberValue) {
   return Value().Set(index, numberValue);
 }
 
@@ -2807,105 +2897,200 @@ inline FunctionReference& FunctionReference::operator =(FunctionReference&& othe
   return *this;
 }
 
-inline Napi::Value FunctionReference::operator ()(
+inline MaybeOrValue<Napi::Value> FunctionReference::operator()(
     const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value()(args));
-}
-
-inline Napi::Value FunctionReference::Call(const std::initializer_list<napi_value>& args) const {
-  EscapableHandleScope scope(_env);
-  Napi::Value result = Value().Call(args);
+  MaybeOrValue<Napi::Value> result = Value()(args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::Call(const std::vector<napi_value>& args) const {
+inline MaybeOrValue<Napi::Value> FunctionReference::Call(
+    const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().Call(args);
+  MaybeOrValue<Napi::Value> result = Value().Call(args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::Call(
+inline MaybeOrValue<Napi::Value> FunctionReference::Call(
+    const std::vector<napi_value>& args) const {
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().Call(args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
+}
+
+inline MaybeOrValue<Napi::Value> FunctionReference::Call(
     napi_value recv, const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().Call(recv, args);
+  MaybeOrValue<Napi::Value> result = Value().Call(recv, args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::Call(
+inline MaybeOrValue<Napi::Value> FunctionReference::Call(
     napi_value recv, const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().Call(recv, args);
+  MaybeOrValue<Napi::Value> result = Value().Call(recv, args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::Call(
+inline MaybeOrValue<Napi::Value> FunctionReference::Call(
     napi_value recv, size_t argc, const napi_value* args) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().Call(recv, argc, args);
+  MaybeOrValue<Napi::Value> result = Value().Call(recv, argc, args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::MakeCallback(
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
     napi_value recv,
     const std::initializer_list<napi_value>& args,
     napi_async_context context) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().MakeCallback(recv, args, context);
+  MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::MakeCallback(
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
     napi_value recv,
     const std::vector<napi_value>& args,
     napi_async_context context) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().MakeCallback(recv, args, context);
+  MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Napi::Value FunctionReference::MakeCallback(
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
     napi_value recv,
     size_t argc,
     const napi_value* args,
     napi_async_context context) const {
   EscapableHandleScope scope(_env);
-  Napi::Value result = Value().MakeCallback(recv, argc, args, context);
+  MaybeOrValue<Napi::Value> result =
+      Value().MakeCallback(recv, argc, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
   if (scope.Env().IsExceptionPending()) {
     return Value();
   }
   return scope.Escape(result);
+#endif
 }
 
-inline Object FunctionReference::New(const std::initializer_list<napi_value>& args) const {
+inline MaybeOrValue<Object> FunctionReference::New(
+    const std::initializer_list<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().New(args)).As<Object>();
+  MaybeOrValue<Object> result = Value().New(args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()).As<Object>());
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Object();
+  }
+  return scope.Escape(result).As<Object>();
+#endif
 }
 
-inline Object FunctionReference::New(const std::vector<napi_value>& args) const {
+inline MaybeOrValue<Object> FunctionReference::New(
+    const std::vector<napi_value>& args) const {
   EscapableHandleScope scope(_env);
-  return scope.Escape(Value().New(args)).As<Object>();
+  MaybeOrValue<Object> result = Value().New(args);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()).As<Object>());
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Object();
+  }
+  return scope.Escape(result).As<Object>();
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -839,10 +839,7 @@ inline int64_t Number::Int64Value() const {
 }
 
 inline float Number::FloatValue() const {
-  double result;
-  napi_status status = napi_get_value_double(_env, _value, &result);
-  NAPI_THROW_IF_FAILED(_env, status, 0);
-  return result;
+  return static_cast<float>(DoubleValue());
 }
 
 inline double Number::DoubleValue() const {
@@ -1192,7 +1189,6 @@ template <typename Key>
 inline Object::PropertyLValue<Key>::operator Value() const {
   MaybeOrValue<Value> val = Object(_env, _object).Get(_key);
 #ifdef NODE_ADDON_API_ENABLE_MAYBE
-  // TODO: Find a way more intuitive on maybe enabled.
   return val.Unwrap();
 #else
   return val;
@@ -1206,7 +1202,6 @@ inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(Valu
 #endif
       Object(_env, _object).Set(_key, value);
 #ifdef NODE_ADDON_API_ENABLE_MAYBE
-  // TODO: Find a way more intuitive on maybe enabled.
   result.Unwrap();
 #endif
   return *this;

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -504,7 +504,7 @@ inline MaybeOrValue<Value> Env::RunScript(const std::string& utf8script) {
 inline MaybeOrValue<Value> Env::RunScript(String script) {
   napi_value result;
   napi_status status = napi_run_script(_env, script, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
@@ -727,28 +727,28 @@ inline T Value::As() const {
 inline MaybeOrValue<Boolean> Value::ToBoolean() const {
   napi_value result;
   napi_status status = napi_coerce_to_bool(_env, _value, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Boolean(_env, result), Napi::Boolean);
 }
 
 inline MaybeOrValue<Number> Value::ToNumber() const {
   napi_value result;
   napi_status status = napi_coerce_to_number(_env, _value, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Number(_env, result), Napi::Number);
 }
 
 inline MaybeOrValue<String> Value::ToString() const {
   napi_value result;
   napi_status status = napi_coerce_to_string(_env, _value, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::String(_env, result), Napi::String);
 }
 
 inline MaybeOrValue<Object> Value::ToObject() const {
   napi_value result;
   napi_status status = napi_coerce_to_object(_env, _value, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Object(_env, result), Napi::Object);
 }
 
@@ -1252,19 +1252,19 @@ inline MaybeOrValue<Value> Object::operator[](uint32_t index) const {
 inline MaybeOrValue<bool> Object::Has(napi_value key) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::Has(Value key) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::Has(const char* utf8name) const {
   bool result;
   napi_status status = napi_has_named_property(_env, _value, utf8name, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::Has(const std::string& utf8name) const {
@@ -1274,13 +1274,13 @@ inline MaybeOrValue<bool> Object::Has(const std::string& utf8name) const {
 inline MaybeOrValue<bool> Object::HasOwnProperty(napi_value key) const {
   bool result;
   napi_status status = napi_has_own_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::HasOwnProperty(Value key) const {
   bool result;
   napi_status status = napi_has_own_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::HasOwnProperty(const char* utf8name) const {
@@ -1298,22 +1298,19 @@ inline MaybeOrValue<bool> Object::HasOwnProperty(
 inline MaybeOrValue<Value> Object::Get(napi_value key) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
-      _env, status, Value(_env, result), Value);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, result), Value);
 }
 
 inline MaybeOrValue<Value> Object::Get(Value key) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
-      _env, status, Value(_env, result), Value);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, result), Value);
 }
 
 inline MaybeOrValue<Value> Object::Get(const char* utf8name) const {
   napi_value result;
   napi_status status = napi_get_named_property(_env, _value, utf8name, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
-      _env, status, Value(_env, result), Value);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, result), Value);
 }
 
 inline MaybeOrValue<Value> Object::Get(const std::string& utf8name) const {
@@ -1324,14 +1321,14 @@ template <typename ValueType>
 inline MaybeOrValue<bool> Object::Set(napi_value key, const ValueType& value) {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
 inline MaybeOrValue<bool> Object::Set(Value key, const ValueType& value) {
   napi_status status =
       napi_set_property(_env, _value, key, Value::From(_env, value));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
@@ -1339,7 +1336,7 @@ inline MaybeOrValue<bool> Object::Set(const char* utf8name,
                                       const ValueType& value) {
   napi_status status =
       napi_set_named_property(_env, _value, utf8name, Value::From(_env, value));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 template <typename ValueType>
@@ -1351,13 +1348,13 @@ inline MaybeOrValue<bool> Object::Set(const std::string& utf8name,
 inline MaybeOrValue<bool> Object::Delete(napi_value key) {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::Delete(Value key) {
   bool result;
   napi_status status = napi_delete_property(_env, _value, key, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<bool> Object::Delete(const char* utf8name) {
@@ -1371,60 +1368,60 @@ inline MaybeOrValue<bool> Object::Delete(const std::string& utf8name) {
 inline MaybeOrValue<bool> Object::Has(uint32_t index) const {
   bool result;
   napi_status status = napi_has_element(_env, _value, index, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 inline MaybeOrValue<Value> Object::Get(uint32_t index) const {
   napi_value value;
   napi_status status = napi_get_element(_env, _value, index, &value);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, value), Value);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Value(_env, value), Value);
 }
 
 template <typename ValueType>
 inline MaybeOrValue<bool> Object::Set(uint32_t index, const ValueType& value) {
   napi_status status =
       napi_set_element(_env, _value, index, Value::From(_env, value));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::Delete(uint32_t index) {
   bool result;
   napi_status status = napi_delete_element(_env, _value, index, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
-inline MaybeOrValue<Array> Object::GetPropertyNames() {
+inline MaybeOrValue<Array> Object::GetPropertyNames() const {
   napi_value result;
   napi_status status = napi_get_property_names(_env, _value, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
-      _env, status, Array(_env, result), Array);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Array(_env, result), Array);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperty(
     const PropertyDescriptor& property) {
   napi_status status = napi_define_properties(_env, _value, 1,
     reinterpret_cast<const napi_property_descriptor*>(&property));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
     const std::initializer_list<PropertyDescriptor>& properties) {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.begin()));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
     const std::vector<PropertyDescriptor>& properties) {
   napi_status status = napi_define_properties(_env, _value, properties.size(),
     reinterpret_cast<const napi_property_descriptor*>(properties.data()));
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
-inline MaybeOrValue<bool> Object::InstanceOf(const Function& constructor) {
+inline MaybeOrValue<bool> Object::InstanceOf(
+    const Function& constructor) const {
   bool result;
   napi_status status = napi_instanceof(_env, _value, constructor, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, result, bool);
 }
 
 template <typename Finalizer, typename T>
@@ -1466,12 +1463,12 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
 #if NAPI_VERSION >= 8
 inline MaybeOrValue<bool> Object::Freeze() {
   napi_status status = napi_object_freeze(_env, _value);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::Seal() {
   napi_status status = napi_object_seal(_env, _value);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 #endif  // NAPI_VERSION >= 8
 
@@ -2154,7 +2151,7 @@ inline MaybeOrValue<Value> Function::Call(napi_value recv,
   napi_value result;
   napi_status status = napi_call_function(
     _env, recv, _value, argc, args, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
@@ -2180,7 +2177,7 @@ inline MaybeOrValue<Value> Function::MakeCallback(
   napi_value result;
   napi_status status = napi_make_callback(
     _env, context, recv, _value, argc, args, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
@@ -2199,7 +2196,7 @@ inline MaybeOrValue<Object> Function::New(size_t argc,
   napi_value result;
   napi_status status = napi_new_instance(
     _env, _value, argc, args, &result);
-  NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(
+  NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Object(_env, result), Napi::Object);
 }
 
@@ -2488,7 +2485,6 @@ inline const std::string& Error::Message() const NAPI_NOEXCEPT {
 inline void Error::ThrowAsJavaScriptException() const {
   HandleScope scope(_env);
   if (!IsEmpty()) {
-
     // We intentionally don't use `NAPI_THROW_*` macros here to ensure
     // that there is no possible recursion as `ThrowAsJavaScriptException`
     // is part of `NAPI_THROW_*` macro definition for noexcept.
@@ -2772,94 +2768,146 @@ inline ObjectReference::ObjectReference(const ObjectReference& other)
 
 inline MaybeOrValue<Napi::Value> ObjectReference::Get(
     const char* utf8name) const {
-  return Value().Get(utf8name);
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().Get(utf8name);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
 }
 
 inline MaybeOrValue<Napi::Value> ObjectReference::Get(
     const std::string& utf8name) const {
-  return Value().Get(utf8name);
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().Get(utf8name);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
                                                napi_value value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
                                                Napi::Value value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
                                                const char* utf8value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
                                                bool boolValue) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const char* utf8name,
                                                double numberValue) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, numberValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
                                                napi_value value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
                                                Napi::Value value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
                                                std::string& utf8value) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
                                                bool boolValue) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
                                                double numberValue) {
+  HandleScope scope(_env);
   return Value().Set(utf8name, numberValue);
 }
 
 inline MaybeOrValue<Napi::Value> ObjectReference::Get(uint32_t index) const {
-  return Value().Get(index);
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().Get(index);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
                                                napi_value value) {
+  HandleScope scope(_env);
   return Value().Set(index, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
                                                Napi::Value value) {
+  HandleScope scope(_env);
   return Value().Set(index, value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
                                                const char* utf8value) {
+  HandleScope scope(_env);
   return Value().Set(index, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
                                                const std::string& utf8value) {
+  HandleScope scope(_env);
   return Value().Set(index, utf8value);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index, bool boolValue) {
+  HandleScope scope(_env);
   return Value().Set(index, boolValue);
 }
 
 inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
                                                double numberValue) {
+  HandleScope scope(_env);
   return Value().Set(index, numberValue);
 }
 

--- a/napi.h
+++ b/napi.h
@@ -34,6 +34,13 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
   #endif
 #endif
 
+// If C++ NAPI_CPP_EXCEPTIONS are enabled, NODE_ADDON_API_ENABLE_MAYBE should
+// not be set
+#if defined(NAPI_CPP_EXCEPTIONS) && defined(NODE_ADDON_API_ENABLE_MAYBE)
+#error NODE_ADDON_API_ENABLE_MAYBE should not be set when \
+    NAPI_CPP_EXCEPTIONS is defined.
+#endif
+
 #ifdef _NOEXCEPT
   #define NAPI_NOEXCEPT _NOEXCEPT
 #else
@@ -77,19 +84,41 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
     return;                                              \
   } while (0)
 
-#define NAPI_THROW_IF_FAILED(env, status, ...)           \
-  if ((status) != napi_ok) {                             \
-    Napi::Error::New(env).ThrowAsJavaScriptException();  \
-    return __VA_ARGS__;                                  \
+#define NAPI_THROW_IF_FAILED(env, status, ...)                                 \
+  if ((status) == napi_pending_exception) {                                    \
+    return __VA_ARGS__;                                                        \
+  }                                                                            \
+  if ((status) != napi_ok) {                                                   \
+    Napi::Error::New(env).ThrowAsJavaScriptException();                        \
+    return __VA_ARGS__;                                                        \
   }
 
-#define NAPI_THROW_IF_FAILED_VOID(env, status)           \
-  if ((status) != napi_ok) {                             \
-    Napi::Error::New(env).ThrowAsJavaScriptException();  \
-    return;                                              \
+#define NAPI_THROW_IF_FAILED_VOID(env, status)                                 \
+  if ((status) == napi_pending_exception) {                                    \
+    return;                                                                    \
+  }                                                                            \
+  if ((status) != napi_ok) {                                                   \
+    Napi::Error::New(env).ThrowAsJavaScriptException();                        \
+    return;                                                                    \
   }
 
 #endif // NAPI_CPP_EXCEPTIONS
+
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+#define NAPI_MAYBE_THROW_IF_FAILED(env, status, type)                          \
+  NAPI_THROW_IF_FAILED(env, status, Napi::Nothing<type>())
+
+#define NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(env, status, result, type)        \
+  NAPI_MAYBE_THROW_IF_FAILED(env, status, type);                               \
+  return Napi::Just<type>(result);
+#else
+#define NAPI_MAYBE_THROW_IF_FAILED(env, status, type)                          \
+  NAPI_THROW_IF_FAILED(env, status, type())
+
+#define NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(env, status, result, type)        \
+  NAPI_MAYBE_THROW_IF_FAILED(env, status, type);                               \
+  return result;
+#endif
 
 # define NAPI_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
 # define NAPI_DISALLOW_COPY(CLASS) CLASS(const CLASS&) = delete;
@@ -98,12 +127,25 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
     NAPI_DISALLOW_ASSIGN(CLASS)           \
     NAPI_DISALLOW_COPY(CLASS)
 
-#define NAPI_FATAL_IF_FAILED(status, location, message)  \
-  do {                                                   \
-    if ((status) != napi_ok) {                           \
-      Napi::Error::Fatal((location), (message));         \
-    }                                                    \
+#define NAPI_CHECK(condition, location, message)                               \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      Napi::Error::Fatal((location), (message));                               \
+    }                                                                          \
   } while (0)
+
+#define NAPI_FATAL_IF_FAILED(status, location, message)                        \
+  NAPI_CHECK((status) == napi_ok, location, message)
+
+// Annotate a function indicating the caller must examine the return value.
+// Use like:
+//   NAPI_WARN_UNUSED_RESULT int foo();
+// TODO: find a way to define NAPI_HAS_ATTRIBUTE_WARN_UNUSED_RESULT
+#if NAPI_HAS_ATTRIBUTE_WARN_UNUSED_RESULT
+#define NAPI_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define NAPI_WARN_UNUSED_RESULT /* NOT SUPPORTED */
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Node-API C++ Wrapper Classes
@@ -165,6 +207,67 @@ namespace Napi {
 
   class MemoryManagement;
 
+  /// A simple Maybe type, representing an object which may or may not have a
+  /// value.
+  ///
+  /// If an API method returns a Maybe<>, the API method can potentially fail
+  /// either because an exception is thrown, or because an exception is pending,
+  /// e.g. because a previous API call threw an exception that hasn't been
+  /// caught yet. In that case, a "Nothing" value is returned.
+  template <class T>
+  class Maybe {
+   public:
+    bool IsNothing() const;
+    bool IsJust() const;
+
+    /// Short-hand for Unwrap(), which doesn't return a value. Could be used
+    /// where the actual value of the Maybe is not needed like Object::Set.
+    /// If this Maybe is nothing (empty), node-addon-api will crash the
+    /// process.
+    void Check() const;
+
+    /// Return the value of type T contained in the Maybe. If this Maybe is
+    /// nothing (empty), node-addon-api will crash the process.
+    T Unwrap() const;
+
+    /// Return the value of type T contained in the Maybe, or using a default
+    /// value if this Maybe is nothing (empty).
+    T UnwrapOr(const T& default_value) const;
+
+    /// Converts this Maybe to a value of type T in the out. If this Maybe is
+    /// nothing (empty), `false` is returned and `out` is left untouched.
+    bool UnwrapTo(T* out) const;
+
+    bool operator==(const Maybe& other) const;
+    bool operator!=(const Maybe& other) const;
+
+   private:
+    Maybe();
+    explicit Maybe(const T& t);
+
+    bool _has_value;
+    T _value;
+
+    template <class U>
+    friend Maybe<U> Nothing();
+    template <class U>
+    friend Maybe<U> Just(const U& u);
+  };
+
+  template <class T>
+  inline Maybe<T> Nothing();
+
+  template <class T>
+  inline Maybe<T> Just(const T& t);
+
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  template <typename T>
+  using MaybeOrValue = Maybe<T>;
+#else
+  template <typename T>
+  using MaybeOrValue = T;
+#endif
+
   /// Environment for Node-API values and operations.
   ///
   /// All Node-API values and operations must be associated with an environment.
@@ -197,9 +300,9 @@ namespace Napi {
     bool IsExceptionPending() const;
     Error GetAndClearPendingException();
 
-    Value RunScript(const char* utf8script);
-    Value RunScript(const std::string& utf8script);
-    Value RunScript(String script);
+    MaybeOrValue<Value> RunScript(const char* utf8script);
+    MaybeOrValue<Value> RunScript(const std::string& utf8script);
+    MaybeOrValue<Value> RunScript(String script);
 
 #if NAPI_VERSION > 5
     template <typename T> T* GetInstanceData();
@@ -311,12 +414,16 @@ namespace Napi {
     /// value type will throw `Napi::Error`.
     template <typename T> T As() const;
 
-    Boolean ToBoolean() const; ///< Coerces a value to a JavaScript boolean.
-    Number ToNumber() const;   ///< Coerces a value to a JavaScript number.
-    String ToString() const;   ///< Coerces a value to a JavaScript string.
-    Object ToObject() const;   ///< Coerces a value to a JavaScript object.
+    MaybeOrValue<Boolean> ToBoolean()
+        const;  ///< Coerces a value to a JavaScript boolean.
+    MaybeOrValue<Number> ToNumber()
+        const;  ///< Coerces a value to a JavaScript number.
+    MaybeOrValue<String> ToString()
+        const;  ///< Coerces a value to a JavaScript string.
+    MaybeOrValue<Object> ToObject()
+        const;  ///< Coerces a value to a JavaScript object.
 
-  protected:
+   protected:
     /// !cond INTERNAL
     napi_env _env;
     napi_value _value;
@@ -536,7 +643,7 @@ namespace Napi {
    );
 
    /// Get a public Symbol (e.g. Symbol.iterator).
-   static Symbol WellKnown(napi_env, const std::string& name);
+   static MaybeOrValue<Symbol> WellKnown(napi_env, const std::string& name);
 
    Symbol();  ///< Creates a new _empty_ Symbol instance.
    Symbol(napi_env env,
@@ -583,177 +690,191 @@ namespace Napi {
     Object(napi_env env,
            napi_value value);  ///< Wraps a Node-API value primitive.
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets a named property.
     PropertyLValue<std::string> operator [](
       const char* utf8name ///< UTF-8 encoded null-terminated property name
     );
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets a named property.
     PropertyLValue<std::string> operator [](
       const std::string& utf8name ///< UTF-8 encoded property name
     );
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets an indexed property or array element.
     PropertyLValue<uint32_t> operator [](
       uint32_t index /// Property / element index
     );
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets a named property.
-    Value operator [](
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    MaybeOrValue<Value> operator[](
+        const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets a named property.
-    Value operator [](
-      const std::string& utf8name ///< UTF-8 encoded property name
+    MaybeOrValue<Value> operator[](
+        const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
+    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets an indexed property or array element.
-    Value operator [](
-      uint32_t index ///< Property / element index
+    MaybeOrValue<Value> operator[](uint32_t index  ///< Property / element index
     ) const;
 
     /// Checks whether a property is present.
-    bool Has(
-      napi_value key ///< Property key primitive
+    MaybeOrValue<bool> Has(napi_value key  ///< Property key primitive
     ) const;
 
     /// Checks whether a property is present.
-    bool Has(
-      Value key ///< Property key
+    MaybeOrValue<bool> Has(Value key  ///< Property key
     ) const;
 
     /// Checks whether a named property is present.
-    bool Has(
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    MaybeOrValue<bool> Has(
+        const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
     /// Checks whether a named property is present.
-    bool Has(
-      const std::string& utf8name ///< UTF-8 encoded property name
+    MaybeOrValue<bool> Has(
+        const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
     /// Checks whether a own property is present.
-    bool HasOwnProperty(
-      napi_value key ///< Property key primitive
+    MaybeOrValue<bool> HasOwnProperty(
+        napi_value key  ///< Property key primitive
     ) const;
 
     /// Checks whether a own property is present.
-    bool HasOwnProperty(
-      Value key ///< Property key
+    MaybeOrValue<bool> HasOwnProperty(Value key  ///< Property key
     ) const;
 
     /// Checks whether a own property is present.
-    bool HasOwnProperty(
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    MaybeOrValue<bool> HasOwnProperty(
+        const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
     /// Checks whether a own property is present.
-    bool HasOwnProperty(
-      const std::string& utf8name ///< UTF-8 encoded property name
+    MaybeOrValue<bool> HasOwnProperty(
+        const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
     /// Gets a property.
-    Value Get(
-      napi_value key ///< Property key primitive
+    MaybeOrValue<Value> Get(napi_value key  ///< Property key primitive
     ) const;
 
     /// Gets a property.
-    Value Get(
-      Value key ///< Property key
+    MaybeOrValue<Value> Get(Value key  ///< Property key
     ) const;
 
     /// Gets a named property.
-    Value Get(
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    MaybeOrValue<Value> Get(
+        const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
     /// Gets a named property.
-    Value Get(
-      const std::string& utf8name ///< UTF-8 encoded property name
+    MaybeOrValue<Value> Get(
+        const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
     /// Sets a property.
     template <typename ValueType>
-    bool Set(napi_value key,         ///< Property key primitive
-             const ValueType& value  ///< Property value primitive
+    MaybeOrValue<bool> Set(napi_value key,         ///< Property key primitive
+                           const ValueType& value  ///< Property value primitive
     );
 
     /// Sets a property.
     template <typename ValueType>
-    bool Set(Value key,              ///< Property key
-             const ValueType& value  ///< Property value
+    MaybeOrValue<bool> Set(Value key,              ///< Property key
+                           const ValueType& value  ///< Property value
     );
 
     /// Sets a named property.
     template <typename ValueType>
-    bool Set(
+    MaybeOrValue<bool> Set(
         const char* utf8name,  ///< UTF-8 encoded null-terminated property name
         const ValueType& value);
 
     /// Sets a named property.
     template <typename ValueType>
-    bool Set(const std::string& utf8name,  ///< UTF-8 encoded property name
-             const ValueType& value        ///< Property value primitive
+    MaybeOrValue<bool> Set(
+        const std::string& utf8name,  ///< UTF-8 encoded property name
+        const ValueType& value        ///< Property value primitive
     );
 
     /// Delete property.
-    bool Delete(
-      napi_value key ///< Property key primitive
+    MaybeOrValue<bool> Delete(napi_value key  ///< Property key primitive
     );
 
     /// Delete property.
-    bool Delete(
-      Value key ///< Property key
+    MaybeOrValue<bool> Delete(Value key  ///< Property key
     );
 
     /// Delete property.
-    bool Delete(
-      const char* utf8name ///< UTF-8 encoded null-terminated property name
+    MaybeOrValue<bool> Delete(
+        const char* utf8name  ///< UTF-8 encoded null-terminated property name
     );
 
     /// Delete property.
-    bool Delete(
-      const std::string& utf8name ///< UTF-8 encoded property name
+    MaybeOrValue<bool> Delete(
+        const std::string& utf8name  ///< UTF-8 encoded property name
     );
 
     /// Checks whether an indexed property is present.
-    bool Has(
-      uint32_t index ///< Property / element index
+    MaybeOrValue<bool> Has(uint32_t index  ///< Property / element index
     ) const;
 
     /// Gets an indexed property or array element.
-    Value Get(
-      uint32_t index ///< Property / element index
+    MaybeOrValue<Value> Get(uint32_t index  ///< Property / element index
     ) const;
 
     /// Sets an indexed property or array element.
     template <typename ValueType>
-    bool Set(uint32_t index,         ///< Property / element index
-             const ValueType& value  ///< Property value primitive
+    MaybeOrValue<bool> Set(uint32_t index,         ///< Property / element index
+                           const ValueType& value  ///< Property value primitive
     );
 
     /// Deletes an indexed property or array element.
-    bool Delete(
-      uint32_t index ///< Property / element index
+    MaybeOrValue<bool> Delete(uint32_t index  ///< Property / element index
     );
 
-    Array GetPropertyNames() const; ///< Get all property names
+    /// This operation can fail in case of Proxy.[[OwnPropertyKeys]] and
+    /// Proxy.[[GetOwnProperty]] calling into JavaScript. See:
+    /// -
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+    /// -
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
+    MaybeOrValue<Array> GetPropertyNames();  ///< Get all property names
 
     /// Defines a property on the object.
-    bool DefineProperty(
+    ///
+    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+    /// into JavaScript. See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+    MaybeOrValue<bool> DefineProperty(
         const PropertyDescriptor&
             property  ///< Descriptor for the property to be defined
     );
 
     /// Defines properties on the object.
-    bool DefineProperties(
+    ///
+    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+    /// into JavaScript. See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+    MaybeOrValue<bool> DefineProperties(
         const std::initializer_list<PropertyDescriptor>& properties
         ///< List of descriptors for the properties to be defined
     );
 
     /// Defines properties on the object.
-    bool DefineProperties(
+    ///
+    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+    /// into JavaScript. See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+    MaybeOrValue<bool> DefineProperties(
         const std::vector<PropertyDescriptor>& properties
         ///< Vector of descriptors for the properties to be defined
     );
@@ -761,9 +882,14 @@ namespace Napi {
     /// Checks if an object is an instance created by a constructor function.
     ///
     /// This is equivalent to the JavaScript `instanceof` operator.
-    bool InstanceOf(
-      const Function& constructor ///< Constructor function
-    ) const;
+    ///
+    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+    /// JavaScript.
+    /// See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+    MaybeOrValue<bool> InstanceOf(
+        const Function& constructor  ///< Constructor function
+    );
 
     template <typename Finalizer, typename T>
     inline void AddFinalizer(Finalizer finalizeCallback, T* data);
@@ -773,8 +899,16 @@ namespace Napi {
                              T* data,
                              Hint* finalizeHint);
 #if NAPI_VERSION >= 8
-    bool Freeze();
-    bool Seal();
+    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+    /// JavaScript.
+    /// See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+    MaybeOrValue<bool> Freeze();
+    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+    /// JavaScript.
+    /// See
+    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+    MaybeOrValue<bool> Seal();
 #endif  // NAPI_VERSION >= 8
   };
 
@@ -1108,30 +1242,37 @@ namespace Napi {
    Function();
    Function(napi_env env, napi_value value);
 
-   Value operator()(const std::initializer_list<napi_value>& args) const;
+   MaybeOrValue<Value> operator()(
+       const std::initializer_list<napi_value>& args) const;
 
-   Value Call(const std::initializer_list<napi_value>& args) const;
-   Value Call(const std::vector<napi_value>& args) const;
-   Value Call(size_t argc, const napi_value* args) const;
-   Value Call(napi_value recv,
-              const std::initializer_list<napi_value>& args) const;
-   Value Call(napi_value recv, const std::vector<napi_value>& args) const;
-   Value Call(napi_value recv, size_t argc, const napi_value* args) const;
+   MaybeOrValue<Value> Call(
+       const std::initializer_list<napi_value>& args) const;
+   MaybeOrValue<Value> Call(const std::vector<napi_value>& args) const;
+   MaybeOrValue<Value> Call(size_t argc, const napi_value* args) const;
+   MaybeOrValue<Value> Call(
+       napi_value recv, const std::initializer_list<napi_value>& args) const;
+   MaybeOrValue<Value> Call(napi_value recv,
+                            const std::vector<napi_value>& args) const;
+   MaybeOrValue<Value> Call(napi_value recv,
+                            size_t argc,
+                            const napi_value* args) const;
 
-   Value MakeCallback(napi_value recv,
-                      const std::initializer_list<napi_value>& args,
-                      napi_async_context context = nullptr) const;
-   Value MakeCallback(napi_value recv,
-                      const std::vector<napi_value>& args,
-                      napi_async_context context = nullptr) const;
-   Value MakeCallback(napi_value recv,
-                      size_t argc,
-                      const napi_value* args,
-                      napi_async_context context = nullptr) const;
+   MaybeOrValue<Value> MakeCallback(
+       napi_value recv,
+       const std::initializer_list<napi_value>& args,
+       napi_async_context context = nullptr) const;
+   MaybeOrValue<Value> MakeCallback(napi_value recv,
+                                    const std::vector<napi_value>& args,
+                                    napi_async_context context = nullptr) const;
+   MaybeOrValue<Value> MakeCallback(napi_value recv,
+                                    size_t argc,
+                                    const napi_value* args,
+                                    napi_async_context context = nullptr) const;
 
-   Object New(const std::initializer_list<napi_value>& args) const;
-   Object New(const std::vector<napi_value>& args) const;
-   Object New(size_t argc, const napi_value* args) const;
+   MaybeOrValue<Object> New(
+       const std::initializer_list<napi_value>& args) const;
+   MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
+   MaybeOrValue<Object> New(size_t argc, const napi_value* args) const;
   };
 
   class Promise : public Object {
@@ -1255,26 +1396,26 @@ namespace Napi {
     ObjectReference& operator =(ObjectReference&& other);
     NAPI_DISALLOW_ASSIGN(ObjectReference)
 
-    Napi::Value Get(const char* utf8name) const;
-    Napi::Value Get(const std::string& utf8name) const;
-    bool Set(const char* utf8name, napi_value value);
-    bool Set(const char* utf8name, Napi::Value value);
-    bool Set(const char* utf8name, const char* utf8value);
-    bool Set(const char* utf8name, bool boolValue);
-    bool Set(const char* utf8name, double numberValue);
-    bool Set(const std::string& utf8name, napi_value value);
-    bool Set(const std::string& utf8name, Napi::Value value);
-    bool Set(const std::string& utf8name, std::string& utf8value);
-    bool Set(const std::string& utf8name, bool boolValue);
-    bool Set(const std::string& utf8name, double numberValue);
+    MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
+    MaybeOrValue<Napi::Value> Get(const std::string& utf8name) const;
+    MaybeOrValue<bool> Set(const char* utf8name, napi_value value);
+    MaybeOrValue<bool> Set(const char* utf8name, Napi::Value value);
+    MaybeOrValue<bool> Set(const char* utf8name, const char* utf8value);
+    MaybeOrValue<bool> Set(const char* utf8name, bool boolValue);
+    MaybeOrValue<bool> Set(const char* utf8name, double numberValue);
+    MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value);
+    MaybeOrValue<bool> Set(const std::string& utf8name, Napi::Value value);
+    MaybeOrValue<bool> Set(const std::string& utf8name, std::string& utf8value);
+    MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue);
+    MaybeOrValue<bool> Set(const std::string& utf8name, double numberValue);
 
-    Napi::Value Get(uint32_t index) const;
-    bool Set(uint32_t index, const napi_value value);
-    bool Set(uint32_t index, const Napi::Value value);
-    bool Set(uint32_t index, const char* utf8value);
-    bool Set(uint32_t index, const std::string& utf8value);
-    bool Set(uint32_t index, bool boolValue);
-    bool Set(uint32_t index, double numberValue);
+    MaybeOrValue<Napi::Value> Get(uint32_t index) const;
+    MaybeOrValue<bool> Set(uint32_t index, const napi_value value);
+    MaybeOrValue<bool> Set(uint32_t index, const Napi::Value value);
+    MaybeOrValue<bool> Set(uint32_t index, const char* utf8value);
+    MaybeOrValue<bool> Set(uint32_t index, const std::string& utf8value);
+    MaybeOrValue<bool> Set(uint32_t index, bool boolValue);
+    MaybeOrValue<bool> Set(uint32_t index, double numberValue);
 
    protected:
     ObjectReference(const ObjectReference&);
@@ -1292,27 +1433,37 @@ namespace Napi {
     FunctionReference& operator =(FunctionReference&& other);
     NAPI_DISALLOW_ASSIGN_COPY(FunctionReference)
 
-    Napi::Value operator ()(const std::initializer_list<napi_value>& args) const;
+    MaybeOrValue<Napi::Value> operator()(
+        const std::initializer_list<napi_value>& args) const;
 
-    Napi::Value Call(const std::initializer_list<napi_value>& args) const;
-    Napi::Value Call(const std::vector<napi_value>& args) const;
-    Napi::Value Call(napi_value recv, const std::initializer_list<napi_value>& args) const;
-    Napi::Value Call(napi_value recv, const std::vector<napi_value>& args) const;
-    Napi::Value Call(napi_value recv, size_t argc, const napi_value* args) const;
+    MaybeOrValue<Napi::Value> Call(
+        const std::initializer_list<napi_value>& args) const;
+    MaybeOrValue<Napi::Value> Call(const std::vector<napi_value>& args) const;
+    MaybeOrValue<Napi::Value> Call(
+        napi_value recv, const std::initializer_list<napi_value>& args) const;
+    MaybeOrValue<Napi::Value> Call(napi_value recv,
+                                   const std::vector<napi_value>& args) const;
+    MaybeOrValue<Napi::Value> Call(napi_value recv,
+                                   size_t argc,
+                                   const napi_value* args) const;
 
-    Napi::Value MakeCallback(napi_value recv,
-                             const std::initializer_list<napi_value>& args,
-                             napi_async_context context = nullptr) const;
-    Napi::Value MakeCallback(napi_value recv,
-                             const std::vector<napi_value>& args,
-                             napi_async_context context = nullptr) const;
-    Napi::Value MakeCallback(napi_value recv,
-                             size_t argc,
-                             const napi_value* args,
-                             napi_async_context context = nullptr) const;
+    MaybeOrValue<Napi::Value> MakeCallback(
+        napi_value recv,
+        const std::initializer_list<napi_value>& args,
+        napi_async_context context = nullptr) const;
+    MaybeOrValue<Napi::Value> MakeCallback(
+        napi_value recv,
+        const std::vector<napi_value>& args,
+        napi_async_context context = nullptr) const;
+    MaybeOrValue<Napi::Value> MakeCallback(
+        napi_value recv,
+        size_t argc,
+        const napi_value* args,
+        napi_async_context context = nullptr) const;
 
-    Object New(const std::initializer_list<napi_value>& args) const;
-    Object New(const std::vector<napi_value>& args) const;
+    MaybeOrValue<Object> New(
+        const std::initializer_list<napi_value>& args) const;
+    MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
   };
 
   // Shortcuts to creating a new reference with inferred type and refcount = 0.

--- a/napi.h
+++ b/napi.h
@@ -131,16 +131,6 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 #define NAPI_FATAL_IF_FAILED(status, location, message)                        \
   NAPI_CHECK((status) == napi_ok, location, message)
 
-// Annotate a function indicating the caller must examine the return value.
-// Use like:
-//   NAPI_WARN_UNUSED_RESULT int foo();
-// TODO: find a way to define NAPI_HAS_ATTRIBUTE_WARN_UNUSED_RESULT
-#if NAPI_HAS_ATTRIBUTE_WARN_UNUSED_RESULT
-#define NAPI_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#else
-#define NAPI_WARN_UNUSED_RESULT /* NOT SUPPORTED */
-#endif
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Node-API C++ Wrapper Classes
 ///
@@ -647,16 +637,22 @@ namespace Napi {
   /// A JavaScript object value.
   class Object : public Value {
   public:
-    /// Enables property and element assignments using indexing syntax.
-    ///
-    /// Example:
-    ///
-    ///     Napi::Value propertyValue = object1['A'];
-    ///     object2['A'] = propertyValue;
-    ///     Napi::Value elementValue = array[0];
-    ///     array[1] = elementValue;
-    template <typename Key>
-    class PropertyLValue {
+   /// Enables property and element assignments using indexing syntax.
+   ///
+   /// This is a convenient helper to get and set object properties. As
+   /// getting and setting object properties may throw with JavaScript
+   /// exceptions, it is notable that these operations may fail.
+   /// When NODE_ADDON_API_ENABLE_MAYBE is defined, the process will abort
+   /// on JavaScript exceptions.
+   ///
+   /// Example:
+   ///
+   ///     Napi::Value propertyValue = object1['A'];
+   ///     object2['A'] = propertyValue;
+   ///     Napi::Value elementValue = array[0];
+   ///     array[1] = elementValue;
+   template <typename Key>
+   class PropertyLValue {
     public:
       /// Converts an L-value to a value.
       operator Value() const;
@@ -684,37 +680,31 @@ namespace Napi {
     Object(napi_env env,
            napi_value value);  ///< Wraps a Node-API value primitive.
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets a named property.
     PropertyLValue<std::string> operator [](
       const char* utf8name ///< UTF-8 encoded null-terminated property name
     );
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets a named property.
     PropertyLValue<std::string> operator [](
       const std::string& utf8name ///< UTF-8 encoded property name
     );
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets or sets an indexed property or array element.
     PropertyLValue<uint32_t> operator [](
       uint32_t index /// Property / element index
     );
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets a named property.
     MaybeOrValue<Value> operator[](
         const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets a named property.
     MaybeOrValue<Value> operator[](
         const std::string& utf8name  ///< UTF-8 encoded property name
     ) const;
 
-    /// TODO(legendecas): find a way to boxing with MaybeOrValue.
     /// Gets an indexed property or array element.
     MaybeOrValue<Value> operator[](uint32_t index  ///< Property / element index
     ) const;

--- a/napi.h
+++ b/napi.h
@@ -102,14 +102,14 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 #define NAPI_MAYBE_THROW_IF_FAILED(env, status, type)                          \
   NAPI_THROW_IF_FAILED(env, status, Napi::Nothing<type>())
 
-#define NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(env, status, result, type)        \
+#define NAPI_RETURN_OR_THROW_IF_FAILED(env, status, result, type)              \
   NAPI_MAYBE_THROW_IF_FAILED(env, status, type);                               \
   return Napi::Just<type>(result);
 #else
 #define NAPI_MAYBE_THROW_IF_FAILED(env, status, type)                          \
   NAPI_THROW_IF_FAILED(env, status, type())
 
-#define NAPI_MAYBE_RETURN_OR_THROW_IF_FAILED(env, status, result, type)        \
+#define NAPI_RETURN_OR_THROW_IF_FAILED(env, status, result, type)              \
   NAPI_MAYBE_THROW_IF_FAILED(env, status, type);                               \
   return result;
 #endif
@@ -831,7 +831,7 @@ namespace Napi {
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
     /// -
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
-    MaybeOrValue<Array> GetPropertyNames();  ///< Get all property names
+    MaybeOrValue<Array> GetPropertyNames() const;  ///< Get all property names
 
     /// Defines a property on the object.
     ///
@@ -873,7 +873,7 @@ namespace Napi {
     /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
     MaybeOrValue<bool> InstanceOf(
         const Function& constructor  ///< Constructor function
-    );
+    ) const;
 
     template <typename Finalizer, typename T>
     inline void AddFinalizer(Finalizer finalizeCallback, T* data);

--- a/napi.h
+++ b/napi.h
@@ -630,16 +630,17 @@ namespace Napi {
    static MaybeOrValue<Symbol> WellKnown(napi_env, const std::string& name);
 
    // Create a symbol in the global registry, UTF-8 Encoded cpp string
-   static Symbol For(napi_env env, const std::string& description);
+   static MaybeOrValue<Symbol> For(napi_env env,
+                                   const std::string& description);
 
    // Create a symbol in the global registry, C style string (null terminated)
-   static Symbol For(napi_env env, const char* description);
+   static MaybeOrValue<Symbol> For(napi_env env, const char* description);
 
    // Create a symbol in the global registry, String value describing the symbol
-   static Symbol For(napi_env env, String description);
+   static MaybeOrValue<Symbol> For(napi_env env, String description);
 
    // Create a symbol in the global registry, napi_value describing the symbol
-   static Symbol For(napi_env env, napi_value description);
+   static MaybeOrValue<Symbol> For(napi_env env, napi_value description);
 
    Symbol();  ///< Creates a new _empty_ Symbol instance.
    Symbol(napi_env env,

--- a/napi.h
+++ b/napi.h
@@ -670,7 +670,7 @@ namespace Napi {
       Key _key;
 
       friend class Napi::Object;
-    };
+   };
 
     /// Creates a new Object value.
     static Object New(napi_env env  ///< Node-API environment

--- a/napi.h
+++ b/napi.h
@@ -85,18 +85,12 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
   } while (0)
 
 #define NAPI_THROW_IF_FAILED(env, status, ...)                                 \
-  if ((status) == napi_pending_exception) {                                    \
-    return __VA_ARGS__;                                                        \
-  }                                                                            \
   if ((status) != napi_ok) {                                                   \
     Napi::Error::New(env).ThrowAsJavaScriptException();                        \
     return __VA_ARGS__;                                                        \
   }
 
 #define NAPI_THROW_IF_FAILED_VOID(env, status)                                 \
-  if ((status) == napi_pending_exception) {                                    \
-    return;                                                                    \
-  }                                                                            \
   if ((status) != napi_ok) {                                                   \
     Napi::Error::New(env).ThrowAsJavaScriptException();                        \
     return;                                                                    \

--- a/test/README.md
+++ b/test/README.md
@@ -1,25 +1,25 @@
 # Writing Tests
 
-There are multiple flavors of node-addon-api test build that covers different
+There are multiple flavors of node-addon-api test builds that cover different
 build flags defined in `napi.h`:
 
 1. c++ exceptions enabled,
 2. c++ exceptions disabled,
-3. c++ exceptions disabled, and `NODE_ADDON_API_ENABLE_MAYBE` is defined.
+3. c++ exceptions disabled, and `NODE_ADDON_API_ENABLE_MAYBE` defined.
 
 Functions in node-addon-api that call into JavaScript can have different
 declared return types to reflect build flavor settings. For example,
 `Napi::Object::Set` returns `bool` when `NODE_ADDON_API_ENABLE_MAYBE`
 is not defined, and `Napi::Maybe<bool>` when `NODE_ADDON_API_ENABLE_MAYBE`
 is defined. In source code, return type variants are defined as
-`Napi::MaybeOrValue<>` to prevent from duplicating most part of the code base.
+`Napi::MaybeOrValue<>` to prevent the duplication of most of the code base.
 
 To properly test these build flavors, all values returned by a function defined
-with `Napi::MaybeOrValue<>` return types in node-addon-api test suite, should
-use one of the following test helpers to handle possible JavaScript exceptions.
+to return `Napi::MaybeOrValue<>` should be tested by using one of the following
+test helpers to handle possible JavaScript exceptions.
 
-There are three test helper functions to conveniently convert `Napi::MaybeOrValue<>`
-type to raw types.
+There are three test helper functions to conveniently convert
+`Napi::MaybeOrValue<>` values to raw values.
 
 ## MaybeUnwrap
 
@@ -37,8 +37,8 @@ Example:
 
 ```cpp
 Object obj = info[0].As<Object>();
-Value value = MaybeUnwrap(obj->Get("foobar")); // we are sure the parameters
-// should not throw
+// we are sure the parameters should not throw
+Value value = MaybeUnwrap(obj->Get("foobar"));
 ```
 
 ## MaybeUnwrapOr
@@ -68,7 +68,7 @@ Value CallWithArgs(const CallbackInfo& info) {
 
 ```cpp
 template <typename T>
-T MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out);
+bool MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out);
 ```
 
 Converts `MaybeOrValue<T>` to `T` by getting the value that wrapped by the
@@ -81,7 +81,7 @@ Example:
 ```cpp
 Object opts = info[0].As<Object>();
 bool hasProperty = false;
-// The check may throwing, but we are going to suppress that.
+// The check may throw, but we are going to suppress that.
 if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
   isBlocking = hasProperty &&
                 MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,102 @@
+# Writing Tests
+
+There are multiple flavors of node-addon-api test build that covers different
+build flags defined in `napi.h`:
+
+1. c++ exceptions enabled,
+2. c++ exceptions disabled,
+3. c++ exceptions disabled, and `NODE_ADDON_API_ENABLE_MAYBE` is defined.
+
+`Napi` functions that calling into JavaScript can have different declared
+`NODE_ADDON_API_ENABLE_MAYBE` is defined and c++ exceptions disabled
+return types to reflect build flavor settings. For example,
+`Napi::Object::Set` returns `bool`, and `Napi::Maybe<bool>` when
+`NODE_ADDON_API_ENABLE_MAYBE` is defined. In source code, return type variants
+are defined as `Napi::MaybeOrValue<>` to prevent from duplicating most of the
+code base.
+
+To properly test these build flavors, we should take care of the return value
+of `Napi` functions that may call into JavaScript. For example:
+
+```cpp
+#include "napi.h"
+#include "test_helper.h"
+
+using namespace Napi;
+
+Value fn(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Value value = MaybeUnwrap(obj->Get("foobar")); // <- `obj->Get` may throws
+}
+```
+
+There are there test helper function to conveniently convert `Napi::MaybeOrValue<>`
+type to raw types.
+
+## MaybeUnwrap
+
+```cpp
+template <typename T>
+T MaybeUnwrap(MaybeOrValue<T> maybe);
+```
+
+Converts `MaybeOrValue<T>` to `T` by checking that `MaybeOrValue` is NOT an
+empty `Maybe`.
+
+Returns the original value if `NODE_ADDON_API_ENABLE_MAYBE` is not defined.
+
+Example:
+
+```cpp
+Object obj = info[0].As<Object>();
+Value value = MaybeUnwrap(obj->Get("foobar")); // we are sure the parameters should not throw
+```
+
+## MaybeUnwrapOr
+
+```cpp
+template <typename T>
+T MaybeUnwrapOr(MaybeOrValue<T> maybe, const T& default_value = T());
+```
+
+Converts `MaybeOrValue<T>` to `T` by getting the value that wrapped by the
+`Maybe` or return the `default_value` if the `Maybe` is empty.
+
+Returns the original value if `NODE_ADDON_API_ENABLE_MAYBE` is not defined.
+
+Example:
+
+```cpp
+Value CallWithArgs(const CallbackInfo& info) {
+  Function func = info[0].As<Function>();
+  // We don't care if the operation is throwing or not, just return it back to node-addon-api
+  return MaybeUnwrapOr(
+      func.Call(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
+}
+```
+
+## MaybeUnwrapTo
+
+```cpp
+template <typename T>
+T MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out);
+```
+
+Converts `MaybeOrValue<T>` to `T` by getting the value that wrapped by the
+e`Maybe` or return `false` if the Maybe is empty
+
+Copies the `value` to `out` when `NODE_ADDON_API_ENABLE_MAYBE` is not defined
+
+Example:
+
+```cpp
+Object opts = info[0].As<Object>();
+bool hasProperty = false;
+// The check may throwing, but we are going to suppress that.
+if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
+  isBlocking = hasProperty &&
+                MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
+} else {
+  env.GetAndClearPendingException();
+}
+```

--- a/test/README.md
+++ b/test/README.md
@@ -18,22 +18,6 @@ To properly test these build flavors, all values returned by a function defined
 with `Napi::MaybeOrValue<>` return types in node-addon-api test suite, should
 use one of the following test helpers to handle possible JavaScript exceptions.
 
-```cpp
-#include "napi.h"
-#include "test_helper.h"
-
-using namespace Napi;
-
-void fn(const CallbackInfo& info) {
-  Object obj = info[0].As<Object>();
-  Value value = MaybeUnwrap(obj->Get("foobar")); // <- `obj->Get` is calling
-  // into JavaScript and may throw JavaScript Exceptions. Here we just assert
-  // getting the parameter must not fail for convenience.
-
-  // ... do works with the value.
-}
-```
-
 There are three test helper functions to conveniently convert `Napi::MaybeOrValue<>`
 type to raw types.
 

--- a/test/addon_data.cc
+++ b/test/addon_data.cc
@@ -1,6 +1,7 @@
 #if (NAPI_VERSION > 5)
 #include <stdio.h>
 #include "napi.h"
+#include "test_helper.h"
 
 // An overly elaborate way to get/set a boolean stored in the instance data:
 // 0. A boolean named "verbose" is stored in the instance data. The constructor
@@ -42,7 +43,8 @@ class Addon {
   };
 
   static Napi::Value Getter(const Napi::CallbackInfo& info) {
-    return info.Env().GetInstanceData<Addon>()->VerboseIndicator.New({});
+    return MaybeUnwrap(
+        info.Env().GetInstanceData<Addon>()->VerboseIndicator.New({}));
   }
 
   static void Setter(const Napi::CallbackInfo& info) {

--- a/test/basic_types/value.cc
+++ b/test/basic_types/value.cc
@@ -76,19 +76,19 @@ static Value IsExternal(const CallbackInfo& info) {
 }
 
 static Value ToBoolean(const CallbackInfo& info) {
-  return MaybeUnwrapOr(info[0].ToBoolean());
+  return MaybeUnwrap(info[0].ToBoolean());
 }
 
 static Value ToNumber(const CallbackInfo& info) {
-  return MaybeUnwrapOr(info[0].ToNumber());
+  return MaybeUnwrap(info[0].ToNumber());
 }
 
 static Value ToString(const CallbackInfo& info) {
-  return MaybeUnwrapOr(info[0].ToString());
+  return MaybeUnwrap(info[0].ToString());
 }
 
 static Value ToObject(const CallbackInfo& info) {
-  return MaybeUnwrapOr(info[0].ToObject());
+  return MaybeUnwrap(info[0].ToObject());
 }
 
 Object InitBasicTypesValue(Env env) {

--- a/test/basic_types/value.cc
+++ b/test/basic_types/value.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -75,19 +76,19 @@ static Value IsExternal(const CallbackInfo& info) {
 }
 
 static Value ToBoolean(const CallbackInfo& info) {
-  return info[0].ToBoolean();
+  return MaybeUnwrapOr(info[0].ToBoolean());
 }
 
 static Value ToNumber(const CallbackInfo& info) {
-  return info[0].ToNumber();
+  return MaybeUnwrapOr(info[0].ToNumber());
 }
 
 static Value ToString(const CallbackInfo& info) {
-  return info[0].ToString();
+  return MaybeUnwrapOr(info[0].ToString());
 }
 
 static Value ToObject(const CallbackInfo& info) {
-  return info[0].ToObject();
+  return MaybeUnwrapOr(info[0].ToObject());
 }
 
 Object InitBasicTypesValue(Env env) {

--- a/test/bigint.cc
+++ b/test/bigint.cc
@@ -3,6 +3,8 @@
 #define NAPI_EXPERIMENTAL
 #include "napi.h"
 
+#include "test_helper.h"
+
 using namespace Napi;
 
 namespace {
@@ -11,7 +13,7 @@ Value IsLossless(const CallbackInfo& info) {
   Env env = info.Env();
 
   BigInt big = info[0].As<BigInt>();
-  bool is_signed = info[1].ToBoolean().Value();
+  bool is_signed = MaybeUnwrap(info[1].ToBoolean()).Value();
 
   bool lossless;
   if (is_signed) {

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -72,6 +72,10 @@ Object InitThunkingManual(Env env);
 Object InitObjectFreezeSeal(Env env);
 #endif
 
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+Object InitMaybeCheck(Env env);
+#endif
+
 Object Init(Env env, Object exports) {
 #if (NAPI_VERSION > 5)
   exports.Set("addon", InitAddon(env));
@@ -148,6 +152,10 @@ Object Init(Env env, Object exports) {
   exports.Set("thunking_manual", InitThunkingManual(env));
 #if (NAPI_VERSION > 7)
   exports.Set("object_freeze_seal", InitObjectFreezeSeal(env));
+#endif
+
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  exports.Set("maybe_check", InitMaybeCheck(env));
 #endif
   return exports;
 }

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -1,6 +1,7 @@
 {
   'target_defaults': {
     'includes': ['../common.gypi'],
+    'include_dirs': ['./common'],
     'sources': [
         'addon.cc',
         'addon_data.cc',
@@ -26,6 +27,7 @@
         'function.cc',
         'functionreference.cc',
         'handlescope.cc',
+        'maybe/check.cc',
         'movable_callbacks.cc',
         'memory_management.cc',
         'name.cc',
@@ -81,6 +83,11 @@
     {
       'target_name': 'binding_noexcept',
       'includes': ['../noexcept.gypi']
+    },
+    {
+      'target_name': 'binding_noexcept_maybe',
+      'includes': ['../noexcept.gypi'],
+      'defines': ['NODE_ADDON_API_ENABLE_MAYBE']
     },
   ],
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -81,6 +81,7 @@ exports.runTest = async function(test, buildType) {
   const bindings = [
     `../build/${buildType}/binding.node`,
     `../build/${buildType}/binding_noexcept.node`,
+    `../build/${buildType}/binding_noexcept_maybe.node`,
   ].map(it => require.resolve(it));
 
   for (const item of bindings) {
@@ -95,6 +96,7 @@ exports.runTestWithBindingPath = async function(test, buildType) {
   const bindings = [
     `../build/${buildType}/binding.node`,
     `../build/${buildType}/binding_noexcept.node`,
+    `../build/${buildType}/binding_noexcept_maybe.node`,
   ].map(it => require.resolve(it));
 
   for (const item of bindings) {

--- a/test/common/test_helper.h
+++ b/test/common/test_helper.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "napi.h"
+
+namespace Napi {
+
+// Use this when a variable or parameter is unused in order to explicitly
+// silence a compiler warning about that.
+template <typename T>
+inline void USE(T&&) {}
+
+/**
+ * A test helper that converts MaybeOrValue<T> to T by checking that
+ * MaybeOrValue is NOT an empty Maybe when NODE_ADDON_API_ENABLE_MAYBE is
+ * defined.
+ *
+ * Do nothing when NODE_ADDON_API_ENABLE_MAYBE is not defined.
+ */
+template <typename T>
+inline T MaybeUnwrap(MaybeOrValue<T> maybe) {
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  return maybe.Unwrap();
+#else
+  return maybe;
+#endif
+}
+
+/**
+ * A test helper that converts MaybeOrValue<T> to T by getting the value that
+ * wrapped by the Maybe or return the default_value if the Maybe is empty when
+ * NODE_ADDON_API_ENABLE_MAYBE is defined.
+ *
+ * Do nothing when NODE_ADDON_API_ENABLE_MAYBE is not defined.
+ */
+template <typename T>
+inline T MaybeUnwrapOr(MaybeOrValue<T> maybe, const T& default_value = T()) {
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  return maybe.UnwrapOr(default_value);
+#else
+  USE(default_value);
+  return maybe;
+#endif
+}
+
+/**
+ * A test helper that converts MaybeOrValue<T> to T by getting the value that
+ * wrapped by the Maybe or return false if the Maybe is empty when
+ * NODE_ADDON_API_ENABLE_MAYBE is defined.
+ *
+ * Copying the value to out when NODE_ADDON_API_ENABLE_MAYBE is not defined.
+ */
+template <typename T>
+inline T MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out) {
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+  return maybe.UnwrapTo(out);
+#else
+  *out = maybe;
+  return true;
+#endif
+}
+
+}  // namespace Napi

--- a/test/common/test_helper.h
+++ b/test/common/test_helper.h
@@ -32,7 +32,7 @@ inline T MaybeUnwrap(MaybeOrValue<T> maybe) {
  * Do nothing when NODE_ADDON_API_ENABLE_MAYBE is not defined.
  */
 template <typename T>
-inline T MaybeUnwrapOr(MaybeOrValue<T> maybe, const T& default_value = T()) {
+inline T MaybeUnwrapOr(MaybeOrValue<T> maybe, const T& default_value) {
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
   return maybe.UnwrapOr(default_value);
 #else

--- a/test/common/test_helper.h
+++ b/test/common/test_helper.h
@@ -49,7 +49,7 @@ inline T MaybeUnwrapOr(MaybeOrValue<T> maybe, const T& default_value) {
  * Copying the value to out when NODE_ADDON_API_ENABLE_MAYBE is not defined.
  */
 template <typename T>
-inline T MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out) {
+inline bool MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out) {
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
   return maybe.UnwrapTo(out);
 #else

--- a/test/function.cc
+++ b/test/function.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -53,8 +54,8 @@ Value ValueCallbackWithData(const CallbackInfo& info) {
 
 Value CallWithArgs(const CallbackInfo& info) {
   Function func = info[0].As<Function>();
-  return func.Call(
-      std::initializer_list<napi_value>{info[1], info[2], info[3]});
+  return MaybeUnwrapOr(
+      func.Call(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
 }
 
 Value CallWithVector(const CallbackInfo& info) {
@@ -64,7 +65,7 @@ Value CallWithVector(const CallbackInfo& info) {
    args.push_back(info[1]);
    args.push_back(info[2]);
    args.push_back(info[3]);
-   return func.Call(args);
+   return MaybeUnwrapOr(func.Call(args));
 }
 
 Value CallWithCStyleArray(const CallbackInfo& info) {
@@ -74,7 +75,7 @@ Value CallWithCStyleArray(const CallbackInfo& info) {
   args.push_back(info[1]);
   args.push_back(info[2]);
   args.push_back(info[3]);
-  return func.Call(args.size(), args.data());
+  return MaybeUnwrapOr(func.Call(args.size(), args.data()));
 }
 
 Value CallWithReceiverAndCStyleArray(const CallbackInfo& info) {
@@ -85,13 +86,14 @@ Value CallWithReceiverAndCStyleArray(const CallbackInfo& info) {
   args.push_back(info[2]);
   args.push_back(info[3]);
   args.push_back(info[4]);
-  return func.Call(receiver, args.size(), args.data());
+  return MaybeUnwrapOr(func.Call(receiver, args.size(), args.data()));
 }
 
 Value CallWithReceiverAndArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
    Value receiver = info[1];
-   return func.Call(receiver, std::initializer_list<napi_value>{ info[2], info[3], info[4] });
+   return MaybeUnwrapOr(func.Call(
+       receiver, std::initializer_list<napi_value>{info[2], info[3], info[4]}));
 }
 
 Value CallWithReceiverAndVector(const CallbackInfo& info) {
@@ -102,17 +104,19 @@ Value CallWithReceiverAndVector(const CallbackInfo& info) {
    args.push_back(info[2]);
    args.push_back(info[3]);
    args.push_back(info[4]);
-   return func.Call(receiver, args);
+   return MaybeUnwrapOr(func.Call(receiver, args));
 }
 
 Value CallWithInvalidReceiver(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return func.Call(Value(), std::initializer_list<napi_value>{});
+   return MaybeUnwrapOr(
+       func.Call(Value(), std::initializer_list<napi_value>{}));
 }
 
 Value CallConstructorWithArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return func.New(std::initializer_list<napi_value>{ info[1], info[2], info[3] });
+   return MaybeUnwrapOr(
+       func.New(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
 }
 
 Value CallConstructorWithVector(const CallbackInfo& info) {
@@ -122,7 +126,7 @@ Value CallConstructorWithVector(const CallbackInfo& info) {
    args.push_back(info[1]);
    args.push_back(info[2]);
    args.push_back(info[3]);
-   return func.New(args);
+   return MaybeUnwrapOr(func.New(args));
 }
 
 Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
@@ -132,7 +136,7 @@ Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
   args.push_back(info[1]);
   args.push_back(info[2]);
   args.push_back(info[3]);
-  return func.New(args.size(), args.data());
+  return MaybeUnwrapOr(func.New(args.size(), args.data()));
 }
 
 void IsConstructCall(const CallbackInfo& info) {
@@ -191,7 +195,7 @@ void MakeCallbackWithInvalidReceiver(const CallbackInfo& info) {
 
 Value CallWithFunctionOperator(const CallbackInfo& info) {
   Function func = info[0].As<Function>();
-  return func({info[1], info[2], info[3]});
+  return MaybeUnwrapOr(func({info[1], info[2], info[3]}));
 }
 
 } // end anonymous namespace

--- a/test/function.cc
+++ b/test/function.cc
@@ -54,7 +54,7 @@ Value ValueCallbackWithData(const CallbackInfo& info) {
 
 Value CallWithArgs(const CallbackInfo& info) {
   Function func = info[0].As<Function>();
-  return MaybeUnwrapOr(
+  return MaybeUnwrap(
       func.Call(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
 }
 
@@ -65,7 +65,7 @@ Value CallWithVector(const CallbackInfo& info) {
    args.push_back(info[1]);
    args.push_back(info[2]);
    args.push_back(info[3]);
-   return MaybeUnwrapOr(func.Call(args));
+   return MaybeUnwrap(func.Call(args));
 }
 
 Value CallWithCStyleArray(const CallbackInfo& info) {
@@ -75,7 +75,7 @@ Value CallWithCStyleArray(const CallbackInfo& info) {
   args.push_back(info[1]);
   args.push_back(info[2]);
   args.push_back(info[3]);
-  return MaybeUnwrapOr(func.Call(args.size(), args.data()));
+  return MaybeUnwrap(func.Call(args.size(), args.data()));
 }
 
 Value CallWithReceiverAndCStyleArray(const CallbackInfo& info) {
@@ -86,13 +86,13 @@ Value CallWithReceiverAndCStyleArray(const CallbackInfo& info) {
   args.push_back(info[2]);
   args.push_back(info[3]);
   args.push_back(info[4]);
-  return MaybeUnwrapOr(func.Call(receiver, args.size(), args.data()));
+  return MaybeUnwrap(func.Call(receiver, args.size(), args.data()));
 }
 
 Value CallWithReceiverAndArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
    Value receiver = info[1];
-   return MaybeUnwrapOr(func.Call(
+   return MaybeUnwrap(func.Call(
        receiver, std::initializer_list<napi_value>{info[2], info[3], info[4]}));
 }
 
@@ -104,18 +104,18 @@ Value CallWithReceiverAndVector(const CallbackInfo& info) {
    args.push_back(info[2]);
    args.push_back(info[3]);
    args.push_back(info[4]);
-   return MaybeUnwrapOr(func.Call(receiver, args));
+   return MaybeUnwrap(func.Call(receiver, args));
 }
 
 Value CallWithInvalidReceiver(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return MaybeUnwrapOr(
-       func.Call(Value(), std::initializer_list<napi_value>{}));
+   return MaybeUnwrapOr(func.Call(Value(), std::initializer_list<napi_value>{}),
+                        Value());
 }
 
 Value CallConstructorWithArgs(const CallbackInfo& info) {
    Function func = info[0].As<Function>();
-   return MaybeUnwrapOr(
+   return MaybeUnwrap(
        func.New(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
 }
 
@@ -126,7 +126,7 @@ Value CallConstructorWithVector(const CallbackInfo& info) {
    args.push_back(info[1]);
    args.push_back(info[2]);
    args.push_back(info[3]);
-   return MaybeUnwrapOr(func.New(args));
+   return MaybeUnwrap(func.New(args));
 }
 
 Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
@@ -136,7 +136,7 @@ Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
   args.push_back(info[1]);
   args.push_back(info[2]);
   args.push_back(info[3]);
-  return MaybeUnwrapOr(func.New(args.size(), args.data()));
+  return MaybeUnwrap(func.New(args.size(), args.data()));
 }
 
 void IsConstructCall(const CallbackInfo& info) {
@@ -195,7 +195,7 @@ void MakeCallbackWithInvalidReceiver(const CallbackInfo& info) {
 
 Value CallWithFunctionOperator(const CallbackInfo& info) {
   Function func = info[0].As<Function>();
-  return MaybeUnwrapOr(func({info[1], info[2], info[3]}));
+  return MaybeUnwrap(func({info[1], info[2], info[3]}));
 }
 
 } // end anonymous namespace

--- a/test/functionreference.cc
+++ b/test/functionreference.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -8,7 +9,7 @@ Value Call(const CallbackInfo& info) {
   FunctionReference ref;
   ref.Reset(info[0].As<Function>());
 
-  return ref.Call({});
+  return MaybeUnwrapOr(ref.Call({}));
 }
 
 Value Construct(const CallbackInfo& info) {
@@ -16,7 +17,7 @@ Value Construct(const CallbackInfo& info) {
   FunctionReference ref;
   ref.Reset(info[0].As<Function>());
 
-  return ref.New({});
+  return MaybeUnwrapOr(ref.New({}));
 }
 }  // namespace
 

--- a/test/functionreference.cc
+++ b/test/functionreference.cc
@@ -9,7 +9,7 @@ Value Call(const CallbackInfo& info) {
   FunctionReference ref;
   ref.Reset(info[0].As<Function>());
 
-  return MaybeUnwrapOr(ref.Call({}));
+  return MaybeUnwrapOr(ref.Call({}), Value());
 }
 
 Value Construct(const CallbackInfo& info) {
@@ -17,7 +17,7 @@ Value Construct(const CallbackInfo& info) {
   FunctionReference ref;
   ref.Reset(info[0].As<Function>());
 
-  return MaybeUnwrapOr(ref.New({}));
+  return MaybeUnwrapOr(ref.New({}), Object());
 }
 }  // namespace
 

--- a/test/globalObject/global_object_delete_property.cc
+++ b/test/globalObject/global_object_delete_property.cc
@@ -1,27 +1,31 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value DeletePropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
-  return Boolean::New(info.Env(), globalObject.Delete(key.Utf8Value().c_str()));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(globalObject.Delete(key.Utf8Value().c_str())));
 }
 
 Value DeletePropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
-  return Boolean::New(info.Env(), globalObject.Delete(key.Utf8Value()));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(globalObject.Delete(key.Utf8Value())));
 }
 
 Value DeletePropertyWithInt32AsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Number key = info[0].As<Number>();
-  return Boolean::New(info.Env(), globalObject.Delete(key.Uint32Value()));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(globalObject.Delete(key.Uint32Value())));
 }
 
 Value DeletePropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
-  return Boolean::New(info.Env(), globalObject.Delete(key));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(globalObject.Delete(key)));
 }

--- a/test/globalObject/global_object_delete_property.cc
+++ b/test/globalObject/global_object_delete_property.cc
@@ -7,25 +7,25 @@ Value DeletePropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
   return Boolean::New(
-      info.Env(), MaybeUnwrapOr(globalObject.Delete(key.Utf8Value().c_str())));
+      info.Env(), MaybeUnwrap(globalObject.Delete(key.Utf8Value().c_str())));
 }
 
 Value DeletePropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
   return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(globalObject.Delete(key.Utf8Value())));
+                      MaybeUnwrap(globalObject.Delete(key.Utf8Value())));
 }
 
 Value DeletePropertyWithInt32AsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Number key = info[0].As<Number>();
   return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(globalObject.Delete(key.Uint32Value())));
+                      MaybeUnwrap(globalObject.Delete(key.Uint32Value())));
 }
 
 Value DeletePropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(globalObject.Delete(key)));
+  return Boolean::New(info.Env(), MaybeUnwrap(globalObject.Delete(key)));
 }

--- a/test/globalObject/global_object_get_property.cc
+++ b/test/globalObject/global_object_get_property.cc
@@ -6,25 +6,25 @@ using namespace Napi;
 Value GetPropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
-  return MaybeUnwrapOr(globalObject.Get(key));
+  return MaybeUnwrap(globalObject.Get(key));
 }
 
 Value GetPropertyWithInt32AsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Number key = info[0].As<Napi::Number>();
-  return MaybeUnwrapOr(globalObject.Get(key.Uint32Value()));
+  return MaybeUnwrapOr(globalObject.Get(key.Uint32Value()), Value());
 }
 
 Value GetPropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String cStrkey = info[0].As<String>();
-  return MaybeUnwrapOr(globalObject.Get(cStrkey.Utf8Value().c_str()));
+  return MaybeUnwrapOr(globalObject.Get(cStrkey.Utf8Value().c_str()), Value());
 }
 
 Value GetPropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String cppStrKey = info[0].As<String>();
-  return MaybeUnwrapOr(globalObject.Get(cppStrKey.Utf8Value()));
+  return MaybeUnwrapOr(globalObject.Get(cppStrKey.Utf8Value()), Value());
 }
 
 void CreateMockTestObject(const CallbackInfo& info) {

--- a/test/globalObject/global_object_get_property.cc
+++ b/test/globalObject/global_object_get_property.cc
@@ -1,29 +1,30 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value GetPropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
-  return globalObject.Get(key);
+  return MaybeUnwrapOr(globalObject.Get(key));
 }
 
 Value GetPropertyWithInt32AsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Number key = info[0].As<Napi::Number>();
-  return globalObject.Get(key.Uint32Value());
+  return MaybeUnwrapOr(globalObject.Get(key.Uint32Value()));
 }
 
 Value GetPropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String cStrkey = info[0].As<String>();
-  return globalObject.Get(cStrkey.Utf8Value().c_str());
+  return MaybeUnwrapOr(globalObject.Get(cStrkey.Utf8Value().c_str()));
 }
 
 Value GetPropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String cppStrKey = info[0].As<String>();
-  return globalObject.Get(cppStrKey.Utf8Value());
+  return MaybeUnwrapOr(globalObject.Get(cppStrKey.Utf8Value()));
 }
 
 void CreateMockTestObject(const CallbackInfo& info) {

--- a/test/globalObject/global_object_has_own_property.cc
+++ b/test/globalObject/global_object_has_own_property.cc
@@ -1,22 +1,26 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value HasPropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
-  return Boolean::New(info.Env(),
-                      globalObject.HasOwnProperty(key.Utf8Value().c_str()));
+  return Boolean::New(
+      info.Env(),
+      MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value().c_str())));
 }
 
 Value HasPropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
-  return Boolean::New(info.Env(), globalObject.HasOwnProperty(key.Utf8Value()));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value())));
 }
 
 Value HasPropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
-  return Boolean::New(info.Env(), globalObject.HasOwnProperty(key));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(globalObject.HasOwnProperty(key)));
 }

--- a/test/globalObject/global_object_has_own_property.cc
+++ b/test/globalObject/global_object_has_own_property.cc
@@ -8,19 +8,21 @@ Value HasPropertyWithCStyleStringAsKey(const CallbackInfo& info) {
   String key = info[0].As<String>();
   return Boolean::New(
       info.Env(),
-      MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value().c_str())));
+      MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value().c_str()),
+                    false));
 }
 
 Value HasPropertyWithCppStyleStringAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   String key = info[0].As<String>();
   return Boolean::New(
-      info.Env(), MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value())));
+      info.Env(),
+      MaybeUnwrapOr(globalObject.HasOwnProperty(key.Utf8Value()), false));
 }
 
 Value HasPropertyWithNapiValueAsKey(const CallbackInfo& info) {
   Object globalObject = info.Env().Global();
   Name key = info[0].As<Name>();
   return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(globalObject.HasOwnProperty(key)));
+                      MaybeUnwrap(globalObject.HasOwnProperty(key)));
 }

--- a/test/maybe/check.cc
+++ b/test/maybe/check.cc
@@ -1,0 +1,23 @@
+#include "napi.h"
+#if defined(NODE_ADDON_API_ENABLE_MAYBE)
+
+using namespace Napi;
+
+namespace {
+
+void VoidCallback(const CallbackInfo& info) {
+  Function fn = info[0].As<Function>();
+
+  Maybe<Value> it = fn.Call({});
+
+  it.Check();
+}
+
+}  // end anonymous namespace
+
+Object InitMaybeCheck(Env env) {
+  Object exports = Object::New(env);
+  exports.Set("voidCallback", Function::New(env, VoidCallback));
+  return exports;
+}
+#endif

--- a/test/maybe/index.js
+++ b/test/maybe/index.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const buildType = process.config.target_defaults.default_configuration;
+const assert = require('assert');
+const os = require('os');
+
+const napiChild = require('../napi_child');
+
+module.exports = test(require(`../build/${buildType}/binding_noexcept_maybe.node`).maybe_check);
+
+function test(binding) {
+  if (process.argv.includes('child')) {
+    child(binding);
+    return;
+  }
+  const cp = napiChild.spawn(process.execPath, [__filename, 'child'], {
+    stdio: ['ignore', 'inherit', 'pipe'],
+  });
+  cp.stderr.setEncoding('utf8');
+  let stderr = '';
+  cp.stderr.on('data', chunk => {
+    stderr += chunk;
+  });
+  cp.on('exit', (code, signal) => {
+    if (process.platform === 'win32') {
+      assert.strictEqual(code, 128 + 6 /* SIGABRT */);
+    } else {
+      assert.strictEqual(signal, 'SIGABRT');
+    }
+    assert.ok(stderr.match(/FATAL ERROR: Napi::Maybe::Check Maybe value is Nothing./));
+  });
+}
+
+function child(binding) {
+  binding.voidCallback(() => {
+    throw new Error('foobar');
+  })
+}

--- a/test/object/delete_property.cc
+++ b/test/object/delete_property.cc
@@ -1,33 +1,36 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value DeletePropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number key = info[1].As<Number>();
-  return Boolean::New(info.Env(), obj.Delete(key.Uint32Value()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(key.Uint32Value())));
 }
 
 Value DeletePropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.Delete(static_cast<napi_value>(key)));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Delete(static_cast<napi_value>(key))));
 }
 
 Value DeletePropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.Delete(key));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(key)));
 }
 
 Value DeletePropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.Delete(jsKey.Utf8Value().c_str()));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value().c_str())));
 }
 
 Value DeletePropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.Delete(jsKey.Utf8Value()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value())));
 }

--- a/test/object/delete_property.cc
+++ b/test/object/delete_property.cc
@@ -6,31 +6,33 @@ using namespace Napi;
 Value DeletePropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number key = info[1].As<Number>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(key.Uint32Value())));
+  return Boolean::New(info.Env(), MaybeUnwrap(obj.Delete(key.Uint32Value())));
 }
 
 Value DeletePropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Delete(static_cast<napi_value>(key))));
+  return Boolean::New(
+      info.Env(),
+      MaybeUnwrapOr(obj.Delete(static_cast<napi_value>(key)), false));
 }
 
 Value DeletePropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(key)));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(key), false));
 }
 
 Value DeletePropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value().c_str())));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value().c_str()), false));
 }
 
 Value DeletePropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value())));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Delete(jsKey.Utf8Value()), false));
 }

--- a/test/object/get_property.cc
+++ b/test/object/get_property.cc
@@ -6,29 +6,29 @@ using namespace Napi;
 Value GetPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return MaybeUnwrapOr(obj.Get(static_cast<napi_value>(key)));
+  return MaybeUnwrapOr(obj.Get(static_cast<napi_value>(key)), Value());
 }
 
 Value GetPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return MaybeUnwrapOr(obj.Get(key));
+  return MaybeUnwrapOr(obj.Get(key), Value());
 }
 
 Value GetPropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number key = info[1].As<Number>();
-  return MaybeUnwrapOr(obj.Get(key.Uint32Value()));
+  return MaybeUnwrap(obj.Get(key.Uint32Value()));
 }
 
 Value GetPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value().c_str()));
+  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value().c_str()), Value());
 }
 
 Value GetPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value()));
+  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value()), Value());
 }

--- a/test/object/get_property.cc
+++ b/test/object/get_property.cc
@@ -1,33 +1,34 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value GetPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return obj.Get(static_cast<napi_value>(key));
+  return MaybeUnwrapOr(obj.Get(static_cast<napi_value>(key)));
 }
 
 Value GetPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return obj.Get(key);
+  return MaybeUnwrapOr(obj.Get(key));
 }
 
 Value GetPropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number key = info[1].As<Number>();
-  return obj.Get(key.Uint32Value());
+  return MaybeUnwrapOr(obj.Get(key.Uint32Value()));
 }
 
 Value GetPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return obj.Get(jsKey.Utf8Value().c_str());
+  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value().c_str()));
 }
 
 Value GetPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return obj.Get(jsKey.Utf8Value());
+  return MaybeUnwrapOr(obj.Get(jsKey.Utf8Value()));
 }

--- a/test/object/has_own_property.cc
+++ b/test/object/has_own_property.cc
@@ -8,25 +8,27 @@ Value HasOwnPropertyWithNapiValue(const CallbackInfo& info) {
   Name key = info[1].As<Name>();
   return Boolean::New(
       info.Env(),
-      MaybeUnwrapOr(obj.HasOwnProperty(static_cast<napi_value>(key))));
+      MaybeUnwrapOr(obj.HasOwnProperty(static_cast<napi_value>(key)), false));
 }
 
 Value HasOwnPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.HasOwnProperty(key)));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.HasOwnProperty(key), false));
 }
 
 Value HasOwnPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
   return Boolean::New(
-      info.Env(), MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value().c_str())));
+      info.Env(),
+      MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value().c_str()), false));
 }
 
 Value HasOwnPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value())));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value()), false));
 }

--- a/test/object/has_own_property.cc
+++ b/test/object/has_own_property.cc
@@ -1,27 +1,32 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value HasOwnPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.HasOwnProperty(static_cast<napi_value>(key)));
+  return Boolean::New(
+      info.Env(),
+      MaybeUnwrapOr(obj.HasOwnProperty(static_cast<napi_value>(key))));
 }
 
 Value HasOwnPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.HasOwnProperty(key));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.HasOwnProperty(key)));
 }
 
 Value HasOwnPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.HasOwnProperty(jsKey.Utf8Value().c_str()));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value().c_str())));
 }
 
 Value HasOwnPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.HasOwnProperty(jsKey.Utf8Value()));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.HasOwnProperty(jsKey.Utf8Value())));
 }

--- a/test/object/has_property.cc
+++ b/test/object/has_property.cc
@@ -6,31 +6,33 @@ using namespace Napi;
 Value HasPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Has(static_cast<napi_value>(key))));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(obj.Has(static_cast<napi_value>(key)), false));
 }
 
 Value HasPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(key)));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(key), false));
 }
 
 Value HasPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
   return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Has(jsKey.Utf8Value().c_str())));
+                      MaybeUnwrapOr(obj.Has(jsKey.Utf8Value().c_str()), false));
 }
 
 Value HasPropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number jsKey = info[1].As<Number>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(jsKey.Uint32Value())));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Has(jsKey.Uint32Value()), false));
 }
 
 Value HasPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(jsKey.Utf8Value())));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Has(jsKey.Utf8Value()), false));
 }

--- a/test/object/has_property.cc
+++ b/test/object/has_property.cc
@@ -1,33 +1,36 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
 Value HasPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.Has(static_cast<napi_value>(key)));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Has(static_cast<napi_value>(key))));
 }
 
 Value HasPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
-  return Boolean::New(info.Env(), obj.Has(key));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(key)));
 }
 
 Value HasPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.Has(jsKey.Utf8Value().c_str()));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Has(jsKey.Utf8Value().c_str())));
 }
 
 Value HasPropertyWithUint32(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Number jsKey = info[1].As<Number>();
-  return Boolean::New(info.Env(), obj.Has(jsKey.Uint32Value()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(jsKey.Uint32Value())));
 }
 
 Value HasPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
-  return Boolean::New(info.Env(), obj.Has(jsKey.Utf8Value()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Has(jsKey.Utf8Value())));
 }

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -96,7 +96,7 @@ Value ConstructorFromObject(const CallbackInfo& info) {
 
 Array GetPropertyNames(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  Array arr = MaybeUnwrapOr(obj.GetPropertyNames());
+  Array arr = MaybeUnwrap(obj.GetPropertyNames());
   return arr;
 }
 
@@ -256,7 +256,7 @@ Value CreateObjectUsingMagic(const CallbackInfo& info) {
 Value InstanceOf(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Function constructor = info[1].As<Function>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.InstanceOf(constructor)));
+  return Boolean::New(info.Env(), MaybeUnwrap(obj.InstanceOf(constructor)));
 }
 
 Object InitObject(Env env) {

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -95,7 +96,7 @@ Value ConstructorFromObject(const CallbackInfo& info) {
 
 Array GetPropertyNames(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  Array arr = obj.GetPropertyNames();
+  Array arr = MaybeUnwrapOr(obj.GetPropertyNames());
   return arr;
 }
 
@@ -255,7 +256,7 @@ Value CreateObjectUsingMagic(const CallbackInfo& info) {
 Value InstanceOf(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Function constructor = info[1].As<Function>();
-  return Boolean::New(info.Env(), obj.InstanceOf(constructor));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.InstanceOf(constructor)));
 }
 
 Object InitObject(Env env) {

--- a/test/object/object_freeze_seal.cc
+++ b/test/object/object_freeze_seal.cc
@@ -7,12 +7,12 @@ using namespace Napi;
 
 Value Freeze(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Freeze()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Freeze(), false));
 }
 
 Value Seal(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Seal()));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Seal(), false));
 }
 
 Object InitObjectFreezeSeal(Env env) {

--- a/test/object/object_freeze_seal.cc
+++ b/test/object/object_freeze_seal.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 #if (NAPI_VERSION > 7)
 
@@ -6,12 +7,12 @@ using namespace Napi;
 
 Value Freeze(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  return Boolean::New(info.Env(), obj.Freeze());
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Freeze()));
 }
 
 Value Seal(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  return Boolean::New(info.Env(), obj.Seal());
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Seal()));
 }
 
 Object InitObjectFreezeSeal(Env env) {

--- a/test/object/set_property.cc
+++ b/test/object/set_property.cc
@@ -8,22 +8,24 @@ Value SetPropertyWithNapiValue(const CallbackInfo& info) {
   Name key = info[1].As<Name>();
   Value value = info[2];
   return Boolean::New(
-      info.Env(), MaybeUnwrapOr(obj.Set(static_cast<napi_value>(key), value)));
+      info.Env(),
+      MaybeUnwrapOr(obj.Set(static_cast<napi_value>(key), value), false));
 }
 
 Value SetPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
   Value value = info[2];
-  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Set(key, value)));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Set(key, value), false));
 }
 
 Value SetPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
   Value value = info[2];
-  return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value().c_str(), value)));
+  return Boolean::New(
+      info.Env(),
+      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value().c_str(), value), false));
 }
 
 Value SetPropertyWithCppStyleString(const CallbackInfo& info) {
@@ -31,5 +33,5 @@ Value SetPropertyWithCppStyleString(const CallbackInfo& info) {
   String jsKey = info[1].As<String>();
   Value value = info[2];
   return Boolean::New(info.Env(),
-                      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value(), value)));
+                      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value(), value), false));
 }

--- a/test/object/set_property.cc
+++ b/test/object/set_property.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -6,26 +7,29 @@ Value SetPropertyWithNapiValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
   Value value = info[2];
-  return Boolean::New(info.Env(), obj.Set(static_cast<napi_value>(key), value));
+  return Boolean::New(
+      info.Env(), MaybeUnwrapOr(obj.Set(static_cast<napi_value>(key), value)));
 }
 
 Value SetPropertyWithNapiWrapperValue(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   Name key = info[1].As<Name>();
   Value value = info[2];
-  return Boolean::New(info.Env(), obj.Set(key, value));
+  return Boolean::New(info.Env(), MaybeUnwrapOr(obj.Set(key, value)));
 }
 
 Value SetPropertyWithCStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
   Value value = info[2];
-  return Boolean::New(info.Env(), obj.Set(jsKey.Utf8Value().c_str(), value));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value().c_str(), value)));
 }
 
 Value SetPropertyWithCppStyleString(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
   String jsKey = info[1].As<String>();
   Value value = info[2];
-  return Boolean::New(info.Env(), obj.Set(jsKey.Utf8Value(), value));
+  return Boolean::New(info.Env(),
+                      MaybeUnwrapOr(obj.Set(jsKey.Utf8Value(), value)));
 }

--- a/test/objectreference.cc
+++ b/test/objectreference.cc
@@ -98,22 +98,22 @@ Value GetFromGetter(const CallbackInfo& info) {
       return String::New(env, "No Referenced Value");
     } else {
       if (info[1].IsString()) {
-        return MaybeUnwrapOr(weak.Get(info[1].As<String>().Utf8Value()));
+        return MaybeUnwrap(weak.Get(info[1].As<String>().Utf8Value()));
       } else if (info[1].IsNumber()) {
-        return MaybeUnwrapOr(weak.Get(info[1].As<Number>().Uint32Value()));
+        return MaybeUnwrap(weak.Get(info[1].As<Number>().Uint32Value()));
       }
     }
   } else if (info[0].As<String>() == String::New(env, "persistent")) {
     if (info[1].IsString()) {
-      return MaybeUnwrapOr(persistent.Get(info[1].As<String>().Utf8Value()));
+      return MaybeUnwrap(persistent.Get(info[1].As<String>().Utf8Value()));
     } else if (info[1].IsNumber()) {
-      return MaybeUnwrapOr(persistent.Get(info[1].As<Number>().Uint32Value()));
+      return MaybeUnwrap(persistent.Get(info[1].As<Number>().Uint32Value()));
     }
   } else {
     if (info[0].IsString()) {
-      return MaybeUnwrapOr(reference.Get(info[0].As<String>().Utf8Value()));
+      return MaybeUnwrap(reference.Get(info[0].As<String>().Utf8Value()));
     } else if (info[0].IsNumber()) {
-      return MaybeUnwrapOr(reference.Get(info[0].As<Number>().Uint32Value()));
+      return MaybeUnwrap(reference.Get(info[0].As<Number>().Uint32Value()));
     }
   }
 
@@ -148,12 +148,12 @@ Value GetCastedFromGetter(const CallbackInfo& info) {
     if (casted_weak.IsEmpty()) {
       return String::New(env, "No Referenced Value");
     } else {
-      return MaybeUnwrapOr(casted_weak.Get(info[1].As<Number>()));
+      return MaybeUnwrap(casted_weak.Get(info[1].As<Number>()));
     }
   } else if (info[0].As<String>() == String::New(env, "persistent")) {
-    return MaybeUnwrapOr(casted_persistent.Get(info[1].As<Number>()));
+    return MaybeUnwrap(casted_persistent.Get(info[1].As<Number>()));
   } else {
-    return MaybeUnwrapOr(casted_reference.Get(info[1].As<Number>()));
+    return MaybeUnwrap(casted_reference.Get(info[1].As<Number>()));
   }
 }
 

--- a/test/objectreference.cc
+++ b/test/objectreference.cc
@@ -4,6 +4,7 @@ it. Subclasses of Objects can only be set using an ObjectReference
 by first casting it as an Object. */
 
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -97,22 +98,22 @@ Value GetFromGetter(const CallbackInfo& info) {
       return String::New(env, "No Referenced Value");
     } else {
       if (info[1].IsString()) {
-        return weak.Get(info[1].As<String>().Utf8Value());
+        return MaybeUnwrapOr(weak.Get(info[1].As<String>().Utf8Value()));
       } else if (info[1].IsNumber()) {
-        return weak.Get(info[1].As<Number>().Uint32Value());
+        return MaybeUnwrapOr(weak.Get(info[1].As<Number>().Uint32Value()));
       }
     }
   } else if (info[0].As<String>() == String::New(env, "persistent")) {
     if (info[1].IsString()) {
-      return persistent.Get(info[1].As<String>().Utf8Value());
+      return MaybeUnwrapOr(persistent.Get(info[1].As<String>().Utf8Value()));
     } else if (info[1].IsNumber()) {
-      return persistent.Get(info[1].As<Number>().Uint32Value());
+      return MaybeUnwrapOr(persistent.Get(info[1].As<Number>().Uint32Value()));
     }
   } else {
     if (info[0].IsString()) {
-      return reference.Get(info[0].As<String>().Utf8Value());
+      return MaybeUnwrapOr(reference.Get(info[0].As<String>().Utf8Value()));
     } else if (info[0].IsNumber()) {
-      return reference.Get(info[0].As<Number>().Uint32Value());
+      return MaybeUnwrapOr(reference.Get(info[0].As<Number>().Uint32Value()));
     }
   }
 
@@ -147,12 +148,12 @@ Value GetCastedFromGetter(const CallbackInfo& info) {
     if (casted_weak.IsEmpty()) {
       return String::New(env, "No Referenced Value");
     } else {
-      return casted_weak.Get(info[1].As<Number>());
+      return MaybeUnwrapOr(casted_weak.Get(info[1].As<Number>()));
     }
   } else if (info[0].As<String>() == String::New(env, "persistent")) {
-    return casted_persistent.Get(info[1].As<Number>());
+    return MaybeUnwrapOr(casted_persistent.Get(info[1].As<Number>()));
   } else {
-    return casted_reference.Get(info[1].As<Number>());
+    return MaybeUnwrapOr(casted_reference.Get(info[1].As<Number>()));
   }
 }
 

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -4,7 +4,7 @@
 Napi::ObjectReference testStaticContextRef;
 
 Napi::Value StaticGetter(const Napi::CallbackInfo& /*info*/) {
-  return MaybeUnwrapOr(testStaticContextRef.Value().Get("value"));
+  return MaybeUnwrap(testStaticContextRef.Value().Get("value"));
 }
 
 void StaticSetter(const Napi::CallbackInfo& /*info*/, const Napi::Value& value) {
@@ -81,7 +81,7 @@ public:
   Napi::Value Iterator(const Napi::CallbackInfo& info) {
     Napi::Array array = Napi::Array::New(info.Env());
     array.Set(array.Length(), Napi::String::From(info.Env(), value_));
-    return MaybeUnwrapOr(
+    return MaybeUnwrap(
         MaybeUnwrap(array.Get(MaybeUnwrap(
                         Napi::Symbol::WellKnown(info.Env(), "iterator"))))
             .As<Napi::Function>()

--- a/test/run_script.cc
+++ b/test/run_script.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 using namespace Napi;
 
@@ -6,39 +7,39 @@ namespace {
 
 Value RunPlainString(const CallbackInfo& info) {
   Env env = info.Env();
-  return env.RunScript("1 + 2 + 3");
+  return MaybeUnwrapOr(env.RunScript("1 + 2 + 3"));
 }
 
 Value RunStdString(const CallbackInfo& info) {
   Env env = info.Env();
   std::string str = "1 + 2 + 3";
-  return env.RunScript(str);
+  return MaybeUnwrapOr(env.RunScript(str));
 }
 
 Value RunJsString(const CallbackInfo& info) {
   Env env = info.Env();
-  return env.RunScript(info[0].As<String>());
+  return MaybeUnwrapOr(env.RunScript(info[0].As<String>()));
 }
 
 Value RunWithContext(const CallbackInfo& info) {
   Env env = info.Env();
 
-  Array keys = info[1].As<Object>().GetPropertyNames();
+  Array keys = MaybeUnwrap(info[1].As<Object>().GetPropertyNames());
   std::string code = "(";
   for (unsigned int i = 0; i < keys.Length(); i++) {
     if (i != 0) code += ",";
-    code += keys.Get(i).As<String>().Utf8Value();
+    code += MaybeUnwrap(keys.Get(i)).As<String>().Utf8Value();
   }
   code += ") => " + info[0].As<String>().Utf8Value();
 
-  Value ret = env.RunScript(code);
+  Value ret = MaybeUnwrap(env.RunScript(code));
   Function fn = ret.As<Function>();
   std::vector<napi_value> args;
   for (unsigned int i = 0; i < keys.Length(); i++) {
-    Value key = keys.Get(i);
-    args.push_back(info[1].As<Object>().Get(key));
+    Value key = MaybeUnwrap(keys.Get(i));
+    args.push_back(MaybeUnwrap(info[1].As<Object>().Get(key)));
   }
-  return fn.Call(args);
+  return MaybeUnwrapOr(fn.Call(args));
 }
 
 } // end anonymous namespace

--- a/test/run_script.cc
+++ b/test/run_script.cc
@@ -7,18 +7,18 @@ namespace {
 
 Value RunPlainString(const CallbackInfo& info) {
   Env env = info.Env();
-  return MaybeUnwrapOr(env.RunScript("1 + 2 + 3"));
+  return MaybeUnwrap(env.RunScript("1 + 2 + 3"));
 }
 
 Value RunStdString(const CallbackInfo& info) {
   Env env = info.Env();
   std::string str = "1 + 2 + 3";
-  return MaybeUnwrapOr(env.RunScript(str));
+  return MaybeUnwrap(env.RunScript(str));
 }
 
 Value RunJsString(const CallbackInfo& info) {
   Env env = info.Env();
-  return MaybeUnwrapOr(env.RunScript(info[0].As<String>()));
+  return MaybeUnwrapOr(env.RunScript(info[0].As<String>()), Value());
 }
 
 Value RunWithContext(const CallbackInfo& info) {
@@ -39,7 +39,7 @@ Value RunWithContext(const CallbackInfo& info) {
     Value key = MaybeUnwrap(keys.Get(i));
     args.push_back(MaybeUnwrap(info[1].As<Object>().Get(key)));
   }
-  return MaybeUnwrapOr(fn.Call(args));
+  return MaybeUnwrap(fn.Call(args));
 }
 
 } // end anonymous namespace

--- a/test/symbol.cc
+++ b/test/symbol.cc
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include "test_helper.h"
 using namespace Napi;
 
 Symbol CreateNewSymbolWithNoArgs(const Napi::CallbackInfo&) {
@@ -22,33 +23,34 @@ Symbol CreateNewSymbolWithNapiString(const Napi::CallbackInfo& info) {
 
 Symbol GetWellknownSymbol(const Napi::CallbackInfo& info) {
   String registrySymbol = info[0].As<String>();
-  return Napi::Symbol::WellKnown(info.Env(),
-                                 registrySymbol.Utf8Value().c_str());
+  return MaybeUnwrap(
+      Napi::Symbol::WellKnown(info.Env(), registrySymbol.Utf8Value().c_str()));
 }
 
 Symbol FetchSymbolFromGlobalRegistry(const Napi::CallbackInfo& info) {
   String registrySymbol = info[0].As<String>();
-  return Napi::Symbol::For(info.Env(), registrySymbol);
+  return MaybeUnwrap(Napi::Symbol::For(info.Env(), registrySymbol));
 }
 
 Symbol FetchSymbolFromGlobalRegistryWithCppKey(const Napi::CallbackInfo& info) {
   String cppStringKey = info[0].As<String>();
-  return Napi::Symbol::For(info.Env(), cppStringKey.Utf8Value());
+  return MaybeUnwrap(Napi::Symbol::For(info.Env(), cppStringKey.Utf8Value()));
 }
 
 Symbol FetchSymbolFromGlobalRegistryWithCKey(const Napi::CallbackInfo& info) {
   String cppStringKey = info[0].As<String>();
-  return Napi::Symbol::For(info.Env(), cppStringKey.Utf8Value().c_str());
+  return MaybeUnwrap(
+      Napi::Symbol::For(info.Env(), cppStringKey.Utf8Value().c_str()));
 }
 
 Symbol TestUndefinedSymbolsCanBeCreated(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  return Napi::Symbol::For(env, env.Undefined());
+  return MaybeUnwrap(Napi::Symbol::For(env, env.Undefined()));
 }
 
 Symbol TestNullSymbolsCanBeCreated(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  return Napi::Symbol::For(env, env.Null());
+  return MaybeUnwrap(Napi::Symbol::For(env, env.Null()));
 }
 
 Object InitSymbol(Env env) {

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
@@ -60,18 +60,13 @@ static Value TestCall(const CallbackInfo &info) {
   bool hasData = false;
   if (info.Length() > 0) {
     Object opts = info[0].As<Object>();
-    bool hasProperty = false;
-    if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
-      isBlocking = hasProperty &&
-                   MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
-    } else {
-      env.GetAndClearPendingException();
+    bool hasProperty = MaybeUnwrap(opts.Has("blocking"));
+    if (hasProperty) {
+      isBlocking = MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
     }
-    if (MaybeUnwrapTo(opts.Has("data"), &hasProperty)) {
-      hasData =
-          hasProperty && MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
-    } else {
-      env.GetAndClearPendingException();
+    hasProperty = MaybeUnwrap(opts.Has("data"));
+    if (hasProperty) {
+      hasData = MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
     }
   }
 

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
@@ -1,5 +1,6 @@
-#include "napi.h"
 #include <cstdlib>
+#include "napi.h"
+#include "test_helper.h"
 
 #if (NAPI_VERSION > 3)
 
@@ -59,11 +60,18 @@ static Value TestCall(const CallbackInfo &info) {
   bool hasData = false;
   if (info.Length() > 0) {
     Object opts = info[0].As<Object>();
-    if (opts.Has("blocking")) {
-      isBlocking = opts.Get("blocking").ToBoolean();
+    bool hasProperty = false;
+    if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
+      isBlocking = hasProperty &&
+                   MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
+    } else {
+      env.GetAndClearPendingException();
     }
-    if (opts.Has("data")) {
-      hasData = opts.Get("data").ToBoolean();
+    if (MaybeUnwrapTo(opts.Has("data"), &hasProperty)) {
+      hasData =
+          hasProperty && MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
+    } else {
+      env.GetAndClearPendingException();
     }
   }
 

--- a/test/threadsafe_function/threadsafe_function_unref.cc
+++ b/test/threadsafe_function/threadsafe_function_unref.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 #if (NAPI_VERSION > 3)
 
@@ -11,7 +12,7 @@ static Value TestUnref(const CallbackInfo& info) {
   Object global = env.Global();
   Object resource = info[0].As<Object>();
   Function cb = info[1].As<Function>();
-  Function setTimeout = global.Get("setTimeout").As<Function>();
+  Function setTimeout = MaybeUnwrap(global.Get("setTimeout")).As<Function>();
   ThreadSafeFunction* tsfn = new ThreadSafeFunction;
 
   *tsfn = ThreadSafeFunction::New(info.Env(), cb, resource, "Test", 1, 1, [tsfn](Napi::Env /* env */) {

--- a/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.cc
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include "napi.h"
+#include "test_helper.h"
 
 #if (NAPI_VERSION > 3)
 
@@ -64,11 +65,18 @@ static Value TestCall(const CallbackInfo& info) {
   bool hasData = false;
   if (info.Length() > 0) {
     Object opts = info[0].As<Object>();
-    if (opts.Has("blocking")) {
-      isBlocking = opts.Get("blocking").ToBoolean();
+    bool hasProperty = false;
+    if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
+      isBlocking = hasProperty &&
+                   MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
+    } else {
+      env.GetAndClearPendingException();
     }
-    if (opts.Has("data")) {
-      hasData = opts.Get("data").ToBoolean();
+    if (MaybeUnwrapTo(opts.Has("data"), &hasProperty)) {
+      hasData =
+          hasProperty && MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
+    } else {
+      env.GetAndClearPendingException();
     }
   }
 

--- a/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.cc
@@ -65,18 +65,13 @@ static Value TestCall(const CallbackInfo& info) {
   bool hasData = false;
   if (info.Length() > 0) {
     Object opts = info[0].As<Object>();
-    bool hasProperty = false;
-    if (MaybeUnwrapTo(opts.Has("blocking"), &hasProperty)) {
-      isBlocking = hasProperty &&
-                   MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
-    } else {
-      env.GetAndClearPendingException();
+    bool hasProperty = MaybeUnwrap(opts.Has("blocking"));
+    if (hasProperty) {
+      isBlocking = MaybeUnwrap(MaybeUnwrap(opts.Get("blocking")).ToBoolean());
     }
-    if (MaybeUnwrapTo(opts.Has("data"), &hasProperty)) {
-      hasData =
-          hasProperty && MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
-    } else {
-      env.GetAndClearPendingException();
+    hasProperty = MaybeUnwrap(opts.Has("data"));
+    if (hasProperty) {
+      hasData = MaybeUnwrap(MaybeUnwrap(opts.Get("data")).ToBoolean());
     }
   }
 

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
@@ -1,4 +1,5 @@
 #include "napi.h"
+#include "test_helper.h"
 
 #if (NAPI_VERSION > 3)
 
@@ -14,7 +15,7 @@ static Value TestUnref(const CallbackInfo& info) {
   Object global = env.Global();
   Object resource = info[0].As<Object>();
   Function cb = info[1].As<Function>();
-  Function setTimeout = global.Get("setTimeout").As<Function>();
+  Function setTimeout = MaybeUnwrap(global.Get("setTimeout")).As<Function>();
   TSFN* tsfn = new TSFN;
 
   *tsfn = TSFN::New(


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-addon-api/issues/690

This PR introduced a Maybe type to enforce value existence check when CPP exceptions disabled and there is a pending JavaScript exception so that the operation can not be performed.

The `Maybe` returning behavior requires a predefined macro `NODE_ADDON_API_ENABLE_MAYBE` to enable.

- [x] make exiting tests compatible with two flavors (with or without Maybes)