### PR TITLE
chore: fixup linter commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,8 +344,8 @@
     "predev:incremental": "node-gyp configure build -C test --debug",
     "dev:incremental": "node test",
     "doc": "doxygen doc/Doxyfile",
-    "lint": "node tools/clang-format.js",
-    "lint:fix": "git-clang-format '*.h', '*.cc'"
+    "lint": "node tools/clang-format",
+    "lint:fix": "node tools/clang-format --fix"
   },
   "pre-commit": "lint",
   "version": "3.1.0",

--- a/tools/clang-format.js
+++ b/tools/clang-format.js
@@ -7,17 +7,31 @@ const filesToCheck = ['*.h', '*.cc'];
 const CLANG_FORMAT_START = process.env.CLANG_FORMAT_START || 'main';
 
 function main(args) {
+  let fix = false;
+  while (args.length > 0) {
+    switch (args[0]) {
+      case '-f':
+      case '--fix':
+        fix = true;
+      default:
+    }
+    args.shift();
+  }
+
   let clangFormatPath = path.dirname(require.resolve('clang-format'));
   const options = ['--binary=node_modules/.bin/clang-format', '--style=file'];
+  if (fix) {
+    options.push(CLANG_FORMAT_START);
+  } else {
+    options.push('--diff', CLANG_FORMAT_START);
+  }
 
   const gitClangFormatPath = path.join(clangFormatPath,
     'bin/git-clang-format');
   const result = spawn('python', [
     gitClangFormatPath,
     ...options,
-    '--diff',
-    CLANG_FORMAT_START,
-    'HEAD',
+    '--',
     ...filesToCheck
   ], { encoding: 'utf-8' });
 
@@ -27,13 +41,19 @@ function main(args) {
   }
 
   const clangFormatOutput = result.stdout.trim();
+  // Bail fast if in fix mode.
+  if (fix) {
+    console.log(clangFormatOutput);
+    return 0;
+  }
+  // Detect if there is any complains from clang-format
   if (clangFormatOutput !== '' &&
       clangFormatOutput !== ('no modified files to format') &&
       clangFormatOutput !== ('clang-format did not modify any files')) {
     console.error(clangFormatOutput);
-    const fixCmd = '"npm run lint:fix"';
+    const fixCmd = 'npm run lint:fix';
     console.error(`
-      ERROR: please run ${fixCmd} to format changes in your commit
+      ERROR: please run "${fixCmd}" to format changes in your commit
         Note that when running the command locally, please keep your local
         main branch and working branch up to date with nodejs/node-addon-api
         to exclude un-related complains.


### PR DESCRIPTION
This PR fixes following issues:
1. `tools/clang-format` suggested an incorrect format (redundant quotes) of fix command;
2. `npm run lint` and `npm run lint:fix` run the clang-format on a different set of changes: `tools/clang-format` (`npm run lint`) compares between two commits, while `git-clang-format` without commits argument (`npm run lint:fix`) compares workspace changes with `HEAD`. This makes pre-commit hooks hard to predict in various conditions.

Refs: https://github.com/nodejs/node-addon-api/pull/938#issuecomment-802161908