### PR TITLE
doc: sync Object::Set value arg with Value::From

### DIFF
--- a/doc/object.md
+++ b/doc/object.md
@@ -86,13 +86,7 @@ The key can be any of the following types:
 - `const std::string&`
 - `uint32_t`
 
-While the value must be any of the following types:
-- `napi_value`
-- [`Napi::Value`](value.md)
-- `const char*`
-- `std::string&`
-- `bool`
-- `double`
+The `value` can be of any type that is accepted by [`Napi::Value::From`][].
 
 ### Delete()
 
@@ -271,3 +265,4 @@ Napi::Value Napi::Object::operator[] (uint32_t index) const;
 Returns an indexed property or array element as a [`Napi::Value`](value.md).
 
 [`Napi::Value`]: ./value.md
+[`Napi::Value::From`]: ./value.md#from


### PR DESCRIPTION
The list of types that are valid for the `value` argument of `Napi::Object::Set` is inaccurate. Instead of trying to maintain it, let's just add a reference to `Napi::Value::From` since any argument to `Napi::Object::Set` is passed to `Napi::Value::From` anyway.