### PR TITLE
test: Correct invalid tsfn binding export

### DIFF
--- a/test/binding.cc
+++ b/test/binding.cc
@@ -121,7 +121,7 @@ Object Init(Env env, Object exports) {
   exports.Set("threadsafe_function_ptr", InitThreadSafeFunctionPtr(env));
   exports.Set("threadsafe_function_sum", InitThreadSafeFunctionSum(env));
   exports.Set("threadsafe_function_unref", InitThreadSafeFunctionUnref(env));
-  exports.Set("threadsafe_function", InitTypedThreadSafeFunction(env));
+  exports.Set("threadsafe_function", InitThreadSafeFunction(env));
   exports.Set("typed_threadsafe_function_ctx",
               InitTypedThreadSafeFunctionCtx(env));
   exports.Set("typed_threadsafe_function_existing_tsfn",


### PR DESCRIPTION
This commit https://github.com/nodejs/node-addon-api/commit/c24c455ced57a3c9ac4818482dc6d4f246f591e7#diff-994bd7eb26e23ba70f1d7faa2084e7c57f520e1ba8d8fb09a1cfa3610456d1a4 incorrectly updated the regular TSFN test with TypedTSFN.

The first attempt https://github.com/nodejs/node-addon-api/pull/974 still has crashes. I guess the action was re-ran and the previous CI failure is no longer visible.

This PR at least can go in while we troubleshoot the failing test. [NB: It may be the case that this fix could solve the intermittent issue itself, since the test implementation uses global static variables... but unlikely imo]