### PR TITLE
src: fix gcc-11 c++20 compilation

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -2474,9 +2474,8 @@ namespace Napi {
         Finalizer finalizeCallback,
         FinalizerDataType* data = nullptr);
 
-    TypedThreadSafeFunction<ContextType, DataType, CallJs>();
-    TypedThreadSafeFunction<ContextType, DataType, CallJs>(
-        napi_threadsafe_function tsFunctionValue);
+    TypedThreadSafeFunction();
+    TypedThreadSafeFunction(napi_threadsafe_function tsFunctionValue);
 
     operator napi_threadsafe_function() const;
 


### PR DESCRIPTION
As mentioned in [this comment](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101032#c2), the as-is code is not valid C++20.  This fix is valid in all C++ standards.

Closes: #1007