### PR TITLE
src: return bool on object freeze and seal

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1389,14 +1389,16 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
 }
 
 #if NAPI_VERSION >= 8
-inline void Object::Freeze() {
+inline bool Object::Freeze() {
   napi_status status = napi_object_freeze(_env, _value);
-  NAPI_THROW_IF_FAILED_VOID(_env, status);
+  NAPI_THROW_IF_FAILED(_env, status, false);
+  return true;
 }
 
-inline void Object::Seal() {
+inline bool Object::Seal() {
   napi_status status = napi_object_seal(_env, _value);
-  NAPI_THROW_IF_FAILED_VOID(_env, status);
+  NAPI_THROW_IF_FAILED(_env, status, false);
+  return true;
 }
 #endif  // NAPI_VERSION >= 8
 

--- a/napi.h
+++ b/napi.h
@@ -773,8 +773,8 @@ namespace Napi {
                              T* data,
                              Hint* finalizeHint);
 #if NAPI_VERSION >= 8
-    void Freeze();
-    void Seal();
+    bool Freeze();
+    bool Seal();
 #endif  // NAPI_VERSION >= 8
   };
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -76,7 +76,7 @@ exports.mustNotCall = function(msg) {
 };
 
 exports.runTest = async function(test, buildType) {
-  buildType = buildType || process.config.target_defaults.default_configuration;
+  buildType = buildType || process.config.target_defaults.default_configuration || 'Release';
 
   const bindings = [
     `../build/${buildType}/binding.node`,
@@ -90,7 +90,7 @@ exports.runTest = async function(test, buildType) {
 }
 
 exports.runTestWithBindingPath = async function(test, buildType) {
-  buildType = buildType || process.config.target_defaults.default_configuration;
+  buildType = buildType || process.config.target_defaults.default_configuration || 'Release';
 
   const bindings = [
     `../build/${buildType}/binding.node`,

--- a/test/object/object_freeze_seal.cc
+++ b/test/object/object_freeze_seal.cc
@@ -4,14 +4,14 @@
 
 using namespace Napi;
 
-void Freeze(const CallbackInfo& info) {
+Value Freeze(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  obj.Freeze();
+  return Boolean::New(info.Env(), obj.Freeze());
 }
 
-void Seal(const CallbackInfo& info) {
+Value Seal(const CallbackInfo& info) {
   Object obj = info[0].As<Object>();
-  obj.Seal();
+  return Boolean::New(info.Env(), obj.Seal());
 }
 
 Object InitObjectFreezeSeal(Env env) {

--- a/test/object/object_freeze_seal.js
+++ b/test/object/object_freeze_seal.js
@@ -7,7 +7,7 @@ module.exports = require('../common').runTest(test);
 function test(binding) {
     {
         const obj = { x: 'a', y: 'b', z: 'c' };
-        binding.object_freeze_seal.freeze(obj);
+        assert.strictEqual(binding.object_freeze_seal.freeze(obj), true);
         assert.strictEqual(Object.isFrozen(obj), true);
         assert.throws(() => {
           obj.x = 10;
@@ -21,8 +21,20 @@ function test(binding) {
     }
 
     {
+        const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+          preventExtensions() {
+            throw new Error('foo');
+          },
+        });
+
+        assert.throws(() => {
+          binding.object_freeze_seal.freeze(obj);
+        }, /foo/);
+    }
+
+    {
         const obj = { x: 'a', y: 'b', z: 'c' };
-        binding.object_freeze_seal.seal(obj);
+        assert.strictEqual(binding.object_freeze_seal.seal(obj), true);
         assert.strictEqual(Object.isSealed(obj), true);
         assert.throws(() => {
           obj.w = 'd';
@@ -33,5 +45,17 @@ function test(binding) {
         // Sealed objects allow updating existing properties,
         // so this should not throw.
         obj.x = 'd';
+    }
+
+    {
+        const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+          preventExtensions() {
+            throw new Error('foo');
+          },
+        });
+
+        assert.throws(() => {
+          binding.object_freeze_seal.seal(obj);
+        }, /foo/);
     }
 }


### PR DESCRIPTION
These operations can call into JavaScript by using Proxy handlers,
hence JavaScript exceptions might pending at the end of the operations.

This is not a breaking change.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
