### PR TITLE
Add quotes for `include_dir`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const include_dir = `"path.relative('.', __dirname)"`;
+const include_dir = `"${path.relative('.', __dirname)}"`;
 
 module.exports = {
   include: `"${__dirname}"`, // deprecated, can be removed as part of 4.0.0

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const include_dir = path.relative('.', __dirname);
+const include_dir = `"path.relative('.', __dirname)"`;
 
 module.exports = {
   include: `"${__dirname}"`, // deprecated, can be removed as part of 4.0.0

--- a/package.json
+++ b/package.json
@@ -260,6 +260,10 @@
       "url": "https://github.com/sam-github"
     },
     {
+      "name": "Surien Joseph Das-Giwojno",
+      "url": "https://github.com/suriendg"
+    },
+    {
       "name": "Taylor Woll",
       "url": "https://github.com/boingoing"
     },


### PR DESCRIPTION
- Added quotes for the `include_dir` path in `index.js` so it works correctly on both Windows and linux platforms (as mentioned in https://github.com/nodejs/node-addon-examples/issues/183)