### PR TITLE
doc: add blurb about SetInstanceData

### DIFF
--- a/doc/addon.md
+++ b/doc/addon.md
@@ -90,6 +90,12 @@ to either attach methods, accessors, and/or values to the `exports` object or to
 create its own `exports` object and attach methods, accessors, and/or values to
 it.
 
+**Note:** `Napi::Addon<T>` uses `Napi::Env::SetInstanceData()` internally. This
+means that the add-on should only use `Napi::Env::GetInstanceData` explicitly to
+retrieve the instance of the `Napi::Addon<T>` class. Variables whose scope would
+otherwise be global should be stored as instance variables in the
+`Napi::Addon<T>` class.
+
 Functions created with `Napi::Function::New()`, accessors created with
 `PropertyDescriptor::Accessor()`, and values can also be attached. If their
 implementation requires the `ExampleAddon` instance, it can be retrieved from


### PR DESCRIPTION
Add a blurb explaining that using `Napi::Addon<T>` entails avoiding the
use of `Napi::Env::SetInstanceData()`.

Fixes: https://github.com/nodejs/node-addon-api/issues/1097

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
