### PR TITLE
src: remove const qualifier on Object::GetPropertyNames and Object::InstanceOf

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1315,7 +1315,7 @@ inline bool Object::Delete(uint32_t index) {
   return result;
 }
 
-inline Array Object::GetPropertyNames() const {
+inline Array Object::GetPropertyNames() {
   napi_value result;
   napi_status status = napi_get_property_names(_env, _value, &result);
   NAPI_THROW_IF_FAILED(_env, status, Array());
@@ -1345,7 +1345,7 @@ inline bool Object::DefineProperties(
   return true;
 }
 
-inline bool Object::InstanceOf(const Function& constructor) const {
+inline bool Object::InstanceOf(const Function& constructor) {
   bool result;
   napi_status status = napi_instanceof(_env, _value, constructor, &result);
   NAPI_THROW_IF_FAILED(_env, status, false);

--- a/napi.h
+++ b/napi.h
@@ -738,7 +738,7 @@ namespace Napi {
       uint32_t index ///< Property / element index
     );
 
-    Array GetPropertyNames() const; ///< Get all property names
+    Array GetPropertyNames();  ///< Get all property names
 
     /// Defines a property on the object.
     bool DefineProperty(
@@ -761,9 +761,8 @@ namespace Napi {
     /// Checks if an object is an instance created by a constructor function.
     ///
     /// This is equivalent to the JavaScript `instanceof` operator.
-    bool InstanceOf(
-      const Function& constructor ///< Constructor function
-    ) const;
+    bool InstanceOf(const Function& constructor  ///< Constructor function
+    );
 
     template <typename Finalizer, typename T>
     inline void AddFinalizer(Finalizer finalizeCallback, T* data);


### PR DESCRIPTION
These operations can call into JavaScript and result in arbitrary
side effects, hence shall not be considered as `const` member functions.

E.g. the following examples intercepts the operations by Proxy handlers:

```javascript
const obj = new Proxy({
  foo: 0,
}, {
  ownKeys(target) {
    target.foo++;
    return [ 'foo' ];
  },
  getPrototypeOf(target) {
    target.foo++;
    return Object.prototype;
  },
});

Object.getOwnPropertyNames(obj);
obj.foo // => 1
obj instanceof Object;
obj.foo // => 2
```

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
