### PR TITLE
create tools/eslint-format

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: CLANG_FORMAT_START=refs/remotes/origin/main npm run lint
+    - run: FORMAT_START=refs/remotes/origin/main npm run lint

--- a/package.json
+++ b/package.json
@@ -377,8 +377,8 @@
     "predev:incremental": "node-gyp configure build -C test --debug",
     "dev:incremental": "node test",
     "doc": "doxygen doc/Doxyfile",
-    "lint": "eslint $(git diff --name-only refs/remotes/origin/main '**/*.js' | xargs) && node tools/clang-format",
-    "lint:fix": "node tools/clang-format --fix && eslint --fix $(git diff --cached --name-only '**/*.js' | xargs && git diff --name-only '**/*.js' | xargs)"
+    "lint": "node tools/eslint-format && node tools/clang-format",
+    "lint:fix": "node tools/clang-format --fix && node tools/eslint-format --fix"
   },
   "pre-commit": "lint",
   "version": "4.2.0",

--- a/tools/clang-format.js
+++ b/tools/clang-format.js
@@ -4,7 +4,7 @@ const spawn = require('child_process').spawnSync;
 const path = require('path');
 
 const filesToCheck = ['*.h', '*.cc'];
-const CLANG_FORMAT_START = process.env.CLANG_FORMAT_START || 'main';
+const FORMAT_START = process.env.FORMAT_START || 'main';
 
 function main (args) {
   let fix = false;
@@ -22,19 +22,17 @@ function main (args) {
   const clangFormatPath = path.dirname(require.resolve('clang-format'));
   const options = ['--binary=node_modules/.bin/clang-format', '--style=file'];
   if (fix) {
-    options.push(CLANG_FORMAT_START);
+    options.push(FORMAT_START);
   } else {
-    options.push('--diff', CLANG_FORMAT_START);
+    options.push('--diff', FORMAT_START);
   }
 
-  const gitClangFormatPath = path.join(clangFormatPath,
-    'bin/git-clang-format');
-  const result = spawn('python', [
-    gitClangFormatPath,
-    ...options,
-    '--',
-    ...filesToCheck
-  ], { encoding: 'utf-8' });
+  const gitClangFormatPath = path.join(clangFormatPath, 'bin/git-clang-format');
+  const result = spawn(
+    'python',
+    [gitClangFormatPath, ...options, '--', ...filesToCheck],
+    { encoding: 'utf-8' }
+  );
 
   if (result.stderr) {
     console.error('Error running git-clang-format:', result.stderr);
@@ -48,9 +46,11 @@ function main (args) {
     return 0;
   }
   // Detect if there is any complains from clang-format
-  if (clangFormatOutput !== '' &&
-      clangFormatOutput !== ('no modified files to format') &&
-      clangFormatOutput !== ('clang-format did not modify any files')) {
+  if (
+    clangFormatOutput !== '' &&
+    clangFormatOutput !== 'no modified files to format' &&
+    clangFormatOutput !== 'clang-format did not modify any files'
+  ) {
     console.error(clangFormatOutput);
     const fixCmd = 'npm run lint:fix';
     console.error(`
@@ -58,7 +58,7 @@ function main (args) {
         Note that when running the command locally, please keep your local
         main branch and working branch up to date with nodejs/node-addon-api
         to exclude un-related complains.
-        Or you can run "env CLANG_FORMAT_START=upstream/main ${fixCmd}".`);
+        Or you can run "env FORMAT_START=upstream/main ${fixCmd}".`);
     return 1;
   }
 }

--- a/tools/eslint-format.js
+++ b/tools/eslint-format.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const spawn = require('child_process').spawnSync;
+
+const filesToCheck = '*.js';
+const FORMAT_START = process.env.FORMAT_START || 'main';
+
+function main (args) {
+  let fix = false;
+  while (args.length > 0) {
+    switch (args[0]) {
+      case '-f':
+      case '--fix':
+        fix = true;
+        break;
+      default:
+    }
+    args.shift();
+  }
+
+  // Check js files that change on unstaged file
+  const fileUnStaged = spawn(
+    'git',
+    ['diff', '--name-only', FORMAT_START, filesToCheck],
+    {
+      encoding: 'utf-8'
+    }
+  );
+
+  // Check js files that change on staged file
+  const fileStaged = spawn(
+    'git',
+    ['diff', '--name-only', '--cached', FORMAT_START, filesToCheck],
+    {
+      encoding: 'utf-8'
+    }
+  );
+
+  const options = [
+    ...fileStaged.stdout.split('\n').filter((f) => f !== ''),
+    ...fileUnStaged.stdout.split('\n').filter((f) => f !== '')
+  ];
+
+  if (fix) {
+    options.push('--fix');
+  }
+  const result = spawn('node_modules/.bin/eslint', [...options], {
+    encoding: 'utf-8'
+  });
+
+  if (result.status === 1) {
+    console.error('Eslint error:', result.stdout);
+    const fixCmd = 'npm run lint:fix';
+    console.error(`ERROR: please run "${fixCmd}" to format changes in your commit
+    Note that when running the command locally, please keep your local
+    main branch and working branch up to date with nodejs/node-addon-api
+    to exclude un-related complains.
+    Or you can run "env FORMAT_START=upstream/main ${fixCmd}".
+    Also fix JS files by yourself if necessary.`);
+    return 1;
+  }
+
+  if (result.stderr) {
+    console.error('Error running eslint:', result.stderr);
+    return 2;
+  }
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Closes #1076 

# Tasks
- [x] Create the `tools/eslint-format.js` to has the same behavior with `tools/clang-format.js`.
- [ ] Using steps suggested by @mhdawson, update file by file to conform to new linter standard (discussed on #1063)

# Note
- I changed `CLANG_FORMAT_START` -> `FORMAT_START`

# Example
@mhdawson I created `tools/eslint-format.js` do you mind checking this one out? the example looks like this when pre-commit
```
Eslint error:
/Users/rubiagatra/github/node-addon-api/test/addon.js
  6:5  error  'a' is defined but never used  no-unused-vars

✖ 1 problem (1 error, 0 warnings)


ERROR: please run "npm run lint:fix" to format changes in your commit
    Note that when running the command locally, please keep your local
    main branch and working branch up to date with nodejs/node-addon-api
    to exclude un-related complains.
    Or you can run "env FORMAT_START=upstream/main npm run lint:fix".
    Also fix JS files by yourself if necessary.
pre-commit:
pre-commit: We've failed to pass the specified git pre-commit hooks as the `lint`
pre-commit: hook returned an exit code (1). If you're feeling adventurous you can
pre-commit: skip the git pre-commit hooks by adding the following flags to your commit:
pre-commit:
pre-commit:   git commit -n (or --no-verify)
pre-commit:
pre-commit: This is ill-advised since the commit is broken.
pre-commit:
```

