### PR TITLE
src: set default return value of Reference Ref/Unref to 0

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2583,7 +2583,7 @@ template <typename T>
 inline uint32_t Reference<T>::Ref() {
   uint32_t result;
   napi_status status = napi_reference_ref(_env, _ref, &result);
-  NAPI_THROW_IF_FAILED(_env, status, 1);
+  NAPI_THROW_IF_FAILED(_env, status, 0);
   return result;
 }
 
@@ -2591,7 +2591,7 @@ template <typename T>
 inline uint32_t Reference<T>::Unref() {
   uint32_t result;
   napi_status status = napi_reference_unref(_env, _ref, &result);
-  NAPI_THROW_IF_FAILED(_env, status, 1);
+  NAPI_THROW_IF_FAILED(_env, status, 0);
   return result;
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Update the default value to reflect the most possible values when there are any errors occurred on `napi_reference_unref`.

See: https://github.com/nodejs/node/blob/master/src/js_native_api_v8.cc#L2535
Related: https://github.com/nodejs/node-addon-api/issues/998#issuecomment-846593458