### PR TITLE
src: do not use non-static class member for constant value

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2607,8 +2607,8 @@ inline Error::Error(napi_env env, napi_value value) : ObjectReference(env, nullp
 
       // property flag that we attach to show the error object is wrapped
       napi_property_descriptor wrapObjFlag = {
-          ERROR_WRAP_VALUE,  // Unique GUID identifier since Symbol isn't a
-                             // viable option
+          ERROR_WRAP_VALUE(),  // Unique GUID identifier since Symbol isn't a
+                               // viable option
           nullptr,
           nullptr,
           nullptr,
@@ -2648,15 +2648,17 @@ inline Object Error::Value() const {
     // We are checking if the object is wrapped
     bool isWrappedObject = false;
 
-    status = napi_has_property(
-        _env, refValue, String::From(_env, ERROR_WRAP_VALUE), &isWrappedObject);
+    status = napi_has_property(_env,
+                               refValue,
+                               String::From(_env, ERROR_WRAP_VALUE()),
+                               &isWrappedObject);
 
     // Don't care about status
     if (isWrappedObject) {
       napi_value unwrappedValue;
       status = napi_get_property(_env,
                                  refValue,
-                                 String::From(_env, ERROR_WRAP_VALUE),
+                                 String::From(_env, ERROR_WRAP_VALUE()),
                                  &unwrappedValue);
       NAPI_THROW_IF_FAILED(_env, status, Object());
 
@@ -2771,6 +2773,10 @@ inline const char* Error::what() const NAPI_NOEXCEPT {
 }
 
 #endif // NAPI_CPP_EXCEPTIONS
+
+inline const char* Error::ERROR_WRAP_VALUE() NAPI_NOEXCEPT {
+  return "4bda9e7e-4913-4dbc-95de-891cbf66598e-errorVal";
+}
 
 template <typename TError>
 inline TError Error::New(napi_env env,

--- a/napi.h
+++ b/napi.h
@@ -1720,8 +1720,7 @@ namespace Napi {
    /// !endcond
 
   private:
-   const char* ERROR_WRAP_VALUE =
-       "4bda9e7e-4913-4dbc-95de-891cbf66598e-errorVal";
+   static inline const char* ERROR_WRAP_VALUE() NAPI_NOEXCEPT;
    mutable std::string _message;
   };
 


### PR DESCRIPTION
Non-static class members need to be set for each instantiated
object and take up extra space, which is why constant data
is generally provided through static members or static functions
(and static functions are a bit easier to use in header-only C++11).

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
