### PR TITLE
test: fixed the way to enable C++ exceptions.

### DIFF
--- a/except.gypi
+++ b/except.gypi
@@ -2,15 +2,24 @@
   'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
   'cflags!': [ '-fno-exceptions' ],
   'cflags_cc!': [ '-fno-exceptions' ],
-  'msvs_settings': {
-    'VCCLCompilerTool': {
-      'ExceptionHandling': 1,
-      'EnablePREfast': 'true',
-    },
-  },
-  'xcode_settings': {
-    'CLANG_CXX_LIBRARY': 'libc++',
-    'MACOSX_DEPLOYMENT_TARGET': '10.7',
-    'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-  },
+  'conditions': [
+    ["OS=='win'", {
+      "defines": [
+        "_HAS_EXCEPTIONS=1"
+      ],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "ExceptionHandling": 1,
+          'EnablePREfast': 'true',
+        },
+      },
+    }],
+    ["OS=='mac'", {
+      'xcode_settings': {
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      },
+    }],
+  ],
 }

--- a/noexcept.gypi
+++ b/noexcept.gypi
@@ -2,15 +2,25 @@
   'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
   'cflags': [ '-fno-exceptions' ],
   'cflags_cc': [ '-fno-exceptions' ],
-  'msvs_settings': {
-    'VCCLCompilerTool': {
-      'ExceptionHandling': 0,
-      'EnablePREfast': 'true',
-    },
-  },
-  'xcode_settings': {
-    'CLANG_CXX_LIBRARY': 'libc++',
-    'MACOSX_DEPLOYMENT_TARGET': '10.7',
-    'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
-  },
+  'conditions': [
+    ["OS=='win'", {
+      # _HAS_EXCEPTIONS is already defined and set to 0 in common.gypi
+      #"defines": [
+      #  "_HAS_EXCEPTIONS=0"
+      #],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          'ExceptionHandling': 0,
+          'EnablePREfast': 'true',
+        },
+      },
+    }],
+    ["OS=='mac'", {
+      'xcode_settings': {
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',
+      },
+    }],
+  ],
 }


### PR DESCRIPTION
In this PR I changed the way we used to enable or disable the C++ expection support for the entire test suite. For more information about this change see the previous PR https://github.com/nodejs/node-addon-api/pull/1059. 
