### PR TITLE
build: add Node.js v16.x to CI

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version:  [10.x, 12.x, 14.x, 15.x]
+        node-version:  [10.x, 12.x, 14.x, 15.x, 16.x]
         os:
           - windows-latest
           - windows-2016

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           - node/12
           - node/14
           - node/15
+          - node/16
         compiler:
           - gcc
           - clang


### PR DESCRIPTION
Node.js v16.x will be the next LTS line in 6 months.