### PR TITLE
doc: unambiguously mark deprecated signatures

### DIFF
--- a/doc/property_descriptor.md
+++ b/doc/property_descriptor.md
@@ -138,7 +138,7 @@ The name of the property can be any of the following types:
 - `napi_value value`
 - `Napi::Name`
 
-**This signature is deprecated. It will result in a memory leak if used.**
+**The above signature is deprecated. It will result in a memory leak if used.**
 
 ```cpp
 static Napi::PropertyDescriptor Napi::PropertyDescriptor::Accessor (
@@ -186,7 +186,7 @@ The name of the property can be any of the following types:
 - `napi_value value`
 - `Napi::Name`
 
-**This signature is deprecated. It will result in a memory leak if used.**
+**The above signature is deprecated. It will result in a memory leak if used.**
 
 ```cpp
 static Napi::PropertyDescriptor Napi::PropertyDescriptor::Accessor (
@@ -236,7 +236,7 @@ The name of the property can be any of the following types:
 - `napi_value value`
 - `Napi::Name`
 
-**This signature is deprecated. It will result in a memory leak if used.**
+**The above signature is deprecated. It will result in a memory leak if used.**
 
 ```cpp
 static Napi::PropertyDescriptor Napi::PropertyDescriptor::Function (


### PR DESCRIPTION
Currently, deprecation notices are always right between two function signatures and it's virtually impossible to be certain whether they refer to the previous signature or the next signature:

```
`void foo()`

This signature is deprecated.

`void bar()`
```

It would be great if someone could confirm that it is indeed always the *above* signature that's deprecated.