### PR TITLE
doc: fix documentation about how to enable C++ exception

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -44,7 +44,7 @@ To use **Node-API** in a native module:
       "defines": [
         "_HAS_EXCEPTIONS=1"
       ],
-        "msvs_settings": {
+      "msvs_settings": {
         "VCCLCompilerTool": {
           "ExceptionHandling": 1
         },

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -39,14 +39,25 @@ To use **Node-API** in a native module:
 ```gyp
   'cflags!': [ '-fno-exceptions' ],
   'cflags_cc!': [ '-fno-exceptions' ],
-  'xcode_settings': {
-    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-    'CLANG_CXX_LIBRARY': 'libc++',
-    'MACOSX_DEPLOYMENT_TARGET': '10.7',
-  },
-  'msvs_settings': {
-    'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-  },
+  'conditions': [
+    ["OS=='win'", {
+      "defines": [
+        "_HAS_EXCEPTIONS=1"
+      ],
+        "msvs_settings": {
+        "VCCLCompilerTool": {
+          "ExceptionHandling": 1
+        },
+      },
+    }],
+    ["OS=='mac'", {
+      'xcode_settings': {
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      },
+    }],
+  ],
 ```
 
   Alternatively, disable use of C++ exceptions in Node-API:


### PR DESCRIPTION
This PR fixes the documentation about how to enbale C++ exception. The problem was identified the first time in this issue: https://github.com/nodejs/node-addon-api/issues/85. In Windows system is not enough add the following configuration on `binding.gyp`:
```
'msvs_settings': {
    'VCCLCompilerTool': { 'ExceptionHandling': 1 },
 },
```
but it's necessary override the defined `_HAS_EXCEPTIONS` macro and set it to 1. 
In the `common.gypi` (see:  https://github.com/nodejs/node/blob/master/common.gypi#L273) the `_HAS_EXCEPTIONS` has been set to 0 to make sure the STL doesn't try to use exceptions, but in the addons with the support for C++ it needs to be changed to 1 otherwise the exceptions system could be catch the wrong exception.
