### PR TITLE
doc: rename N-API with Node-API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ contribute to **node-addon-api**:
 - Source code fixes
 - Additional tests
 - Documentation improvements
-- Joining the N-API working group and participating in meetings
+- Joining the Node-API working group and participating in meetings
 
 ## Source changes
 
-**node-addon-api** is meant to be a thin convenience wrapper around N-API. With this
-in mind, contributions of any new APIs that wrap around a core N-API API will
+**node-addon-api** is meant to be a thin convenience wrapper around Node-API. With this
+in mind, contributions of any new APIs that wrap around a core Node-API API will
 be considered for merge. However, changes that wrap existing **node-addon-api**
 APIs are encouraged to instead be provided as an ecosystem module. The
 **node-addon-api** team is happy to link to a curated set of modules that build on
@@ -19,7 +19,7 @@ a recommended idiom or pattern.
 
 ### Rationale
 
-The N-API team considered a couple different approaches with regards to changes
+The Node-API team considered a couple different approaches with regards to changes
 extending **node-addon-api**
 - Larger core module - Incorporate these helpers and patterns into **node-addon-api**
 - Extras package - Create a new package (strawman name '**node-addon-api**-extras')
@@ -35,7 +35,7 @@ encourage folks to make PRs for utility helpers against the same repository.
 
 The downside of the approach is the following:
 - Less coherency for our API set
-- More maintenance burden on the N-API WG core team.
+- More maintenance burden on the Node-API WG core team.
 
 #### Extras Package
 This involves us spinning up a new package which contains the utility classes
@@ -48,10 +48,10 @@ The downside of this approach is the following:
 community understand where a particular contribution should be directed to (what
 belongs in **node-addon-api** vs **node-addon-api-extras**)
 - Need to define the level of support/API guarantees
-- Unclear if the maintenance burden on the N-API WG is reduced or not
+- Unclear if the maintenance burden on the Node-API WG is reduced or not
 
 #### Ecosystem
-This doesn't require a ton of up-front work from the N-API WG. Instead of
+This doesn't require a ton of up-front work from the Node-API WG. Instead of
 accepting utility PRs into **node-addon-api** or creating and maintaining a new
 module, the WG will encourage the creation of an ecosystem of modules that
 build on top of **node-addon-api**, and provide some level of advertising for these
@@ -61,6 +61,6 @@ etc).
 The downside of this approach is the following:
 - Potential for lack of visibility - evangelism and education is hard, and module
 authors might not find right patterns and instead implement things themselves
-- There might be greater friction for the N-API WG in evolving APIs since the
+- There might be greater friction for the Node-API WG in evolving APIs since the
 ecosystem would have taken dependencies on the API shape of **node-addon-api**
 

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ git branch -u origin/main main
 
 # **node-addon-api module**
 This module contains **header-only C++ wrapper classes** which simplify
