### PR TITLE
src,test: Fix up null char * exception thrown

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -900,10 +900,11 @@ inline String String::New(napi_env env, const std::u16string& val) {
 }
 
 inline String String::New(napi_env env, const char* val) {
+  // TODO(@gabrielschulhof) Remove if-statement when core's error handling is
+  // available in all supported versions.
   if (val == nullptr) {
-    NAPI_THROW(
-        TypeError::New(env, "String::New received a nullpointer as a value"),
-        Napi::String());
+    // Throw an error that looks like it came from core.
+    NAPI_THROW_IF_FAILED(env, napi_invalid_arg, String());
   }
   napi_value value;
   napi_status status = napi_create_string_utf8(env, val, std::strlen(val), &value);
@@ -913,6 +914,12 @@ inline String String::New(napi_env env, const char* val) {
 
 inline String String::New(napi_env env, const char16_t* val) {
   napi_value value;
+  // TODO(@gabrielschulhof) Remove if-statement when core's error handling is
+  // available in all supported versions.
+  if (val == nullptr) {
+    // Throw an error that looks like it came from core.
+    NAPI_THROW_IF_FAILED(env, napi_invalid_arg, String());
+  }
   napi_status status = napi_create_string_utf16(env, val, std::u16string(val).size(), &value);
   NAPI_THROW_IF_FAILED(env, status, String());
   return String(env, value);

--- a/test/name.cc
+++ b/test/name.cc
@@ -82,8 +82,13 @@ Value CheckSymbol(const CallbackInfo& info) {
   return Boolean::New(info.Env(), info[0].Type() == napi_symbol);
 }
 
-void AssertErrorThrownWhenPassedNullptr(const CallbackInfo& info) {
+void NullStringShouldThrow(const CallbackInfo& info) {
   const char* nullStr = nullptr;
+  String::New(info.Env(), nullStr);
+}
+
+void NullString16ShouldThrow(const CallbackInfo& info) {
+  const char16_t* nullStr = nullptr;
   String::New(info.Env(), nullStr);
 }
 
@@ -92,8 +97,9 @@ Object InitName(Env env) {
 
   exports["echoString"] = Function::New(env, EchoString);
   exports["createString"] = Function::New(env, CreateString);
-  exports["nullStringShouldThrow"] =
-      Function::New(env, AssertErrorThrownWhenPassedNullptr);
+  exports["nullStringShouldThrow"] = Function::New(env, NullStringShouldThrow);
+  exports["nullString16ShouldThrow"] =
+      Function::New(env, NullString16ShouldThrow);
   exports["checkString"] = Function::New(env, CheckString);
   exports["createSymbol"] = Function::New(env, CreateSymbol);
   exports["checkSymbol"] = Function::New(env, CheckSymbol);

--- a/test/name.js
+++ b/test/name.js
@@ -9,8 +9,8 @@ function test(binding) {
 
 
   assert.throws(binding.name.nullStringShouldThrow, {
-    name: 'TypeError',
-    message: 'String::New received a nullpointer as a value',
+    name: 'Error',
+    message: 'Error in native callback',
   });
   assert.ok(binding.name.checkString(expected, 'utf8'));
   assert.ok(binding.name.checkString(expected, 'utf16'));


### PR DESCRIPTION
Throw an exception when receiving a null pointer for the `char *` and
`char16_t *` overloads of `String::New` that looks identical to an
error that core would have thrown under the circumstances
(`napi_invalid_arg`).

Also, rename the test methods to conform with our naming convention.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
