### PR TITLE
Add Function::Call Napi::Value override

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2287,6 +2287,11 @@ inline MaybeOrValue<Value> Function::Call(
   return Call(Env().Undefined(), args);
 }
 
+inline MaybeOrValue<Value> Function::Call(
+    const std::vector<Value>& args) const {
+  return Call(Env().Undefined(), args);
+}
+
 inline MaybeOrValue<Value> Function::Call(size_t argc,
                                           const napi_value* args) const {
   return Call(Env().Undefined(), argc, args);
@@ -2300,6 +2305,27 @@ inline MaybeOrValue<Value> Function::Call(
 inline MaybeOrValue<Value> Function::Call(
     napi_value recv, const std::vector<napi_value>& args) const {
   return Call(recv, args.size(), args.data());
+}
+
+inline MaybeOrValue<Value> Function::Call(
+    napi_value recv, const std::vector<Value>& args) const {
+  const size_t argc = args.size();
+  const size_t stackArgsCount = 6;
+  napi_value stackArgs[stackArgsCount];
+  std::vector<napi_value> heapArgs;
+  napi_value* argv;
+  if (argc <= stackArgsCount) {
+    argv = stackArgs;
+  } else {
+    heapArgs.resize(argc);
+    argv = heapArgs.data();
+  }
+
+  for (size_t index = 0; index < argc; index++) {
+    argv[index] = static_cast<napi_value>(args[index]);
+  }
+
+  return Call(recv, argc, argv);
 }
 
 inline MaybeOrValue<Value> Function::Call(napi_value recv,

--- a/napi.h
+++ b/napi.h
@@ -1350,11 +1350,14 @@ namespace Napi {
    MaybeOrValue<Value> Call(
        const std::initializer_list<napi_value>& args) const;
    MaybeOrValue<Value> Call(const std::vector<napi_value>& args) const;
+   MaybeOrValue<Value> Call(const std::vector<Value>& args) const;
    MaybeOrValue<Value> Call(size_t argc, const napi_value* args) const;
    MaybeOrValue<Value> Call(
        napi_value recv, const std::initializer_list<napi_value>& args) const;
    MaybeOrValue<Value> Call(napi_value recv,
                             const std::vector<napi_value>& args) const;
+   MaybeOrValue<Value> Call(napi_value recv,
+                            const std::vector<Value>& args) const;
    MaybeOrValue<Value> Call(napi_value recv,
                             size_t argc,
                             const napi_value* args) const;

--- a/test/function.cc
+++ b/test/function.cc
@@ -69,6 +69,16 @@ Value CallWithVector(const CallbackInfo& info) {
    return MaybeUnwrap(func.Call(args));
 }
 
+Value CallWithVectorUsingCppWrapper(const CallbackInfo& info) {
+  Function func = info[0].As<Function>();
+  std::vector<Value> args;
+  args.reserve(3);
+  args.push_back(info[1]);
+  args.push_back(info[2]);
+  args.push_back(info[3]);
+  return MaybeUnwrap(func.Call(args));
+}
+
 Value CallWithCStyleArray(const CallbackInfo& info) {
   Function func = info[0].As<Function>();
   std::vector<napi_value> args;
@@ -106,6 +116,17 @@ Value CallWithReceiverAndVector(const CallbackInfo& info) {
    args.push_back(info[3]);
    args.push_back(info[4]);
    return MaybeUnwrap(func.Call(receiver, args));
+}
+
+Value CallWithReceiverAndVectorUsingCppWrapper(const CallbackInfo& info) {
+  Function func = info[0].As<Function>();
+  Value receiver = info[1];
+  std::vector<Value> args;
+  args.reserve(3);
+  args.push_back(info[2]);
+  args.push_back(info[3]);
+  args.push_back(info[4]);
+  return MaybeUnwrap(func.Call(receiver, args));
 }
 
 Value CallWithInvalidReceiver(const CallbackInfo& info) {
@@ -213,11 +234,15 @@ Object InitFunction(Env env) {
     Function::New(env, ValueCallbackWithData, nullptr, &testData);
   exports["callWithArgs"] = Function::New(env, CallWithArgs);
   exports["callWithVector"] = Function::New(env, CallWithVector);
+  exports["callWithVectorUsingCppWrapper"] =
+      Function::New(env, CallWithVectorUsingCppWrapper);
   exports["callWithCStyleArray"] = Function::New(env, CallWithCStyleArray);
   exports["callWithReceiverAndCStyleArray"] =
       Function::New(env, CallWithReceiverAndCStyleArray);
   exports["callWithReceiverAndArgs"] = Function::New(env, CallWithReceiverAndArgs);
   exports["callWithReceiverAndVector"] = Function::New(env, CallWithReceiverAndVector);
+  exports["callWithReceiverAndVectorUsingCppWrapper"] =
+      Function::New(env, CallWithReceiverAndVectorUsingCppWrapper);
   exports["callWithInvalidReceiver"] = Function::New(env, CallWithInvalidReceiver);
   exports["callConstructorWithArgs"] = Function::New(env, CallConstructorWithArgs);
   exports["callConstructorWithVector"] = Function::New(env, CallConstructorWithVector);
@@ -246,6 +271,8 @@ Object InitFunction(Env env) {
       Function::New<ValueCallbackWithData>(env, nullptr, &testData);
   exports["callWithArgs"] = Function::New<CallWithArgs>(env);
   exports["callWithVector"] = Function::New<CallWithVector>(env);
+  exports["callWithVectorUsingCppWrapper"] =
+      Function::New<CallWithVectorUsingCppWrapper>(env);
   exports["callWithCStyleArray"] = Function::New<CallWithCStyleArray>(env);
   exports["callWithReceiverAndCStyleArray"] =
       Function::New<CallWithReceiverAndCStyleArray>(env);
@@ -253,6 +280,8 @@ Object InitFunction(Env env) {
       Function::New<CallWithReceiverAndArgs>(env);
   exports["callWithReceiverAndVector"] =
       Function::New<CallWithReceiverAndVector>(env);
+  exports["callWithReceiverAndVectorUsingCppWrapper"] =
+      Function::New<CallWithReceiverAndVectorUsingCppWrapper>(env);
   exports["callWithInvalidReceiver"] =
       Function::New<CallWithInvalidReceiver>(env);
   exports["callConstructorWithArgs"] =

--- a/test/function.js
+++ b/test/function.js
@@ -49,6 +49,11 @@ function test(binding) {
   assert.strictEqual(receiver, undefined);
   assert.deepStrictEqual(args, [ 2, 3, 4 ]);
 
+  ret = 5;
+  assert.strictEqual(binding.callWithVectorUsingCppWrapper(testFunction, 2, 3, 4), 5);
+  assert.strictEqual(receiver, undefined);
+  assert.deepStrictEqual(args, [ 2, 3, 4 ]);
+
   ret = 6;
   assert.strictEqual(binding.callWithReceiverAndArgs(testFunction, obj, 3, 4, 5), 6);
   assert.deepStrictEqual(receiver, obj);
@@ -56,6 +61,11 @@ function test(binding) {
 
   ret = 7;
   assert.strictEqual(binding.callWithReceiverAndVector(testFunction, obj, 4, 5, 6), 7);
+  assert.deepStrictEqual(receiver, obj);
+  assert.deepStrictEqual(args, [ 4, 5, 6 ]);
+
+  ret = 7;
+  assert.strictEqual(binding.callWithReceiverAndVectorUsingCppWrapper(testFunction, obj, 4, 5, 6), 7);
   assert.deepStrictEqual(receiver, obj);
   assert.deepStrictEqual(args, [ 4, 5, 6 ]);
 

--- a/test/function.js
+++ b/test/function.js
@@ -8,81 +8,81 @@ module.exports = require('./common').runTest(binding => {
   testLambda(binding.function.lambda);
 });
 
-function test(binding) {
+function test (binding) {
   assert.strictEqual(binding.emptyConstructor(true), true);
   assert.strictEqual(binding.emptyConstructor(false), false);
 
   let obj = {};
   assert.deepStrictEqual(binding.voidCallback(obj), undefined);
-  assert.deepStrictEqual(obj, { "foo": "bar" });
+  assert.deepStrictEqual(obj, { foo: 'bar' });
 
-  assert.deepStrictEqual(binding.valueCallback(), { "foo": "bar" });
+  assert.deepStrictEqual(binding.valueCallback(), { foo: 'bar' });
 
   let args = null;
   let ret = null;
   let receiver = null;
-  function testFunction() {
+  function testFunction () {
     receiver = this;
     args = [].slice.call(arguments);
     return ret;
   }
-  function testConstructor() {
+  function testConstructor () {
     args = [].slice.call(arguments);
   }
 
-  function makeCallbackTestFunction(receiver, expectedOne, expectedTwo, expectedThree) {
-    return function callback(one, two, three) {
+  function makeCallbackTestFunction (receiver, expectedOne, expectedTwo, expectedThree) {
+    return function callback (one, two, three) {
       assert.strictEqual(this, receiver);
       assert.strictEqual(one, expectedOne);
       assert.strictEqual(two, expectedTwo);
       assert.strictEqual(three, expectedThree);
-    }
+    };
   }
 
   ret = 4;
   assert.strictEqual(binding.callWithArgs(testFunction, 1, 2, 3), 4);
   assert.strictEqual(receiver, undefined);
-  assert.deepStrictEqual(args, [ 1, 2, 3 ]);
+  assert.deepStrictEqual(args, [1, 2, 3]);
 
   ret = 5;
   assert.strictEqual(binding.callWithVector(testFunction, 2, 3, 4), 5);
   assert.strictEqual(receiver, undefined);
-  assert.deepStrictEqual(args, [ 2, 3, 4 ]);
+  assert.deepStrictEqual(args, [2, 3, 4]);
 
   ret = 5;
   assert.strictEqual(binding.callWithVectorUsingCppWrapper(testFunction, 2, 3, 4), 5);
   assert.strictEqual(receiver, undefined);
-  assert.deepStrictEqual(args, [ 2, 3, 4 ]);
+  assert.deepStrictEqual(args, [2, 3, 4]);
 
   ret = 6;
   assert.strictEqual(binding.callWithReceiverAndArgs(testFunction, obj, 3, 4, 5), 6);
   assert.deepStrictEqual(receiver, obj);
-  assert.deepStrictEqual(args, [ 3, 4, 5 ]);
+  assert.deepStrictEqual(args, [3, 4, 5]);
 
   ret = 7;
   assert.strictEqual(binding.callWithReceiverAndVector(testFunction, obj, 4, 5, 6), 7);
   assert.deepStrictEqual(receiver, obj);
-  assert.deepStrictEqual(args, [ 4, 5, 6 ]);
+  assert.deepStrictEqual(args, [4, 5, 6]);
 
   ret = 7;
   assert.strictEqual(binding.callWithReceiverAndVectorUsingCppWrapper(testFunction, obj, 4, 5, 6), 7);
   assert.deepStrictEqual(receiver, obj);
-  assert.deepStrictEqual(args, [ 4, 5, 6 ]);
+  assert.deepStrictEqual(args, [4, 5, 6]);
 
   ret = 8;
   assert.strictEqual(binding.callWithCStyleArray(testFunction, 5, 6, 7), ret);
   assert.deepStrictEqual(receiver, undefined);
-  assert.deepStrictEqual(args, [ 5, 6, 7 ]);
+  assert.deepStrictEqual(args, [5, 6, 7]);
 
   ret = 9;
   assert.strictEqual(binding.callWithReceiverAndCStyleArray(testFunction, obj, 6, 7, 8), ret);
   assert.deepStrictEqual(receiver, obj);
-  assert.deepStrictEqual(args, [ 6, 7, 8 ]);
+  assert.deepStrictEqual(args, [6, 7, 8]);
 
   ret = 10;
   assert.strictEqual(binding.callWithFunctionOperator(testFunction, 7, 8, 9), ret);
   assert.strictEqual(receiver, undefined);
-  assert.deepStrictEqual(args, [ 7, 8, 9 ]);
+  assert.deepStrictEqual(args, [7, 8, 9]);
 
   assert.throws(() => {
     binding.callWithInvalidReceiver();
@@ -90,33 +90,35 @@ function test(binding) {
 
   obj = binding.callConstructorWithArgs(testConstructor, 5, 6, 7);
   assert(obj instanceof testConstructor);
-  assert.deepStrictEqual(args, [ 5, 6, 7 ]);
+  assert.deepStrictEqual(args, [5, 6, 7]);
 
   obj = binding.callConstructorWithVector(testConstructor, 6, 7, 8);
   assert(obj instanceof testConstructor);
-  assert.deepStrictEqual(args, [ 6, 7, 8 ]);
+  assert.deepStrictEqual(args, [6, 7, 8]);
 
   obj = binding.callConstructorWithCStyleArray(testConstructor, 7, 8, 9);
   assert(obj instanceof testConstructor);
-  assert.deepStrictEqual(args, [ 7, 8, 9 ]);
+  assert.deepStrictEqual(args, [7, 8, 9]);
 
   obj = {};
   assert.deepStrictEqual(binding.voidCallbackWithData(obj), undefined);
-  assert.deepStrictEqual(obj, { "foo": "bar", "data": 1 });
+  assert.deepStrictEqual(obj, { foo: 'bar', data: 1 });
 
-  assert.deepStrictEqual(binding.valueCallbackWithData(), { "foo": "bar", "data": 1 });
+  assert.deepStrictEqual(binding.valueCallbackWithData(), { foo: 'bar', data: 1 });
 
   assert.strictEqual(binding.voidCallback.name, 'voidCallback');
   assert.strictEqual(binding.valueCallback.name, 'valueCallback');
 
-  let testConstructCall = undefined;
+  let testConstructCall;
   binding.isConstructCall((result) => { testConstructCall = result; });
   assert.ok(!testConstructCall);
+  /* eslint-disable no-new, new-cap */
   new binding.isConstructCall((result) => { testConstructCall = result; });
+  /* eslint-enable no-new, new-cap */
   assert.ok(testConstructCall);
 
   obj = {};
-  binding.makeCallbackWithArgs(makeCallbackTestFunction(obj, "1", "2", "3"), obj, "1", "2", "3");
+  binding.makeCallbackWithArgs(makeCallbackTestFunction(obj, '1', '2', '3'), obj, '1', '2', '3');
   binding.makeCallbackWithVector(makeCallbackTestFunction(obj, 4, 5, 6), obj, 4, 5, 6);
   binding.makeCallbackWithCStyleArray(makeCallbackTestFunction(obj, 7, 8, 9), obj, 7, 8, 9);
   assert.throws(() => {
@@ -124,7 +126,7 @@ function test(binding) {
   });
 }
 
-function testLambda(binding) {
+function testLambda (binding) {
   assert.ok(binding.lambdaWithNoCapture());
   assert.ok(binding.lambdaWithCapture());
   assert.ok(binding.lambdaWithMoveOnlyCapture());


### PR DESCRIPTION
Adds an override to Napi::Function::Call so that you can call it with a c-style array of Napi::Value's