-the use of the C based [N-API](https://nodejs.org/dist/latest/docs/api/n-api.html)
+the use of the C based [Node-API](https://nodejs.org/dist/latest/docs/api/n-api.html)
 provided by Node.js when using C++. It provides a C++ object model
 and exception handling semantics with low overhead.
 
-There are three options for implementing addons: N-API, nan, or direct
+There are three options for implementing addons: Node-API, nan, or direct
 use of internal V8, libuv and Node.js libraries. Unless there is a need for
-direct access to functionality which is not exposed by N-API as outlined
+direct access to functionality which is not exposed by Node-API as outlined
 in [C/C++ addons](https://nodejs.org/dist/latest/docs/api/addons.html)
-in Node.js core, use N-API. Refer to
-[C/C++ addons with N-API](https://nodejs.org/dist/latest/docs/api/n-api.html)
-for more information on N-API.
+in Node.js core, use Node-API. Refer to
+[C/C++ addons with Node-API](https://nodejs.org/dist/latest/docs/api/n-api.html)
+for more information on Node-API.
 
-N-API is an ABI stable C interface provided by Node.js for building native
+Node-API is an ABI stable C interface provided by Node.js for building native
 addons. It is independent from the underlying JavaScript runtime (e.g. V8 or ChakraCore)
 and is maintained as part of Node.js itself. It is intended to insulate
 native addons from changes in the underlying JavaScript engine and allow
@@ -31,24 +31,24 @@ modules compiled for one version to run on later versions of Node.js without
 recompilation.
 
 The `node-addon-api` module, which is not part of Node.js, preserves the benefits
-of the N-API as it consists only of inline code that depends only on the stable API
-provided by N-API. As such, modules built against one version of Node.js
+of the Node-API as it consists only of inline code that depends only on the stable API
+provided by Node-API. As such, modules built against one version of Node.js
 using node-addon-api should run without having to be rebuilt with newer versions
 of Node.js.
 
 It is important to remember that *other* Node.js interfaces such as
 `libuv` (included in a project via `#include <uv.h>`) are not ABI-stable across
-Node.js major versions. Thus, an addon must use N-API and/or `node-addon-api`
+Node.js major versions. Thus, an addon must use Node-API and/or `node-addon-api`
 exclusively and build against a version of Node.js that includes an
-implementation of N-API (meaning an active LTS version of Node.js) in
+implementation of Node-API (meaning an active LTS version of Node.js) in
 order to benefit from ABI stability across Node.js major versions. Node.js
 provides an [ABI stability guide][] containing a detailed explanation of ABI
-stability in general, and the N-API ABI stability guarantee in particular.
+stability in general, and the Node-API ABI stability guarantee in particular.
 
-As new APIs are added to N-API, node-addon-api must be updated to provide
+As new APIs are added to Node-API, node-addon-api must be updated to provide
 wrappers for those new APIs. For this reason node-addon-api provides
-methods that allow callers to obtain the underlying N-API handles so
-direct calls to N-API and the use of the objects/methods provided by
+methods that allow callers to obtain the underlying Node-API handles so
+direct calls to Node-API and the use of the objects/methods provided by
 node-addon-api can be used together. For example, in order to be able
 to use an API for which the node-addon-api does not yet provide a wrapper.
 
@@ -56,8 +56,8 @@ APIs exposed by node-addon-api are generally used to create and
 manipulate JavaScript values. Concepts and operations generally map
 to ideas specified in the **ECMA262 Language Specification**.
 
-The [N-API Resource](https://nodejs.github.io/node-addon-examples/) offers an
-excellent orientation and tips for developers just getting started with N-API
+The [Node-API Resource](https://nodejs.github.io/node-addon-examples/) offers an
+excellent orientation and tips for developers just getting started with Node-API
 and node-addon-api.
 
 - **[Setup](#setup)**
@@ -78,8 +78,8 @@ and node-addon-api.
 
 <a name="setup"></a>
 
-node-addon-api is based on [N-API](https://nodejs.org/api/n-api.html) and supports using different N-API versions.
-This allows addons built with it to run with Node.js versions which support the targeted N-API version.
+node-addon-api is based on [Node-API](https://nodejs.org/api/n-api.html) and supports using different Node-API versions.
+This allows addons built with it to run with Node.js versions which support the targeted Node-API version.
 **However** the node-addon-api support model is to support only the active LTS Node.js versions. This means that
 every year there will be a new major which drops support for the Node.js LTS version which has gone out of service.
 
@@ -178,14 +178,14 @@ npm install
 npm test --disable-deprecated
 ```
 
-To run the tests targeting a specific version of N-API run
+To run the tests targeting a specific version of Node-API run
 ```
 npm install
 export NAPI_VERSION=X
 npm test --NAPI_VERSION=X
 ```
 
-where X is the version of N-API you want to target.
+where X is the version of Node-API you want to target.
 
 ### **Debug**
 
@@ -217,11 +217,11 @@ See [benchmark/README.md](benchmark/README.md) for more details about running an
 
 ### **More resource and info about native Addons**
 - **[C++ Addons](https://nodejs.org/dist/latest/docs/api/addons.html)**
-- **[N-API](https://nodejs.org/dist/latest/docs/api/n-api.html)**
-- **[N-API - Next Generation Node API for Native Modules](https://youtu.be/-Oniup60Afs)**
-- **[How We Migrated Realm JavaScript From NAN to N-API](https://developer.mongodb.com/article/realm-javascript-nan-to-n-api)**
+- **[Node-API](https://nodejs.org/dist/latest/docs/api/n-api.html)**
+- **[Node-API - Next Generation Node API for Native Modules](https://youtu.be/-Oniup60Afs)**
+- **[How We Migrated Realm JavaScript From NAN to Node-API](https://developer.mongodb.com/article/realm-javascript-nan-to-n-api)**
 
-As node-addon-api's core mission is to expose the plain C N-API as C++
+As node-addon-api's core mission is to expose the plain C Node-API as C++
 wrappers, tools that facilitate n-api/node-addon-api providing more
 convenient patterns on developing a Node.js add-ons with n-api/node-addon-api
 can be published to NPM as standalone packages. It is also recommended to tag
@@ -233,19 +233,19 @@ Quick links to NPM searches: [keywords:node-addon-api](https://www.npmjs.com/sea
 
 ### **Badges**
 
-The use of badges is recommended to indicate the minimum version of N-API
+The use of badges is recommended to indicate the minimum version of Node-API
 required for the module. This helps to determine which Node.js major versions are
-supported. Addon maintainers can consult the [N-API support matrix][] to determine
-which Node.js versions provide a given N-API version. The following badges are
+supported. Addon maintainers can consult the [Node-API support matrix][] to determine
+which Node.js versions provide a given Node-API version. The following badges are
 available:
 
-![N-API v1 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v1%20Badge.svg)
-![N-API v2 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v2%20Badge.svg)
-![N-API v3 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v3%20Badge.svg)
-![N-API v4 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v4%20Badge.svg)
-![N-API v5 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v5%20Badge.svg)
-![N-API v6 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20v6%20Badge.svg)
-![N-API Experimental Version Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/N-API%20Experimental%20Version%20Badge.svg)
+![Node-API v1 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v1%20Badge.svg)
+![Node-API v2 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v2%20Badge.svg)
+![Node-API v3 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v3%20Badge.svg)
+![Node-API v4 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v4%20Badge.svg)
+![Node-API v5 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v5%20Badge.svg)
+![Node-API v6 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v6%20Badge.svg)
+![Node-API Experimental Version Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20Experimental%20Version%20Badge.svg)
 
 ## **Contributing**
 
@@ -282,4 +282,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on our philosophy around
 Licensed under [MIT](./LICENSE.md)
 
 [ABI stability guide]: https://nodejs.org/en/docs/guides/abi-stability/
-[N-API support matrix]: https://nodejs.org/dist/latest/docs/api/n-api.html#n_api_n_api_version_matrix
+[Node-API support matrix]: https://nodejs.org/dist/latest/docs/api/n-api.html#n_api_n_api_version_matrix

--- a/doc/async_context.md
+++ b/doc/async_context.md
@@ -61,8 +61,8 @@ Returns the `Napi::Env` environment in which the async context has been created.
 Napi::AsyncContext::operator napi_async_context() const;
 ```
 
-Returns the N-API `napi_async_context` wrapped by the `Napi::AsyncContext`
-object. This can be used to mix usage of the C N-API and node-addon-api.
+Returns the Node-API `napi_async_context` wrapped by the `Napi::AsyncContext`
+object. This can be used to mix usage of the C Node-API and node-addon-api.
 
 ## Example
 

--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -343,7 +343,7 @@ virtual Napi::AsyncWorker::~AsyncWorker();
 Napi::AsyncWorker::operator napi_async_work() const;
 ```
 
-Returns the Node-API napi_async_work wrapped by the `Napi::AsyncWorker` object. This
+Returns the Node-API `napi_async_work` wrapped by the `Napi::AsyncWorker` object. This
 can be used to mix usage of the C Node-API and node-addon-api.
 
 ## Example

--- a/doc/async_worker.md
+++ b/doc/async_worker.md
@@ -343,8 +343,8 @@ virtual Napi::AsyncWorker::~AsyncWorker();
 Napi::AsyncWorker::operator napi_async_work() const;
 ```
 
-Returns the N-API napi_async_work wrapped by the `Napi::AsyncWorker` object. This
-can be used to mix usage of the C N-API and node-addon-api.
+Returns the Node-API napi_async_work wrapped by the `Napi::AsyncWorker` object. This
+can be used to mix usage of the C Node-API and node-addon-api.
 
 ## Example
 

--- a/doc/callback_scope.md
+++ b/doc/callback_scope.md
@@ -2,7 +2,7 @@
 
 There are cases (for example, resolving promises) where it is necessary to have
 the equivalent of the scope associated with a callback in place when making
-certain N-API calls.
+certain Node-API calls.
 
 ## Methods
 
@@ -50,5 +50,5 @@ Returns the `Napi::Env` associated with the `Napi::CallbackScope`.
 Napi::CallbackScope::operator napi_callback_scope() const;
 ```
 
-Returns the N-API `napi_callback_scope` wrapped by the `Napi::CallbackScope`
-object. This can be used to mix usage of the C N-API and node-addon-api.
+Returns the Node-API `napi_callback_scope` wrapped by the `Napi::CallbackScope`
+object. This can be used to mix usage of the C Node-API and node-addon-api.

--- a/doc/checker-tool.md
+++ b/doc/checker-tool.md
@@ -2,7 +2,7 @@
 
 **node-addon-api** provides a [checker tool][] that will inspect a given
 directory tree, identifying all Node.js native addons therein, and further
-indicating for each addon whether it is an N-API addon.
+indicating for each addon whether it is an Node-API addon.
 
 ## To use the checker tool:
 

--- a/doc/class_property_descriptor.md
+++ b/doc/class_property_descriptor.md
@@ -108,10 +108,10 @@ inside the `Napi::ObjectWrap<T>` class.
 operator napi_property_descriptor&() { return _desc; }
 ```
 
-Returns the original N-API `napi_property_descriptor` wrapped inside the `Napi::ClassPropertyDescriptor`
+Returns the original Node-API `napi_property_descriptor` wrapped inside the `Napi::ClassPropertyDescriptor`
 
 ```cpp
 operator const napi_property_descriptor&() const { return _desc; }
 ```
 
-Returns the original N-API `napi_property_descriptor` wrapped inside the `Napi::ClassPropertyDescriptor`
+Returns the original Node-API `napi_property_descriptor` wrapped inside the `Napi::ClassPropertyDescriptor`

--- a/doc/cmake-js.md
+++ b/doc/cmake-js.md
@@ -27,19 +27,19 @@ Your project will require a `CMakeLists.txt` file. The [CMake.js README file](ht
 
 ### NAPI_VERSION
 
-When building N-API addons, it's crucial to specify the N-API version your code is designed to work with. With CMake.js, this information is specified in the `CMakeLists.txt` file:
+When building Node-API addons, it's crucial to specify the Node-API version your code is designed to work with. With CMake.js, this information is specified in the `CMakeLists.txt` file:
 
 ```
 add_definitions(-DNAPI_VERSION=3)
 ```
 
-Since N-API is ABI-stable, your N-API addon will work, without recompilation, with the N-API version you specify in `NAPI_VERSION` and all subsequent N-API versions.
+Since Node-API is ABI-stable, your Node-API addon will work, without recompilation, with the Node-API version you specify in `NAPI_VERSION` and all subsequent Node-API versions.
 
-In the absence of a need for features available only in a specific N-API version, version 3 is a good choice as it is the version of N-API that was active when N-API left experimental status.
+In the absence of a need for features available only in a specific Node-API version, version 3 is a good choice as it is the version of Node-API that was active when Node-API left experimental status.
 
 ### NAPI_EXPERIMENTAL
 
-The following line in the `CMakeLists.txt` file will enable N-API experimental features if your code requires them:
+The following line in the `CMakeLists.txt` file will enable Node-API experimental features if your code requires them:
 
 ```
 add_definitions(-DNAPI_EXPERIMENTAL)
@@ -47,17 +47,17 @@ add_definitions(-DNAPI_EXPERIMENTAL)
 
 ### node-addon-api
 
-If your N-API native add-on uses the optional [**node-addon-api**](https://github.com/nodejs/node-addon-api#node-addon-api-module) C++ wrapper, the `CMakeLists.txt` file requires additional configuration information as described on the [CMake.js README file](https://github.com/cmake-js/cmake-js#n-api-and-node-addon-api).
+If your Node-API native add-on uses the optional [**node-addon-api**](https://github.com/nodejs/node-addon-api#node-addon-api-module) C++ wrapper, the `CMakeLists.txt` file requires additional configuration information as described on the [CMake.js README file](https://github.com/cmake-js/cmake-js#n-api-and-node-addon-api).
 
 ## Example
 
-A working example of an N-API native addon built using CMake.js can be found on the [node-addon-examples repository](https://github.com/nodejs/node-addon-examples/tree/HEAD/build_with_cmake#building-n-api-addons-using-cmakejs).
+A working example of an Node-API native addon built using CMake.js can be found on the [node-addon-examples repository](https://github.com/nodejs/node-addon-examples/tree/HEAD/build_with_cmake#building-n-api-addons-using-cmakejs).
 
 ## **CMake** Reference
 
   - [Installation](https://github.com/cmake-js/cmake-js#installation)
   - [How to use](https://github.com/cmake-js/cmake-js#usage)
-  - [Using N-API and node-addon-api](https://github.com/cmake-js/cmake-js#n-api-and-node-addon-api)
+  - [Using Node-API and node-addon-api](https://github.com/cmake-js/cmake-js#n-api-and-node-addon-api)
   - [Tutorials](https://github.com/cmake-js/cmake-js#tutorials)
   - [Use case in the works - ArrayFire.js](https://github.com/cmake-js/cmake-js#use-case-in-the-works---arrayfirejs)
 

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -41,8 +41,8 @@ exception, then node-addon-api automatically converts and throws it as a C++
 exception of type `Napi:Error` on return from the JavaScript code to the native
 method.
 
-If a C++ exception of type `Napi::Error` escapes from a N-API C++ callback, then
-the N-API wrapper automatically converts and throws it as a JavaScript exception.
+If a C++ exception of type `Napi::Error` escapes from a Node-API C++ callback, then
+the Node-API wrapper automatically converts and throws it as a JavaScript exception.
 
 On return from a native method, node-addon-api will automatically convert a pending C++
 exception to a JavaScript exception.
@@ -67,7 +67,7 @@ will bubble up as a C++ exception of type `Napi::Error`, until it is either caug
 while still in C++, or else automatically propagated as a JavaScript exception
 when returning to JavaScript.
 
-### Propagating a N-API C++ exception
+### Propagating a Node-API C++ exception
 
 ```cpp
 Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
@@ -81,7 +81,7 @@ executed. The exception will bubble up as a C++ exception of type `Napi::Error`,
 until it is either caught while still in C++, or else automatically propagated as
 a JavaScript exception when returning to JavaScript.
 
-### Handling a N-API C++ exception
+### Handling a Node-API C++ exception
 
 ```cpp
 Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
@@ -123,7 +123,7 @@ return;
 After throwing a JavaScript exception, the code should generally return
 immediately from the native callback, after performing any necessary cleanup.
 
-### Propagating a N-API JS exception
+### Propagating a Node-API JS exception
 
 ```cpp
 Napi::Env env = ...
@@ -139,7 +139,7 @@ If env.IsExceptionPending() returns true a JavaScript exception is pending. To
 let the exception propagate, the code should generally return immediately from
 the native callback, after performing any necessary cleanup.
 
-### Handling a N-API JS exception
+### Handling a Node-API JS exception
 
 ```cpp
 Napi::Env env = ...
@@ -154,10 +154,10 @@ if (env.IsExceptionPending()) {
 Since the exception was cleared here, it will not be propagated as a JavaScript
 exception after the native callback returns.
 
-## Calling N-API directly from a **node-addon-api** addon
+## Calling Node-API directly from a **node-addon-api** addon
 
 **node-addon-api** provides macros for throwing errors in response to non-OK
-`napi_status` results when calling [N-API](https://nodejs.org/docs/latest/api/n-api.html)
+`napi_status` results when calling [Node-API](https://nodejs.org/docs/latest/api/n-api.html)
 functions from within a native addon. These macros are defined differently
 depending on whether C++ exceptions are enabled or not, but are available for
 use in either case.

--- a/doc/escapable_handle_scope.md
+++ b/doc/escapable_handle_scope.md
@@ -40,7 +40,7 @@ Napi::EscapableHandleScope Napi::EscapableHandleScope::New(napi_env env, napi_ha
 
 Returns a new `Napi::EscapableHandleScope` instance which wraps the
 napi_escapable_handle_scope handle passed in. This can be used
-to mix usage of the C N-API and node-addon-api.
+to mix usage of the C Node-API and node-addon-api.
 
 operator EscapableHandleScope::napi_escapable_handle_scope
 
@@ -48,8 +48,8 @@ operator EscapableHandleScope::napi_escapable_handle_scope
 operator Napi::EscapableHandleScope::napi_escapable_handle_scope() const
 ```
 
-Returns the N-API napi_escapable_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
-This can be used to mix usage of the C N-API and node-addon-api by allowing
+Returns the Node-API napi_escapable_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
+This can be used to mix usage of the C Node-API and node-addon-api by allowing
 the class to be used be converted to a napi_escapable_handle_scope.
 
 ### Destructor

--- a/doc/escapable_handle_scope.md
+++ b/doc/escapable_handle_scope.md
@@ -35,11 +35,11 @@ Creates a new escapable handle scope.
 Napi::EscapableHandleScope Napi::EscapableHandleScope::New(napi_env env, napi_handle_scope scope);
 ```
 
-- `[in] env`: napi_env in which the scope passed in was created.
-- `[in] scope`: pre-existing napi_handle_scope.
+- `[in] env`: `napi_env` in which the scope passed in was created.
+- `[in] scope`: pre-existing `napi_handle_scope`.
 
 Returns a new `Napi::EscapableHandleScope` instance which wraps the
-napi_escapable_handle_scope handle passed in. This can be used
+`napi_escapable_handle_scope` handle passed in. This can be used
 to mix usage of the C Node-API and node-addon-api.
 
 operator EscapableHandleScope::napi_escapable_handle_scope
@@ -48,9 +48,9 @@ operator EscapableHandleScope::napi_escapable_handle_scope
 operator Napi::EscapableHandleScope::napi_escapable_handle_scope() const
 ```
 
-Returns the Node-API napi_escapable_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
+Returns the Node-API `napi_escapable_handle_scope` wrapped by the `Napi::EscapableHandleScope` object.
 This can be used to mix usage of the C Node-API and node-addon-api by allowing
-the class to be used be converted to a napi_escapable_handle_scope.
+the class to be used be converted to a `napi_escapable_handle_scope`.
 
 ### Destructor
 ```cpp
@@ -67,7 +67,7 @@ guarantee as to when the garbage collector will do this.
 napi::Value Napi::EscapableHandleScope::Escape(napi_value escapee);
 ```
 
-- `[in] escapee`: Napi::Value or napi_env to promote to the outer scope
+- `[in] escapee`: `Napi::Value` or `napi_env` to promote to the outer scope
 
 Returns `Napi::Value` which can be used in the outer scope. This method can
 be called at most once on a given `Napi::EscapableHandleScope`. If it is called

--- a/doc/escapable_handle_scope.md
+++ b/doc/escapable_handle_scope.md
@@ -42,8 +42,6 @@ Returns a new `Napi::EscapableHandleScope` instance which wraps the
 `napi_escapable_handle_scope` handle passed in. This can be used
 to mix usage of the C Node-API and node-addon-api.
 
-operator EscapableHandleScope::napi_escapable_handle_scope
-
 ```cpp
 operator Napi::EscapableHandleScope::napi_escapable_handle_scope() const
 ```

--- a/doc/function_reference.md
+++ b/doc/function_reference.md
@@ -60,7 +60,7 @@ Napi::FunctionReference::FunctionReference(napi_env env, napi_ref ref);
 ```
 
 - `[in] env`: The environment in which to construct the `Napi::FunctionReference` object.
-- `[in] ref`: The N-API reference to be held by the `Napi::FunctionReference`.
+- `[in] ref`: The Node-API reference to be held by the `Napi::FunctionReference`.
 
 Returns a newly created `Napi::FunctionReference` object.
 

--- a/doc/generator.md
+++ b/doc/generator.md
@@ -3,8 +3,8 @@
 ## What is generator
 
 **[generator-napi-module](https://www.npmjs.com/package/generator-napi-module)** is a module to quickly generate a skeleton module using
-**N-API**, the new API for Native addons. This module automatically sets up your
-**gyp file** to use **node-addon-api**, the C++ wrappers for N-API and generates
+**Node-API**, the new API for Native addons. This module automatically sets up your
+**gyp file** to use **node-addon-api**, the C++ wrappers for Node-API and generates
 a wrapper JS module. Optionally, it can even configure the generated project to
 use **TypeScript** instead.
 

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -37,8 +37,6 @@ Returns a new `Napi::HandleScope` instance which wraps the `napi_handle_scope`
 handle passed in.  This can be used to mix usage of the C Node-API
 and node-addon-api.
 
-operator HandleScope::napi_handle_scope
-
 ```cpp
 operator Napi::HandleScope::napi_handle_scope() const
 ```

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -34,7 +34,7 @@ Napi::HandleScope::HandleScope(Napi::Env env, Napi::HandleScope scope);
 - `[in] scope`: pre-existing `Napi::HandleScope`.
 
 Returns a new `Napi::HandleScope` instance which wraps the napi_handle_scope
-handle passed in.  This can be used to mix usage of the C N-API
+handle passed in.  This can be used to mix usage of the C Node-API
 and node-addon-api.
 
 operator HandleScope::napi_handle_scope
@@ -43,8 +43,8 @@ operator HandleScope::napi_handle_scope
 operator Napi::HandleScope::napi_handle_scope() const
 ```
 
-Returns the N-API napi_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
-This can be used to mix usage of the C N-API and node-addon-api by allowing
+Returns the Node-API napi_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
+This can be used to mix usage of the C Node-API and node-addon-api by allowing
 the class to be used be converted to a napi_handle_scope.
 
 ### Destructor

--- a/doc/handle_scope.md
+++ b/doc/handle_scope.md
@@ -33,7 +33,7 @@ Napi::HandleScope::HandleScope(Napi::Env env, Napi::HandleScope scope);
 - `[in] env`: `Napi::Env` in which the scope passed in was created.
 - `[in] scope`: pre-existing `Napi::HandleScope`.
 
-Returns a new `Napi::HandleScope` instance which wraps the napi_handle_scope
+Returns a new `Napi::HandleScope` instance which wraps the `napi_handle_scope`
 handle passed in.  This can be used to mix usage of the C Node-API
 and node-addon-api.
 
@@ -43,9 +43,9 @@ operator HandleScope::napi_handle_scope
 operator Napi::HandleScope::napi_handle_scope() const
 ```
 
-Returns the Node-API napi_handle_scope wrapped by the `Napi::EscapableHandleScope` object.
+Returns the Node-API `napi_handle_scope` wrapped by the `Napi::EscapableHandleScope` object.
 This can be used to mix usage of the C Node-API and node-addon-api by allowing
-the class to be used be converted to a napi_handle_scope.
+the class to be used be converted to a `napi_handle_scope`.
 
 ### Destructor
 ```cpp

--- a/doc/object_reference.md
+++ b/doc/object_reference.md
@@ -75,7 +75,7 @@ Napi::ObjectReference::ObjectReference(napi_env env, napi_value value);
 
 * `[in] env`: The `napi_env` environment in which to construct the `Napi::ObjectReference` object.
 
-* `[in] value`: The N-API primitive value to be held by the `Napi::ObjectReference`.
+* `[in] value`: The Node-API primitive value to be held by the `Napi::ObjectReference`.
 
 Returns the newly created reference.
 

--- a/doc/prebuild_tools.md
+++ b/doc/prebuild_tools.md
@@ -9,7 +9,7 @@ possible to distribute the native add-on in pre-built form for different platfor
 and architectures. The prebuild tools help to create and distribute the pre-built
 form of a native add-on.
 
-The following list report known tools that are compatible with **N-API**:
+The following list report known tools that are compatible with **Node-API**:
 
 - **[node-pre-gyp](https://www.npmjs.com/package/node-pre-gyp)**
 - **[prebuild](https://www.npmjs.com/package/prebuild)**

--- a/doc/promises.md
+++ b/doc/promises.md
@@ -63,7 +63,7 @@ void Napi::Promise::Deferred::Resolve(napi_value value) const;
 
 Resolves the `Napi::Promise` object held by the `Napi::Promise::Deferred` object.
 
-* `[in] value`: The N-API primitive value with which to resolve the `Napi::Promise`.
+* `[in] value`: The Node-API primitive value with which to resolve the `Napi::Promise`.
 
 ### Reject
 
@@ -73,7 +73,7 @@ void Napi::Promise::Deferred::Reject(napi_value value) const;
 
 Rejects the Promise object held by the `Napi::Promise::Deferred` object.
 
-* `[in] value`: The N-API primitive value with which to reject the `Napi::Promise`.
+* `[in] value`: The Node-API primitive value with which to reject the `Napi::Promise`.
 
 
 [`Napi::Object`]: ./object.md

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -40,7 +40,7 @@ Napi::Reference::Reference(napi_env env, napi_value value);
 
 * `[in] env`: The `napi_env` environment in which to construct the `Napi::Reference` object.
 
-* `[in] value`: The N-API primitive value to be held by the `Napi::Reference`.
+* `[in] value`: The Node-API primitive value to be held by the `Napi::Reference`.
 
 ### Env
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Before starting to use **N-API** you need to assure you have the following
+Before starting to use **Node-API** you need to assure you have the following
 prerequisites:
 
 * **Node.JS** see: [Installing Node.js](https://nodejs.org/)
@@ -13,7 +13,7 @@ prerequisites:
 
 ## Installation and usage
 
-To use **N-API** in a native module:
+To use **Node-API** in a native module:
 
   1. Add a dependency on this package to `package.json`:
 
@@ -29,9 +29,9 @@ To use **N-API** in a native module:
   'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
 ```
 
-  3. Decide whether the package will enable C++ exceptions in the N-API wrapper.
+  3. Decide whether the package will enable C++ exceptions in the Node-API wrapper.
      The base ABI-stable C APIs do not throw or handle C++ exceptions, but the
-     N-API C++ wrapper classes may _optionally_
+     Node-API C++ wrapper classes may _optionally_
      [integrate C++ and JavaScript exception-handling
      ](https://github.com/nodejs/node-addon-api/blob/HEAD/doc/error_handling.md).
      To enable that capability, C++ exceptions must be enabled in `binding.gyp`:
@@ -49,7 +49,7 @@ To use **N-API** in a native module:
   },
 ```
 
-  Alternatively, disable use of C++ exceptions in N-API:
+  Alternatively, disable use of C++ exceptions in Node-API:
 
 ```gyp
   'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
@@ -74,8 +74,8 @@ To use **N-API** in a native module:
 #include "napi.h"
 ```
 
-At build time, the N-API back-compat library code will be used only when the
-targeted node version *does not* have N-API built-in.
+At build time, the Node-API back-compat library code will be used only when the
+targeted node version *does not* have Node-API built-in.
 
 The preprocessor directive `NODE_ADDON_API_DISABLE_DEPRECATED` can be defined at
 compile time before including `napi.h` to skip the definition of deprecated APIs.

--- a/doc/string.md
+++ b/doc/string.md
@@ -15,7 +15,7 @@ being used, callers should check the result of `Env::IsExceptionPending` before
 attempting to use the returned value.
 
 ```cpp
-Napi::String::String(napi_env env, napi_value value); ///< Wraps a N-API value primitive.
+Napi::String::String(napi_env env, napi_value value); ///< Wraps a Node-API value primitive.
 ```
 - `[in] env` - The environment in which to create the string.
 - `[in] value` - The primitive to wrap.

--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -28,7 +28,7 @@ Napi::Symbol::New(napi_env env, napi_value description);
   - `std::string&` - UTF8 string description.
   - `const char*` - represents a UTF8 string description.
   - `String` - Node addon API String description.
-  - `napi_value` - N-API `napi_value` description.
+  - `napi_value` - Node-API `napi_value` description.
 
 If an error occurs, a `Napi::Error` will get thrown. If C++ exceptions are not
 being used, callers should check the result of `Napi::Env::IsExceptionPending` before

--- a/doc/threadsafe.md
+++ b/doc/threadsafe.md
@@ -48,7 +48,7 @@ native C++ code (the "callback") on the Node.js thread.
 
 ### [`Napi::ThreadSafeFunction`](threadsafe_function.md)
 
-This API is designed without N-API 5 native support for [the optional JavaScript
+This API is designed without Node-API 5 native support for [the optional JavaScript
   function callback feature](https://github.com/nodejs/node/commit/53297e66cb).
 
 This API has some dynamic functionality, in that:
@@ -65,7 +65,7 @@ situational **memory leaks**:
   and dynamically constructs a wrapper for your callback on the heap for every
   call to `[Non]BlockingCall()`.
 - In acting in this "broker" fashion, the API will call the underlying "make
-  call" N-API method on this packaged item. If the API has determined the
+  call" Node-API method on this packaged item. If the API has determined the
   thread-safe function is no longer accessible (eg. all threads have released
   yet there are still items on the queue), **the callback passed to
   [Non]BlockingCall will not execute**. This means it is impossible to perform
@@ -81,11 +81,11 @@ situational **memory leaks**:
 ### [`Napi::TypedThreadSafeFunction`](typed_threadsafe_function.md)
 
 The `TypedThreadSafeFunction` class is a new implementation to address the
-drawbacks listed above. The API is designed with N-API 5's support of an
+drawbacks listed above. The API is designed with Node-API 5's support of an
 optional function callback. The API will correctly allow developers to pass
 `std::nullptr` instead of a `const Function&` for the callback function
-specified in `::New`. It also provides helper APIs to _target_ N-API 4 and
-construct a no-op `Function` **or** to target N-API 5 and "construct" a
+specified in `::New`. It also provides helper APIs to _target_ Node-API 4 and
+construct a no-op `Function` **or** to target Node-API 5 and "construct" a
 `std::nullptr` callback. This allows a single codebase to use the same APIs,
 with just a switch of the `NAPI_VERSION` compile-time constant.
 
@@ -111,7 +111,7 @@ The removal of the dynamic call functionality has the following implications:
 
 In summary, it may be best to use `Napi::TypedThreadSafeFunction` if:
 
-- static, compile-time support for targeting N-API 4 or 5+ with an optional
+- static, compile-time support for targeting Node-API 4 or 5+ with an optional
   JavaScript callback feature is desired;
 - the callback can have `static` storage class and will not change across calls
   to `[Non]BlockingCall()`;

--- a/doc/threadsafe_function.md
+++ b/doc/threadsafe_function.md
@@ -159,7 +159,7 @@ napi_status Napi::ThreadSafeFunction::NonBlockingCall(DataType* data, Callback c
   call as an `Napi::Function` in its parameters and the `DataType*` data pointer
   (if provided). Must implement `void operator()(Napi::Env env, Function
   jsCallback, DataType* data)`, skipping `data` if not provided. It is not
-  necessary to call into JavaScript via `MakeCallback()` because N-API runs
+  necessary to call into JavaScript via `MakeCallback()` because Node-API runs
   `callback` in a context appropriate for callbacks.
 
 **These specific function overloads should only be used on a `ThreadSafeFunction`

--- a/doc/typed_threadsafe_function.md
+++ b/doc/typed_threadsafe_function.md
@@ -263,7 +263,7 @@ void CallJs(Napi::Env env, Function callback, Context *context,
   // Is the JavaScript environment still available to call into, eg. the TSFN is
   // not aborted
   if (env != nullptr) {
-    // On N-API 5+, the `callback` parameter is optional; however, this example
+    // On Node-API 5+, the `callback` parameter is optional; however, this example
     // does ensure a callback is provided.
     if (callback != nullptr) {
       callback.Call(context->Value(), {Number::New(env, *data)});

--- a/doc/value.md
+++ b/doc/value.md
@@ -3,9 +3,9 @@
 `Napi::Value` is the C++ manifestation of a JavaScript value. It is the base
 class upon which other JavaScript values such as `Napi::Number`,
 `Napi::Boolean`, `Napi::String`, and `Napi::Object` are based. It represents a
-JavaScript value of an unknown type. It is a thin wrapper around the N-API
+JavaScript value of an unknown type. It is a thin wrapper around the Node-API
 datatype `napi_value`. Methods on this class can be used to check the JavaScript
-type of the underlying N-API `napi_value` and also to convert to C++ types.
+type of the underlying Node-API `napi_value` and also to convert to C++ types.
 
 ## Constructors
 
@@ -45,7 +45,7 @@ value` may be any of:
 Napi::Value::operator napi_value() const;
 ```
 
-Returns the underlying N-API `napi_value`. If the instance is _empty_, this
+Returns the underlying Node-API `napi_value`. If the instance is _empty_, this
 returns `nullptr`.
 
 ### operator ==
@@ -98,10 +98,10 @@ static Napi::Value Napi::Value::From(napi_env env, const T& value);
 
 - `[in] env`: The `napi_env` environment in which to create the `Napi::Value`
 object.
-- `[in] value`: The N-API primitive value from which to create the `Napi::Value`
+- `[in] value`: The Node-API primitive value from which to create the `Napi::Value`
 object.
 
-Returns a `Napi::Value` object from an N-API primitive value.
+Returns a `Napi::Value` object from an Node-API primitive value.
 
 This method is used to convert from a C++ type to a JavaScript value.
 Here, `value` may be any of:
@@ -192,7 +192,7 @@ Thus, when C++ exceptions are not being used, callers should check the result of
 bool Napi::Value::IsExternal() const;
 ```
 
-Returns `true` if the underlying value is a N-API external object or `false`
+Returns `true` if the underlying value is a Node-API external object or `false`
 otherwise.
 
 ### IsFunction

--- a/doc/version_management.md
+++ b/doc/version_management.md
@@ -1,14 +1,14 @@
 # VersionManagement
 
 The `Napi::VersionManagement` class contains methods that allow information
-to be retrieved about the version of N-API and Node.js. In some cases it is
+to be retrieved about the version of Node-API and Node.js. In some cases it is
 important to make decisions based on different versions of the system.
 
 ## Methods
 
 ### GetNapiVersion
 
-Retrieves the highest N-API version supported by Node.js runtime.
+Retrieves the highest Node-API version supported by Node.js runtime.
 
 ```cpp
 static uint32_t Napi::VersionManagement::GetNapiVersion(Env env);
@@ -16,7 +16,7 @@ static uint32_t Napi::VersionManagement::GetNapiVersion(Env env);
 
 - `[in] env`: The environment in which the API is invoked under.
 
-Returns the highest N-API version supported by Node.js runtime.
+Returns the highest Node-API version supported by Node.js runtime.
 
 ### GetNodeVersion
 


### PR DESCRIPTION
Done by running:
```sh
sed -i "s/N-API/Node-API/g" doc/*
```

Fixes: https://github.com/nodejs/node-addon-api/issues/950