### PR TITLE
Added badges for Node-API v7 and v8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ available:
 ![Node-API v4 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v4%20Badge.svg)
 ![Node-API v5 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v5%20Badge.svg)
 ![Node-API v6 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v6%20Badge.svg)
+![Node-API v7 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v7%20Badge.svg)
+![Node-API v8 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v8%20Badge.svg)
 ![Node-API Experimental Version Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20Experimental%20Version%20Badge.svg)
 
 ## **Contributing**


### PR DESCRIPTION
This PR add new badges for Node-API v7 and v8.
The PR should be landed after:
- https://github.com/nodejs/abi-stable-node/pull/428
- https://github.com/nodejs/node-addon-api/pull/951 