### PR TITLE
src: fix casts to not be undefined behavior

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2046,7 +2046,7 @@ inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
   if (value != nullptr) {
     void* data = nullptr;
     status = napi_get_typedarray_info(
-      _env, _value, &_type, &_length, &data, nullptr, nullptr); 
+        _env, _value, &_type, &_length, &data, nullptr, nullptr); 
     _data = static_cast<T*>(data);
   } else {
     _type = TypedArrayTypeForPrimitiveType<T>();

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2046,7 +2046,7 @@ inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
   if (value != nullptr) {
     void* data = nullptr;
     status = napi_get_typedarray_info(
-        _env, _value, &_type, &_length, &data, nullptr, nullptr); 
+        _env, _value, &_type, &_length, &data, nullptr, nullptr);
     _data = static_cast<T*>(data);
   } else {
     _type = TypedArrayTypeForPrimitiveType<T>();

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2044,8 +2044,10 @@ inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
   : TypedArray(env, value), _data(nullptr) {
   napi_status status = napi_ok;
   if (value != nullptr) {
+    void* data = nullptr;
     status = napi_get_typedarray_info(
-      _env, _value, &_type, &_length, reinterpret_cast<void**>(&_data), nullptr, nullptr);
+      _env, _value, &_type, &_length, &data, nullptr, nullptr); 
+    _data = static_cast<T*>(data);
   } else {
     _type = TypedArrayTypeForPrimitiveType<T>();
     _length = 0;
@@ -3967,10 +3969,10 @@ inline ObjectWrap<T>::~ObjectWrap() {
 
 template<typename T>
 inline T* ObjectWrap<T>::Unwrap(Object wrapper) {
-  T* unwrapped;
-  napi_status status = napi_unwrap(wrapper.Env(), wrapper, reinterpret_cast<void**>(&unwrapped));
+  void* unwrapped;
+  napi_status status = napi_unwrap(wrapper.Env(), wrapper, &unwrapped);
   NAPI_THROW_IF_FAILED(wrapper.Env(), status, nullptr);
-  return unwrapped;
+  return static_cast<T*>(unwrapped);
 }
 
 template <typename T>


### PR DESCRIPTION
I guess if these were broken in practice, V8/Node.js itself would also
experience difficulties with it, but there’s no real reason not to use
the proper alternatives.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
