### PR TITLE
doc: update tests to avoid running in parallel

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -102,7 +102,7 @@ exports.runTestWithBindingPath = async function(test, buildType) {
   }
 }
 
-exports.runTestNoBinding = async function(test, buildType) {
+exports.runTestWithBuildType = async function(test, buildType) {
   buildType = buildType || process.config.target_defaults.default_configuration || 'Release';
 
    await Promise.resolve(test(buildType))

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -101,3 +101,10 @@ exports.runTestWithBindingPath = async function(test, buildType) {
     await test(item);
   }
 }
+
+exports.runTestNoBinding = async function(test, buildType) {
+  buildType = buildType || process.config.target_defaults.default_configuration || 'Release';
+
+   await Promise.resolve(test(buildType))
+     .finally(exports.mustCall());
+}

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -1,14 +1,19 @@
 'use strict';
+const path = require('path');
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
-if (isMainThread) {
-    const buildType = process.config.target_defaults.default_configuration;
-    new Worker(__filename, { workerData: buildType });
-} else {
-    const test = binding => {
-        new binding.objectwrap.Test();
-    };
+module.exports = require('./common').runTestNoBinding(test);
 
-    const buildType = workerData;
-    require('./common').runTest(test, buildType);
+async function test(buildType) {
+  if (isMainThread) {
+    const buildType = process.config.target_defaults.default_configuration;
+    const worker = new Worker(__filename, { workerData: buildType });
+    return new Promise((resolve, reject) => {
+      worker.on('exit', () => {
+        resolve();
+      });
+    }, () => {});
+  } else {
+    await require(path.join(__dirname, 'objectwrap.js'));
+  }
 }

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const { Worker, isMainThread, workerData } = require('worker_threads');
 
-module.exports = require('./common').runTestNoBinding(test);
+module.exports = require('./common').runTestWithBuildType(test);
 
 async function test(buildType) {
   if (isMainThread) {

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 module.exports = require('./common').runTest(test);
 
 
-async function test(binding)
+function test(binding)
 {
 
     const wellKnownSymbolFunctions = ['asyncIterator','hasInstance','isConcatSpreadable', 'iterator','match','matchAll','replace','search','split','species','toPrimitive','toStringTag','unscopables'];

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -8,8 +8,12 @@ module.exports = require('./common').runTest(test);
 
 function test(binding)
 {
+    const majorNodeVersion = process.versions.node.split('.')[0];
 
-    const wellKnownSymbolFunctions = ['asyncIterator','hasInstance','isConcatSpreadable', 'iterator','match','matchAll','replace','search','split','species','toPrimitive','toStringTag','unscopables'];
+    let wellKnownSymbolFunctions = ['asyncIterator','hasInstance','isConcatSpreadable', 'iterator','match','replace','search','split','species','toPrimitive','toStringTag','unscopables'];
+    if (majorNodeVersion >= 12) {
+      wellKnownSymbolFunctions.push('matchAll');
+    }
 
     function assertCanCreateSymbol(symbol)
     {

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -3,8 +3,7 @@
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
-test(require(`./build/${buildType}/binding.node`));
-test(require(`./build/${buildType}/binding_noexcept.node`));
+module.exports = require('./common').runTest(test);
 
 
 async function test(binding)


### PR DESCRIPTION
fixes: https://github.com/nodejs/node-addon-api/issues/1022

The objectwrap_worker_thread and symbol tests
were not waiting for the test to complete before the
subsequent tests were started. This caused intermittent
crashes in the CI.

Updated both tests so that they complete before the
next test runs.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
