### PR TITLE
test: common test runners

### DIFF
--- a/test/addon.js
+++ b/test/addon.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   assert.strictEqual(binding.addon.increment(), 43);

--- a/test/addon_data.js
+++ b/test/addon_data.js
@@ -1,15 +1,10 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const { spawn } = require('child_process');
 const readline = require('readline');
-const path = require('path');
 
-module.exports =
-  test(path.resolve(__dirname, `./build/${buildType}/binding.node`))
-  .then(() =>
-    test(path.resolve(__dirname,
-                      `./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTestWithBindingPath(test);
 
 // Make sure the instance data finalizer is called at process exit. If the hint
 // is non-zero, it will be printed out by the child process.

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -1,10 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   return testUtil.runGCTests([

--- a/test/asynccontext.js
+++ b/test/asynccontext.js
@@ -1,5 +1,5 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const common = require('./common');
 
@@ -17,8 +17,7 @@ function checkAsyncHooks() {
   return false;
 }
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = common.runTest(test);
 
 function installAsyncHooksForTest() {
   return new Promise((resolve, reject) => {
@@ -53,21 +52,24 @@ function installAsyncHooksForTest() {
 }
 
 function test(binding) {
-  binding.asynccontext.makeCallback(common.mustCall(), { foo: 'foo' });
-  if (!checkAsyncHooks())
+  if (!checkAsyncHooks()) {
     return;
+  }
 
   const hooks = installAsyncHooksForTest();
   const triggerAsyncId = async_hooks.executionAsyncId();
-  hooks.then(actual => {
-    assert.deepStrictEqual(actual, [
-      { eventName: 'init',
-        type: 'async_context_test',
-        triggerAsyncId: triggerAsyncId,
-        resource: { foo: 'foo' } },
-      { eventName: 'before' },
-      { eventName: 'after' },
-      { eventName: 'destroy' }
-    ]);
-  }).catch(common.mustNotCall());
+  const interval = setInterval(() => {}, 10);
+  binding.asynccontext.makeCallback(common.mustCall(), { foo: 'foo' });
+  return hooks.then(actual => {
+      assert.deepStrictEqual(actual, [
+        { eventName: 'init',
+          type: 'async_context_test',
+          triggerAsyncId: triggerAsyncId,
+          resource: { foo: 'foo' } },
+        { eventName: 'before' },
+        { eventName: 'after' },
+        { eventName: 'destroy' }
+      ]);
+  }).catch(common.mustNotCall())
+  .finally(() => clearInterval(interval));
 }

--- a/test/asyncprogressqueueworker.js
+++ b/test/asyncprogressqueueworker.js
@@ -1,11 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const common = require('./common')
 const assert = require('assert');
-const os = require('os');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = common.runTest(test);
 
 async function test({ asyncprogressqueueworker }) {
   await success(asyncprogressqueueworker);

--- a/test/asyncprogressworker.js
+++ b/test/asyncprogressworker.js
@@ -1,10 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const common = require('./common')
 const assert = require('assert');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = common.runTest(test);
 
 async function test({ asyncprogressworker }) {
   await success(asyncprogressworker);

--- a/test/asyncworker-nocallback.js
+++ b/test/asyncworker-nocallback.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const common = require('./common');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = common.runTest(test);
 
 async function test(binding) {
   await binding.asyncworker.doWorkNoCallback(true, {})

--- a/test/asyncworker-persistent.js
+++ b/test/asyncworker-persistent.js
@@ -1,9 +1,6 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
-const common = require('./common');
-const binding = require(`./build/${buildType}/binding.node`);
-const noexceptBinding = require(`./build/${buildType}/binding_noexcept.node`);
 
 function test(binding, succeed) {
   return new Promise((resolve) =>
@@ -21,7 +18,7 @@ function test(binding, succeed) {
     }));
 }
 
-module.exports = test(binding.persistentasyncworker, false)
-  .then(() => test(binding.persistentasyncworker, true))
-  .then(() => test(noexceptBinding.persistentasyncworker, false))
-  .then(() => test(noexceptBinding.persistentasyncworker, true));
+module.exports = require('./common').runTest(async binding => {
+  await test(binding.persistentasyncworker, false);
+  await test(binding.persistentasyncworker, true);
+});

--- a/test/asyncworker.js
+++ b/test/asyncworker.js
@@ -22,7 +22,21 @@ function installAsyncHooksForTest() {
   return new Promise((resolve, reject) => {
     let id;
     const events = [];
-    const hook = async_hooks.createHook({
+    /**
+     * TODO(legendecas): investigate why resolving & disabling hooks in
+     * destroy callback causing crash with case 'callbackscope.js'.
+     */
+     let hook;
+     let destroyed = false;
+     const interval = setInterval(() => {
+       if (destroyed) {
+         hook.disable();
+         clearInterval(interval);
+         resolve(events);
+       }
+     }, 10);
+
+    hook = async_hooks.createHook({
       init(asyncId, type, triggerAsyncId, resource) {
         if (id === undefined && type === 'TestResource') {
           id = asyncId;
@@ -42,8 +56,7 @@ function installAsyncHooksForTest() {
       destroy(asyncId) {
         if (asyncId === id) {
           events.push({ eventName: 'destroy' });
-          hook.disable();
-          resolve(events);
+          destroyed = true;
         }
       }
     }).enable();

--- a/test/asyncworker.js
+++ b/test/asyncworker.js
@@ -1,5 +1,4 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const common = require('./common');
 
@@ -17,8 +16,7 @@ function checkAsyncHooks() {
   return false;
 }
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = common.runTest(test);
 
 function installAsyncHooksForTest() {
   return new Promise((resolve, reject) => {

--- a/test/basic_types/array.js
+++ b/test/basic_types/array.js
@@ -1,9 +1,7 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
 

--- a/test/basic_types/boolean.js
+++ b/test/basic_types/boolean.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   const bool1 = binding.basic_types_boolean.createBoolean(true);

--- a/test/basic_types/number.js
+++ b/test/basic_types/number.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   const MIN_INT32 = -2147483648;

--- a/test/basic_types/value.js
+++ b/test/basic_types/value.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   const externalValue = binding.basic_types_value.createExternal();

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   const {

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -1,11 +1,10 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
 const safeBuffer = require('safe-buffer');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   return testUtil.runGCTests([

--- a/test/callbackscope.js
+++ b/test/callbackscope.js
@@ -23,7 +23,7 @@ function test(binding) {
 
   let id;
   let insideHook = false;
-  async_hooks.createHook({
+  const hook = async_hooks.createHook({
     init(asyncId, type, triggerAsyncId, resource) {
       if (id === undefined && type === 'callback_scope_test') {
         id = asyncId;
@@ -39,7 +39,11 @@ function test(binding) {
     }
   }).enable();
 
-  binding.callbackscope.runInCallbackScope(function() {
-    assert(insideHook);
+  return new Promise(resolve => {
+    binding.callbackscope.runInCallbackScope(function() {
+      assert(insideHook);
+      hook.disable();
+      resolve();
+    });
   });
 }

--- a/test/callbackscope.js
+++ b/test/callbackscope.js
@@ -1,7 +1,5 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
-const common = require('./common');
 
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
@@ -17,8 +15,7 @@ function checkAsyncHooks() {
   return false;
 }
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   if (!checkAsyncHooks())

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -83,15 +83,10 @@ exports.runTest = async function(test, buildType) {
     `../build/${buildType}/binding_noexcept.node`,
   ].map(it => require.resolve(it));
 
-  // TODO(legendecas): investigate strange CHECK failures in Node.js core
-  // - src/callback.cc
-  //   - InternalCallbackScope::Close
-  //     - CHECK_EQ(env_->execution_async_id(), 0);
-  //
-  // for (const item of bindings) {
-  //   await test(require(item));
-  // }
-  return bindings.map(item => test(require(item)));
+  for (const item of bindings) {
+    await Promise.resolve(test(require(item)))
+      .finally(exports.mustCall());
+  }
 }
 
 exports.runTestWithBindingPath = async function(test, buildType) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -74,3 +74,35 @@ exports.mustNotCall = function(msg) {
     assert.fail(msg || 'function should not have been called');
   };
 };
+
+exports.runTest = async function(test, buildType) {
+  buildType = buildType || process.config.target_defaults.default_configuration;
+
+  const bindings = [
+    `../build/${buildType}/binding.node`,
+    `../build/${buildType}/binding_noexcept.node`,
+  ].map(it => require.resolve(it));
+
+  // TODO(legendecas): investigate strange CHECK failures in Node.js core
+  // - src/callback.cc
+  //   - InternalCallbackScope::Close
+  //     - CHECK_EQ(env_->execution_async_id(), 0);
+  //
+  // for (const item of bindings) {
+  //   await test(require(item));
+  // }
+  return bindings.map(item => test(require(item)));
+}
+
+exports.runTestWithBindingPath = async function(test, buildType) {
+  buildType = buildType || process.config.target_defaults.default_configuration;
+
+  const bindings = [
+    `../build/${buildType}/binding.node`,
+    `../build/${buildType}/binding_noexcept.node`,
+  ].map(it => require.resolve(it));
+
+  for (const item of bindings) {
+    await test(item);
+  }
+}

--- a/test/dataview/dataview.js
+++ b/test/dataview/dataview.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
-
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testDataViewCreation(factory, arrayBuffer, offset, length) {

--- a/test/dataview/dataview_read_write.js
+++ b/test/dataview/dataview_read_write.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function expected(type, value) {

--- a/test/date.js
+++ b/test/date.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   const {

--- a/test/error.js
+++ b/test/error.js
@@ -1,5 +1,5 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
 if (process.argv[2] === 'fatal') {
@@ -8,8 +8,7 @@ if (process.argv[2] === 'fatal') {
   return;
 }
 
-test(`./build/${buildType}/binding.node`);
-test(`./build/${buildType}/binding_noexcept.node`);
+module.exports = require('./common').runTestWithBindingPath(test);
 
 function test(bindingPath) {
   const binding = require(bindingPath);

--- a/test/external.js
+++ b/test/external.js
@@ -1,5 +1,5 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 const testUtil = require('./testUtil');
@@ -40,9 +40,7 @@ if (process.argv.length === 3) {
   return;
 }
 
-module.exports = test(require.resolve(`./build/${buildType}/binding.node`))
-  .then(() =>
-    test(require.resolve(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTestWithBindingPath(test);
 
 function test(bindingPath) {
   const binding = require(bindingPath);

--- a/test/function.js
+++ b/test/function.js
@@ -1,11 +1,11 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`).function.plain);
-test(require(`./build/${buildType}/binding_noexcept.node`).function.plain);
-test(require(`./build/${buildType}/binding.node`).function.templated);
-test(require(`./build/${buildType}/binding_noexcept.node`).function.templated);
+module.exports = require('./common').runTest(binding => {
+  test(binding.function.plain);
+  test(binding.function.templated);
+});
 
 function test(binding) {
   assert.strictEqual(binding.emptyConstructor(true), true);

--- a/test/globalObject/global_object_delete_property.js
+++ b/test/globalObject/global_object_delete_property.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
-
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
     const KEY_TYPE = {

--- a/test/globalObject/global_object_get_property.js
+++ b/test/globalObject/global_object_get_property.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
-
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   const KEY_TYPE = {

--- a/test/globalObject/global_object_has_own_property.js
+++ b/test/globalObject/global_object_has_own_property.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
-
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
     const KEY_TYPE = {

--- a/test/globalObject/global_object_set_property.js
+++ b/test/globalObject/global_object_set_property.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
-
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   const KEY_TYPE = {

--- a/test/handlescope.js
+++ b/test/handlescope.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   assert.strictEqual(binding.handlescope.createScope(), 'scope');

--- a/test/index.js
+++ b/test/index.js
@@ -117,17 +117,17 @@ if (napiVersion < 8) {
 }
 
 (async function() {
-console.log(`Testing with Node-API Version '${napiVersion}'.`);
+  console.log(`Testing with Node-API Version '${napiVersion}'.`);
 
-console.log('Starting test suite\n');
+  console.log('Starting test suite\n');
 
-// Requiring each module runs tests in the module.
-for (const name of testModules) {
-  console.log(`Running test '${name}'`);
-  await require('./' + name);
-};
+  // Requiring each module runs tests in the module.
+  for (const name of testModules) {
+    console.log(`Running test '${name}'`);
+    await require('./' + name);
+  };
 
-console.log('\nAll tests passed!');
+  console.log('\nAll tests passed!');
 })().catch((error) => {
   console.log(error);
   process.exit(1);

--- a/test/memory_management.js
+++ b/test/memory_management.js
@@ -1,10 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
-function test(binding) { 
+function test(binding) {
     assert.strictEqual(binding.memory_management.externalAllocatedMemory(), true)
 }

--- a/test/movable_callbacks.js
+++ b/test/movable_callbacks.js
@@ -1,15 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const common = require('./common');
 const testUtil = require('./testUtil');
 
-Promise.all([
-  test(require(`./build/${buildType}/binding.node`).movable_callbacks),
-  test(require(`./build/${buildType}/binding_noexcept.node`).movable_callbacks),
-]).catch(e => {
-  console.error(e);
-  process.exitCode = 1;
-});
+module.exports = require('./common').runTest(binding => test(binding.movable_callbacks));
 
 async function test(binding) {
   await testUtil.runGCTests([

--- a/test/name.js
+++ b/test/name.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   const expected = '123456789';

--- a/test/object/delete_property.js
+++ b/test/object/delete_property.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testDeleteProperty(nativeDeleteProperty) {

--- a/test/object/finalizer.js
+++ b/test/object/finalizer.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('../testUtil');
 
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 function createWeakRef(binding, bindingToTest) {
   return binding.object[bindingToTest]({});

--- a/test/object/get_property.js
+++ b/test/object/get_property.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testGetProperty(nativeGetProperty) {

--- a/test/object/has_own_property.js
+++ b/test/object/has_own_property.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testHasOwnProperty(nativeHasOwnProperty) {

--- a/test/object/has_property.js
+++ b/test/object/has_property.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testHasProperty(nativeHasProperty) {

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function assertPropertyIs(obj, key, attribute) {

--- a/test/object/object_deprecated.js
+++ b/test/object/object_deprecated.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   if (!('object_deprecated' in binding)) {

--- a/test/object/object_freeze_seal.js
+++ b/test/object/object_freeze_seal.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
     {

--- a/test/object/set_property.js
+++ b/test/object/set_property.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testSetProperty(nativeSetProperty) {

--- a/test/object/subscript_operator.js
+++ b/test/object/subscript_operator.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   function testProperty(obj, key, value, nativeGetProperty, nativeSetProperty) {

--- a/test/objectreference.js
+++ b/test/objectreference.js
@@ -10,12 +10,11 @@
  */
 
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   function testCastedEqual(testToCompare) {

--- a/test/objectwrap-removewrap.js
+++ b/test/objectwrap-removewrap.js
@@ -5,10 +5,11 @@ if (process.argv[2] === 'child') {
   return new (require(process.argv[3]).objectwrap.Test)();
 }
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 const testUtil = require('./testUtil');
+
+module.exports = require('./common').runTestWithBindingPath(test);
 
 function test(bindingName) {
   return testUtil.runGCTests([
@@ -37,6 +38,3 @@ function test(bindingName) {
   assert.strictEqual(child.signal, null);
   assert.strictEqual(child.status, 0);
 }
-
-module.exports = test(`./build/${buildType}/binding.node`)
-  .then(() => test(`./build/${buildType}/binding_noexcept.node`));

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -1,7 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
+
+module.exports = require('./common').runTest(test);
 
 async function test(binding) {
   const Test = binding.objectwrap.Test;
@@ -280,6 +282,3 @@ async function test(binding) {
   // Make sure the C++ object can be garbage collected without issues.
   await testUtil.runGCTests(['one last gc', () => {}, () => {}]);
 }
-
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -1,5 +1,5 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
@@ -15,5 +15,4 @@ function test(binding) {
   ]);
 }
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);

--- a/test/objectwrap_multiple_inheritance.js
+++ b/test/objectwrap_multiple_inheritance.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
 const test = bindingName => {
@@ -11,5 +10,4 @@ const test = bindingName => {
   assert.strictEqual(testmi.test, 0);
 }
 
-test(`./build/${buildType}/binding.node`);
-test(`./build/${buildType}/binding_noexcept.node`);
+module.exports = require('./common').runTestWithBindingPath(test);

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -10,6 +10,5 @@ if (isMainThread) {
     };
 
     const buildType = workerData;
-    test(require(`./build/${buildType}/binding.node`));
-    test(require(`./build/${buildType}/binding_noexcept.node`));
+    require('./common').runTest(test, buildType);
 }

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,10 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const common = require('./common');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = common.runTest(test);
 
 async function test(binding) {
   assert.strictEqual(binding.promise.isPromise({}), false);

--- a/test/reference.js
+++ b/test/reference.js
@@ -1,12 +1,9 @@
 'use strict';
 
-
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   return testUtil.runGCTests([

--- a/test/run_script.js
+++ b/test/run_script.js
@@ -1,10 +1,9 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-module.exports = test(require(`./build/${buildType}/binding.node`))
-  .then(() => test(require(`./build/${buildType}/binding_noexcept.node`)));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   return testUtil.runGCTests([

--- a/test/threadsafe_function/threadsafe_function.js
+++ b/test/threadsafe_function/threadsafe_function.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const common = require('../common');
 
-module.exports = (async function() {
-  await test(require(`../build/${buildType}/binding.node`));
-  await test(require(`../build/${buildType}/binding_noexcept.node`));
-})();
+module.exports = common.runTest(test);
 
 async function test(binding) {
   const expectedArray = (function(arrayLength) {

--- a/test/threadsafe_function/threadsafe_function_ctx.js
+++ b/test/threadsafe_function/threadsafe_function_ctx.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 async function test(binding) {
   const ctx = { };

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.js
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.js
@@ -2,14 +2,11 @@
 
 const assert = require('assert');
 
-const buildType = process.config.target_defaults.default_configuration;
-
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 async function test(binding) {
   const testCall = binding.threadsafe_function_existing_tsfn.testCall;
-  
+
   assert.strictEqual(typeof await testCall({ blocking: true,  data: true  }), "number");
   assert.strictEqual(typeof await testCall({ blocking: true,  data: false }), "undefined");
   assert.strictEqual(typeof await testCall({ blocking: false, data: true  }), "number");

--- a/test/threadsafe_function/threadsafe_function_ptr.js
+++ b/test/threadsafe_function/threadsafe_function_ptr.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
-
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   binding.threadsafe_function_ptr.test({}, () => {});

--- a/test/threadsafe_function/threadsafe_function_sum.js
+++ b/test/threadsafe_function/threadsafe_function_sum.js
@@ -1,6 +1,5 @@
 'use strict';
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
 /**
  *
@@ -29,8 +28,7 @@ const buildType = process.config.target_defaults.default_configuration;
 const THREAD_COUNT = 5;
 const EXPECTED_SUM = (THREAD_COUNT - 1) * (THREAD_COUNT) / 2;
 
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 /** @param {number[]} N */
 const sum = (N) => N.reduce((sum, n) => sum + n, 0);

--- a/test/threadsafe_function/threadsafe_function_unref.js
+++ b/test/threadsafe_function/threadsafe_function_unref.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
 const isMainProcess = process.argv[1] != __filename;
 
@@ -15,8 +14,7 @@ const isMainProcess = process.argv[1] != __filename;
  */
 
 if (isMainProcess) {
-  module.exports = test(`../build/${buildType}/binding.node`)
-    .then(() => test(`../build/${buildType}/binding_noexcept.node`));
+  module.exports = require('../common').runTestWithBindingPath(test);
 } else {
   test(process.argv[2]);
 }

--- a/test/thunking_manual.js
+++ b/test/thunking_manual.js
@@ -1,10 +1,9 @@
 // Flags: --expose-gc
 'use strict';
-const buildType = 'Debug';
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   console.log("Thunking: Performing initial GC");

--- a/test/typed_threadsafe_function/typed_threadsafe_function.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 const common = require('../common');
 
-module.exports = (async function () {
-  await test(require(`../build/${buildType}/binding.node`));
-  await test(require(`../build/${buildType}/binding_noexcept.node`));
-})();
+module.exports = common.runTest(test);
 
 async function test(binding) {
   const expectedArray = (function (arrayLength) {

--- a/test/typed_threadsafe_function/typed_threadsafe_function_ctx.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ctx.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 async function test(binding) {
   const ctx = { };

--- a/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.js
@@ -2,10 +2,7 @@
 
 const assert = require('assert');
 
-const buildType = process.config.target_defaults.default_configuration;
-
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 async function test(binding) {
   const testCall = binding.typed_threadsafe_function_existing_tsfn.testCall;

--- a/test/typed_threadsafe_function/typed_threadsafe_function_ptr.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ptr.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
-
-test(require(`../build/${buildType}/binding.node`));
-test(require(`../build/${buildType}/binding_noexcept.node`));
+module.exports = require('../common').runTest(test);
 
 function test(binding) {
   binding.typed_threadsafe_function_ptr.test({}, () => {});

--- a/test/typed_threadsafe_function/typed_threadsafe_function_sum.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_sum.js
@@ -1,6 +1,5 @@
 'use strict';
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
 /**
  *
@@ -29,8 +28,7 @@ const buildType = process.config.target_defaults.default_configuration;
 const THREAD_COUNT = 5;
 const EXPECTED_SUM = (THREAD_COUNT - 1) * (THREAD_COUNT) / 2;
 
-module.exports = test(require(`../build/${buildType}/binding.node`))
-  .then(() => test(require(`../build/${buildType}/binding_noexcept.node`)));
+module.exports = require('../common').runTest(test);
 
 /** @param {number[]} N */
 const sum = (N) => N.reduce((sum, n) => sum + n, 0);

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const buildType = process.config.target_defaults.default_configuration;
 
 const isMainProcess = process.argv[1] != __filename;
 
@@ -15,8 +14,7 @@ const isMainProcess = process.argv[1] != __filename;
  */
 
 if (isMainProcess) {
-  module.exports = test(`../build/${buildType}/binding.node`)
-    .then(() => test(`../build/${buildType}/binding_noexcept.node`));
+  module.exports = require('../common').runTestWithBindingPath(test);
 } else {
   test(process.argv[2]);
 }

--- a/test/typedarray-bigint.js
+++ b/test/typedarray-bigint.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   [

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function test(binding) {
   const testData = [

--- a/test/version_management.js
+++ b/test/version_management.js
@@ -1,9 +1,8 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 function parseVersion() {
     const expected = {};


### PR DESCRIPTION
Collects test entries so that we can run tests one by another. Also, it makes adding new test cases and test suites easier, i.e. we don't have to add the addon path to every test case file.