### PR TITLE
Remove `const` from `AsyncProgressWorker::Signal` and `AsyncProgressQueueWorker::Signal`

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -5877,8 +5877,8 @@ inline void AsyncProgressWorker<T>::Signal() {
   this->NonBlockingCall(static_cast<T*>(nullptr));
 }
 
-template<class T>
-inline void AsyncProgressWorker<T>::ExecutionProgress::Signal() {
+template <class T>
+inline void AsyncProgressWorker<T>::ExecutionProgress::Signal() const {
   _worker->Signal();
 }
 
@@ -5995,8 +5995,8 @@ inline void AsyncProgressQueueWorker<T>::OnWorkComplete(Napi::Env env, napi_stat
   AsyncProgressWorkerBase<std::pair<T*, size_t>>::OnWorkComplete(env, status);
 }
 
-template<class T>
-inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Signal() {
+template <class T>
+inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Signal() const {
   _worker->Signal();
 }
 

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -5873,12 +5873,12 @@ inline void AsyncProgressWorker<T>::SendProgress_(const T* data, size_t count) {
 }
 
 template<class T>
-inline void AsyncProgressWorker<T>::Signal() const {
+inline void AsyncProgressWorker<T>::Signal() {
   this->NonBlockingCall(static_cast<T*>(nullptr));
 }
 
 template<class T>
-inline void AsyncProgressWorker<T>::ExecutionProgress::Signal() const {
+inline void AsyncProgressWorker<T>::ExecutionProgress::Signal() {
   _worker->Signal();
 }
 
@@ -5985,7 +5985,7 @@ inline void AsyncProgressQueueWorker<T>::SendProgress_(const T* data, size_t cou
 }
 
 template<class T>
-inline void AsyncProgressQueueWorker<T>::Signal() const {
+inline void AsyncProgressQueueWorker<T>::Signal() {
   this->NonBlockingCall(nullptr);
 }
 
@@ -5996,7 +5996,7 @@ inline void AsyncProgressQueueWorker<T>::OnWorkComplete(Napi::Env env, napi_stat
 }
 
 template<class T>
-inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Signal() const {
+inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Signal() {
   _worker->Signal();
 }
 

--- a/napi.h
+++ b/napi.h
@@ -2871,7 +2871,7 @@ namespace Napi {
                                   const char* resource_name,
                                   const Object& resource);
 #endif
-     virtual void Execute(const ExecutionProgress& progress) = 0;
+     virtual void Execute(ExecutionProgress& progress) = 0;
      virtual void OnProgress(const T* data, size_t count) = 0;
 
     private:
@@ -2929,7 +2929,7 @@ namespace Napi {
                                        const char* resource_name,
                                        const Object& resource);
 #endif
-     virtual void Execute(const ExecutionProgress& progress) = 0;
+     virtual void Execute(ExecutionProgress& progress) = 0;
      virtual void OnProgress(const T* data, size_t count) = 0;
 
     private:

--- a/napi.h
+++ b/napi.h
@@ -2835,7 +2835,7 @@ namespace Napi {
      class ExecutionProgress {
         friend class AsyncProgressWorker;
        public:
-        void Signal() const;
+        void Signal();
         void Send(const T* data, size_t count) const;
        private:
         explicit ExecutionProgress(AsyncProgressWorker* worker) : _worker(worker) {}
@@ -2876,7 +2876,7 @@ namespace Napi {
 
     private:
      void Execute() override;
-     void Signal() const;
+     void Signal();
      void SendProgress_(const T* data, size_t count);
 
      std::mutex _mutex;
@@ -2892,7 +2892,7 @@ namespace Napi {
      class ExecutionProgress {
         friend class AsyncProgressQueueWorker;
        public:
-        void Signal() const;
+        void Signal();
         void Send(const T* data, size_t count) const;
        private:
         explicit ExecutionProgress(AsyncProgressQueueWorker* worker) : _worker(worker) {}
@@ -2934,7 +2934,7 @@ namespace Napi {
 
     private:
      void Execute() override;
-     void Signal() const;
+     void Signal();
      void SendProgress_(const T* data, size_t count);
   };
   #endif  // NAPI_VERSION > 3 && !defined(__wasm32__)

--- a/napi.h
+++ b/napi.h
@@ -2835,7 +2835,7 @@ namespace Napi {
      class ExecutionProgress {
         friend class AsyncProgressWorker;
        public:
-        void Signal();
+        void Signal() const;
         void Send(const T* data, size_t count) const;
        private:
         explicit ExecutionProgress(AsyncProgressWorker* worker) : _worker(worker) {}
@@ -2892,7 +2892,7 @@ namespace Napi {
      class ExecutionProgress {
         friend class AsyncProgressQueueWorker;
        public:
-        void Signal();
+        void Signal() const;
         void Send(const T* data, size_t count) const;
        private:
         explicit ExecutionProgress(AsyncProgressQueueWorker* worker) : _worker(worker) {}

--- a/napi.h
+++ b/napi.h
@@ -2871,7 +2871,7 @@ namespace Napi {
                                   const char* resource_name,
                                   const Object& resource);
 #endif
-     virtual void Execute(ExecutionProgress& progress) = 0;
+     virtual void Execute(const ExecutionProgress& progress) = 0;
      virtual void OnProgress(const T* data, size_t count) = 0;
 
     private:
@@ -2929,7 +2929,7 @@ namespace Napi {
                                        const char* resource_name,
                                        const Object& resource);
 #endif
-     virtual void Execute(ExecutionProgress& progress) = 0;
+     virtual void Execute(const ExecutionProgress& progress) = 0;
      virtual void OnProgress(const T* data, size_t count) = 0;
 
     private:

--- a/test/async_progress_queue_worker.cc
+++ b/test/async_progress_queue_worker.cc
@@ -35,7 +35,7 @@ class TestWorker : public AsyncProgressQueueWorker<ProgressData> {
   }
 
  protected:
-  void Execute(ExecutionProgress& progress) override {
+  void Execute(const ExecutionProgress& progress) override {
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(1s);
 
@@ -91,7 +91,7 @@ class SignalTestWorker : public AsyncProgressQueueWorker<ProgressData> {
   }
 
  protected:
-  void Execute(ExecutionProgress& progress) override {
+  void Execute(const ExecutionProgress& progress) override {
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(1s);
 

--- a/test/async_progress_queue_worker.cc
+++ b/test/async_progress_queue_worker.cc
@@ -96,8 +96,8 @@ class SignalTestWorker : public AsyncProgressQueueWorker<ProgressData> {
     std::this_thread::sleep_for(1s);
 
     for (int32_t idx = 0; idx < _times; idx++) {
-      // TODO: unlike AsyncProgressWorker, this signal does not trigger OnProgress() below, to run
-      // the JS callback. Investigate and fix.
+      // TODO: unlike AsyncProgressWorker, this signal does not trigger
+      // OnProgress() below, to run the JS callback. Investigate and fix.
       progress.Signal();
     }
   }
@@ -110,10 +110,10 @@ class SignalTestWorker : public AsyncProgressQueueWorker<ProgressData> {
 
  private:
   SignalTestWorker(Function cb,
-             Function progress,
-             const char* resource_name,
-             const Object& resource,
-             int32_t times)
+                   Function progress,
+                   const char* resource_name,
+                   const Object& resource,
+                   int32_t times)
       : AsyncProgressQueueWorker(cb, resource_name, resource), _times(times) {
     _js_progress_cb.Reset(progress, 1);
   }
@@ -128,7 +128,8 @@ Object InitAsyncProgressQueueWorker(Env env) {
   Object exports = Object::New(env);
   exports["createWork"] = Function::New(env, TestWorker::CreateWork);
   exports["queueWork"] = Function::New(env, TestWorker::QueueWork);
-  exports["createSignalWork"] = Function::New(env, SignalTestWorker::CreateWork);
+  exports["createSignalWork"] =
+      Function::New(env, SignalTestWorker::CreateWork);
   exports["queueSignalWork"] = Function::New(env, SignalTestWorker::QueueWork);
   return exports;
 }

--- a/test/async_progress_queue_worker.cc
+++ b/test/async_progress_queue_worker.cc
@@ -35,7 +35,7 @@ class TestWorker : public AsyncProgressQueueWorker<ProgressData> {
   }
 
  protected:
-  void Execute(const ExecutionProgress& progress) override {
+  void Execute(ExecutionProgress& progress) override {
     using namespace std::chrono_literals;
     std::this_thread::sleep_for(1s);
 

--- a/test/async_progress_queue_worker.js
+++ b/test/async_progress_queue_worker.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const common = require('./common')
+const common = require('./common');
 const assert = require('assert');
 
 module.exports = common.runTest(test);
 
-async function test({ asyncprogressqueueworker }) {
+async function test ({ asyncprogressqueueworker }) {
   await success(asyncprogressqueueworker);
   await fail(asyncprogressqueueworker);
   await signalTest(asyncprogressqueueworker);
 }
 
-function success(binding) {
+function success (binding) {
   return new Promise((resolve, reject) => {
     const expected = [0, 1, 2, 3];
     const actual = [];
@@ -33,11 +33,11 @@ function success(binding) {
   });
 }
 
-function fail(binding) {
+function fail (binding) {
   return new Promise((resolve, reject) => {
     const worker = binding.createWork(-1,
       common.mustCall((err) => {
-        assert.throws(() => { throw err }, /test error/);
+        assert.throws(() => { throw err; }, /test error/);
         resolve();
       }),
       common.mustNotCall()
@@ -46,7 +46,7 @@ function fail(binding) {
   });
 }
 
-function signalTest(binding) {
+function signalTest (binding) {
   return new Promise((resolve, reject) => {
     const expectedCalls = 4;
     let actualCalls = 0;

--- a/test/async_progress_queue_worker.js
+++ b/test/async_progress_queue_worker.js
@@ -8,6 +8,7 @@ module.exports = common.runTest(test);
 async function test({ asyncprogressqueueworker }) {
   await success(asyncprogressqueueworker);
   await fail(asyncprogressqueueworker);
+  await signalTest(asyncprogressqueueworker);
 }
 
 function success(binding) {
@@ -42,5 +43,27 @@ function fail(binding) {
       common.mustNotCall()
     );
     binding.queueWork(worker);
+  });
+}
+
+function signalTest(binding) {
+  return new Promise((resolve, reject) => {
+    const expectedCalls = 4;
+    let actualCalls = 0;
+    const worker = binding.createSignalWork(expectedCalls,
+      common.mustCall((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          if (actualCalls === expectedCalls) {
+            resolve();
+          }
+        }
+      }),
+      common.mustCall((_progress) => {
+        actualCalls++;
+      }, expectedCalls)
+    );
+    binding.queueSignalWork(worker);
   });
 }

--- a/test/async_progress_worker.cc
+++ b/test/async_progress_worker.cc
@@ -29,7 +29,7 @@ class TestWorker : public AsyncProgressWorker<ProgressData> {
   }
 
  protected:
-  void Execute(const ExecutionProgress& progress) override {
+  void Execute(ExecutionProgress& progress) override {
     if (_times < 0) {
       SetError("test error");
     }
@@ -77,7 +77,7 @@ class MalignWorker : public AsyncProgressWorker<ProgressData> {
   }
 
  protected:
-  void Execute(const ExecutionProgress& progress) override {
+  void Execute(ExecutionProgress& progress) override {
     std::unique_lock<std::mutex> lock(_cvm);
     // Testing a nullptr send is acceptable.
     progress.Send(nullptr, 0);

--- a/test/async_progress_worker.cc
+++ b/test/async_progress_worker.cc
@@ -29,7 +29,7 @@ class TestWorker : public AsyncProgressWorker<ProgressData> {
   }
 
  protected:
-  void Execute(ExecutionProgress& progress) override {
+  void Execute(const ExecutionProgress& progress) override {
     if (_times < 0) {
       SetError("test error");
     }
@@ -77,7 +77,7 @@ class MalignWorker : public AsyncProgressWorker<ProgressData> {
   }
 
  protected:
-  void Execute(ExecutionProgress& progress) override {
+  void Execute(const ExecutionProgress& progress) override {
     std::unique_lock<std::mutex> lock(_cvm);
     // Testing a nullptr send is acceptable.
     progress.Send(nullptr, 0);
@@ -137,7 +137,7 @@ class SignalTestWorker : public AsyncProgressWorker<ProgressData> {
   }
 
  protected:
-  void Execute(ExecutionProgress& progress) override {
+  void Execute(const ExecutionProgress& progress) override {
     if (_times < 0) {
       SetError("test error");
     }

--- a/test/async_progress_worker.js
+++ b/test/async_progress_worker.js
@@ -9,6 +9,7 @@ async function test({ asyncprogressworker }) {
   await success(asyncprogressworker);
   await fail(asyncprogressworker);
   await malignTest(asyncprogressworker);
+  await signalTest(asyncprogressworker);
 }
 
 function success(binding) {
@@ -56,6 +57,26 @@ function malignTest(binding) {
       common.mustCallAtLeast((error, reason) => {
         assert(!error, reason);
       }, 1)
+    );
+  });
+}
+
+function signalTest (binding) {
+  return new Promise((resolve, reject) => {
+    const expectedCalls = 3;
+    let actualCalls = 0;
+    binding.doWork(expectedCalls,
+      common.mustCall((err) => {
+        if (err) {
+          reject(err);
+        }
+      }),
+      common.mustCall((_progress) => {
+        actualCalls++;
+        if (expectedCalls === actualCalls) {
+          resolve();
+        }
+      }, expectedCalls)
     );
   });
 }

--- a/test/async_progress_worker.js
+++ b/test/async_progress_worker.js
@@ -65,7 +65,7 @@ function signalTest (binding) {
   return new Promise((resolve, reject) => {
     const expectedCalls = 3;
     let actualCalls = 0;
-    binding.doWork(expectedCalls,
+    binding.doSignalTest(expectedCalls,
       common.mustCall((err) => {
         if (err) {
           reject(err);

--- a/test/async_progress_worker.js
+++ b/test/async_progress_worker.js
@@ -1,18 +1,18 @@
 'use strict';
 
-const common = require('./common')
+const common = require('./common');
 const assert = require('assert');
 
 module.exports = common.runTest(test);
 
-async function test({ asyncprogressworker }) {
+async function test ({ asyncprogressworker }) {
   await success(asyncprogressworker);
   await fail(asyncprogressworker);
   await malignTest(asyncprogressworker);
   await signalTest(asyncprogressworker);
 }
 
-function success(binding) {
+function success (binding) {
   return new Promise((resolve, reject) => {
     const expected = [0, 1, 2, 3];
     const actual = [];
@@ -33,11 +33,11 @@ function success(binding) {
   });
 }
 
-function fail(binding) {
+function fail (binding) {
   return new Promise((resolve) => {
     binding.doWork(-1,
       common.mustCall((err) => {
-        assert.throws(() => { throw err }, /test error/)
+        assert.throws(() => { throw err; }, /test error/);
         resolve();
       }),
       common.mustNotCall()
@@ -45,7 +45,7 @@ function fail(binding) {
   });
 }
 
-function malignTest(binding) {
+function malignTest (binding) {
   return new Promise((resolve, reject) => {
     binding.doMalignTest(
       common.mustCall((err) => {


### PR DESCRIPTION
This PR fixes #1081 by removing `const` from the `AsyncProgressWorker::Signal` and `AsyncProgressQueueWorker::Signal` methods, and also from the `ExecutionProgress` parameter of the `Execute` method (this one might be a breaking change).

Also added a test for the `AsyncProgressWorker::Signal`. ~`AsyncProgressQueueWorker::Signal` needs to be tested as well.~ EDIT: Test added, but `AsyncProgressQueueWorker::Signal()` [doesn't work](https://github.com/nodejs/node-addon-api/blob/6074571004eae11b7d5c750f587b4e79a1533288/test/async_progress_queue_worker.cc#L99-L100), needs fixing.