### PR TITLE
doc: added some warnings for buffer and array buffer factory method.

### DIFF
--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -29,12 +29,12 @@ The `Napi::ArrayBuffer` instance does not assume ownership for the data and
 expects it to be valid for the lifetime of the instance. Since the
 `Napi::ArrayBuffer` is subject to garbage collection this overload is only
 suitable for data which is static and never needs to be freed.
-This factory method will not provide the caller with an opportunity to free the 
-data when they get garbage-collected. If you need to free the data retained by
-the `Napi::ArrayBuffer` object please use other variants of the 
-`Napi::ArrayBuffer::New` factory method that accept `Napi::Finalizer` a 
-function that will be invoked when `Napi::ArrayBuffer` object has been 
-destroyed. 
+This factory method will not provide the caller with an opportunity to free the
+data when hen the `Napi::ArrayBuffer` gets garbage-collected. If you need to
+free the data retained by the `Napi::ArrayBuffer` object please use other
+variants of the `Napi::ArrayBuffer::New` factory method that accept
+`Napi::Finalizer`, which is a function that will be invoked when  the
+`Napi::ArrayBuffer` object has been destroyed.
 
 ```cpp
 static Napi::ArrayBuffer Napi::ArrayBuffer::New(napi_env env, void* externalData, size_t byteLength);

--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -30,10 +30,10 @@ expects it to be valid for the lifetime of the instance. Since the
 `Napi::ArrayBuffer` is subject to garbage collection this overload is only
 suitable for data which is static and never needs to be freed.
 This factory method will not provide the caller with an opportunity to free the
-data when hen the `Napi::ArrayBuffer` gets garbage-collected. If you need to
-free the data retained by the `Napi::ArrayBuffer` object please use other
+data when the `Napi::ArrayBuffer` gets garbage-collected. If you need to free
+the data retained by the `Napi::ArrayBuffer` object please use other
 variants of the `Napi::ArrayBuffer::New` factory method that accept
-`Napi::Finalizer`, which is a function that will be invoked when  the
+`Napi::Finalizer`, which is a function that will be invoked when the
 `Napi::ArrayBuffer` object has been destroyed.
 
 ```cpp

--- a/doc/array_buffer.md
+++ b/doc/array_buffer.md
@@ -29,6 +29,12 @@ The `Napi::ArrayBuffer` instance does not assume ownership for the data and
 expects it to be valid for the lifetime of the instance. Since the
 `Napi::ArrayBuffer` is subject to garbage collection this overload is only
 suitable for data which is static and never needs to be freed.
+This factory method will not provide the caller with an opportunity to free the 
+data when they get garbage-collected. If you need to free the data retained by
+the `Napi::ArrayBuffer` object please use other variants of the 
+`Napi::ArrayBuffer::New` factory method that accept `Napi::Finalizer` a 
+function that will be invoked when `Napi::ArrayBuffer` object has been 
+destroyed. 
 
 ```cpp
 static Napi::ArrayBuffer Napi::ArrayBuffer::New(napi_env env, void* externalData, size_t byteLength);

--- a/doc/buffer.md
+++ b/doc/buffer.md
@@ -27,7 +27,12 @@ Wraps the provided external data into a new `Napi::Buffer` object.
 The `Napi::Buffer` object does not assume ownership for the data and expects it to be
 valid for the lifetime of the object. Since the `Napi::Buffer` is subject to garbage
 collection this overload is only suitable for data which is static and never
-needs to be freed.
+needs to be freed. 
+This factory method will not provide the caller with an opportunity to free the 
+data when they get garbage-collected. If you need to free the data retained by the 
+`Napi::Buffer` object please use other variants of the `Napi::Buffer::New` factory 
+method that accept `Napi::Finalizer` a function that will be invoked when 
+`Napi::Buffer` object has been destroyed.
 
 ```cpp
 static Napi::Buffer<T> Napi::Buffer::New(napi_env env, T* data, size_t length);

--- a/doc/buffer.md
+++ b/doc/buffer.md
@@ -27,12 +27,13 @@ Wraps the provided external data into a new `Napi::Buffer` object.
 The `Napi::Buffer` object does not assume ownership for the data and expects it to be
 valid for the lifetime of the object. Since the `Napi::Buffer` is subject to garbage
 collection this overload is only suitable for data which is static and never
-needs to be freed. 
-This factory method will not provide the caller with an opportunity to free the 
-data when they get garbage-collected. If you need to free the data retained by the 
-`Napi::Buffer` object please use other variants of the `Napi::Buffer::New` factory 
-method that accept `Napi::Finalizer` a function that will be invoked when 
-`Napi::Buffer` object has been destroyed.
+needs to be freed.
+This factory method will not provide the caller with an opportunity to free the
+data when the `Napi::Buffer` gets garbage-collected. If you need to free the
+data retained by the `Napi::Buffer` object please use other variants of the
+`Napi::Buffer::New` factory method that accept `Napi::Finalizer`, which is a
+function that will be invoked when the `Napi::Buffer` object has been
+destroyed.
 
 ```cpp
 static Napi::Buffer<T> Napi::Buffer::New(napi_env env, T* data, size_t length);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-addon-api/issues/258
This PR add some warnings on documentation for:
```cpp 
static Napi::Buffer<T> Napi::Buffer::New(napi_env env, T* data, size_t length);
static Napi::ArrayBuffer Napi::ArrayBuffer::New(napi_env env, void* externalData, size_t byteLength);
```
