### PR TITLE
src,test: allow creating Function with move-only functor

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <mutex>
 #include <type_traits>
+#include <utility>
 
 namespace Napi {
 
@@ -2154,7 +2155,7 @@ inline Function Function::New(napi_env env,
                               void* data) {
   using ReturnType = decltype(cb(CallbackInfo(nullptr, nullptr)));
   using CbData = details::CallbackData<Callable, ReturnType>;
-  auto callbackData = new CbData({ cb, data });
+  auto callbackData = new CbData{std::move(cb), data};
 
   napi_value value;
   napi_status status = CreateFunction(env,

--- a/test/function.cc
+++ b/test/function.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include "napi.h"
 #include "test_helper.h"
 
@@ -271,5 +272,24 @@ Object InitFunction(Env env) {
   exports["callWithFunctionOperator"] =
       Function::New<CallWithFunctionOperator>(env);
   result["templated"] = exports;
+
+  exports = Object::New(env);
+  exports["lambdaWithNoCapture"] =
+      Function::New(env, [](const CallbackInfo& info) {
+        auto env = info.Env();
+        return Boolean::New(env, true);
+      });
+  exports["lambdaWithCapture"] =
+      Function::New(env, [data = 42](const CallbackInfo& info) {
+        auto env = info.Env();
+        return Boolean::New(env, data == 42);
+      });
+  exports["lambdaWithMoveOnlyCapture"] = Function::New(
+      env, [data = std::make_unique<int>(42)](const CallbackInfo& info) {
+        auto env = info.Env();
+        return Boolean::New(env, *data == 42);
+      });
+  result["lambda"] = exports;
+
   return result;
 }

--- a/test/function.js
+++ b/test/function.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 module.exports = require('./common').runTest(binding => {
   test(binding.function.plain);
   test(binding.function.templated);
+  testLambda(binding.function.lambda);
 });
 
 function test(binding) {
@@ -111,4 +112,10 @@ function test(binding) {
   assert.throws(() => {
     binding.makeCallbackWithInvalidReceiver(() => {});
   });
+}
+
+function testLambda(binding) {
+  assert.ok(binding.lambdaWithNoCapture());
+  assert.ok(binding.lambdaWithCapture());
+  assert.ok(binding.lambdaWithMoveOnlyCapture());
 }


### PR DESCRIPTION
Function::New fails to compile when given a move-only functor. For
example, when constructing a callback function for Promise#then, a
lambda might capture an ObjectReference. Creating a Function for such a
lambda results in a compilation error.

Tweak Function::New to work with move-only functors.

For existing users of Function::New, this commit should not change
behavior.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
