### PR TITLE
test: update compiler used for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,14 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - node/10
           - node/12
           - node/14
-          - node/15
           - node/16
         compiler:
           - gcc
           - clang
         os:
-          - ubuntu-16.04 # ubuntu-18.04/ubuntu-latest missing package g++-4.9
+          - ubuntu-18.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,7 +25,7 @@ jobs:
         if [ "${{ matrix.compiler }}" = "gcc" -a "${{ matrix.os }}" = ubuntu-* ]; then
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install g++-4.9
+          sudo apt-get install g++-6.5
         fi
     - name: Use Node.js ${{ matrix.node-version }}
       run: |
@@ -45,7 +43,7 @@ jobs:
           export CC="gcc" CXX="g++"
         fi
         if [ "${{ matrix.compiler }}" = "gcc" -a "${{ matrix.os }}" = ubuntu-* ]; then
-          export CC="gcc-4.9" CXX="g++-4.9" AR="gcc-ar-4.9" RANLIB="gcc-ranlib-4.9" NM="gcc-nm-4.9"
+          export CC="gcc-6.5" CXX="g++-6.5" AR="gcc-ar-6.5" RANLIB="gcc-ranlib-6.5" NM="gcc-nm-6.5"
         fi
         if [ "${{ matrix.compiler }}" = "clang" ]; then
           export CC="clang" CXX="clang++"


### PR DESCRIPTION
Looks like github no longer has ubuntu 16 so we'll
need to update the compiler and remove 10.x testing.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
