### PR TITLE
src: enable wrapping Napi namespace with custom namespace

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -18,6 +18,10 @@
 
 namespace Napi {
 
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+namespace NAPI_CPP_CUSTOM_NAMESPACE {
+#endif
+
 // Helpers to handle functions exposed from C++.
 namespace details {
 
@@ -6212,6 +6216,10 @@ bool Env::CleanupHook<Hook, Arg>::IsEmpty() const {
   return data == nullptr;
 }
 #endif  // NAPI_VERSION > 2
+
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+}  // namespace NAPI_CPP_CUSTOM_NAMESPACE
+#endif
 
 } // namespace Napi
 

--- a/napi.h
+++ b/napi.h
@@ -140,6 +140,18 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 ////////////////////////////////////////////////////////////////////////////////
 namespace Napi {
 
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+// NAPI_CPP_CUSTOM_NAMESPACE can be #define'd per-addon to avoid symbol
+// conflicts between different instances of node-addon-api
+
+// First dummy definition of the namespace to make sure that Napi::(name) still
+// refers to the right things inside this file.
+namespace NAPI_CPP_CUSTOM_NAMESPACE {}
+using namespace NAPI_CPP_CUSTOM_NAMESPACE;
+
+namespace NAPI_CPP_CUSTOM_NAMESPACE {
+#endif
+
   // Forward declarations
   class Env;
   class Value;
@@ -2976,6 +2988,10 @@ namespace Napi {
     Object entry_point_;
   };
 #endif  // NAPI_VERSION > 5
+
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+  }  // namespace NAPI_CPP_CUSTOM_NAMESPACE
+#endif
 
 } // namespace Napi
 

--- a/package.json
+++ b/package.json
@@ -323,7 +323,6 @@
       "name": "WenheLI",
       "url": "https://github.com/WenheLI"
     },
-
     {
       "name": "Yohei Kishimoto",
       "url": "https://github.com/morokosi"

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -114,5 +114,11 @@
       'sources': ['>@(build_sources_swallowexcept)'],
       'defines': ['NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS']
     },
+    {
+      'target_name': 'binding_custom_namespace',
+      'includes': ['../noexcept.gypi'],
+      'sources': ['>@(build_sources)'],
+      'defines': ['NAPI_CPP_CUSTOM_NAMESPACE=cstm']
+    },
   ],
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -81,7 +81,8 @@ exports.runTest = async function (test, buildType, buildPathRoot = process.env.B
   const bindings = [
     path.join(buildPathRoot, `../build/${buildType}/binding.node`),
     path.join(buildPathRoot, `../build/${buildType}/binding_noexcept.node`),
-    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept_maybe.node`)
+    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept_maybe.node`),
+    path.join(buildPathRoot, `../build/${buildType}/binding_custom_namespace.node`)
   ].map(it => require.resolve(it));
 
   for (const item of bindings) {
@@ -96,7 +97,8 @@ exports.runTestWithBindingPath = async function (test, buildType, buildPathRoot 
   const bindings = [
     path.join(buildPathRoot, `../build/${buildType}/binding.node`),
     path.join(buildPathRoot, `../build/${buildType}/binding_noexcept.node`),
-    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept_maybe.node`)
+    path.join(buildPathRoot, `../build/${buildType}/binding_noexcept_maybe.node`),
+    path.join(buildPathRoot, `../build/${buildType}/binding_custom_namespace.node`)
   ].map(it => require.resolve(it));
 
   for (const item of bindings) {

--- a/test/common/test_helper.h
+++ b/test/common/test_helper.h
@@ -3,6 +3,12 @@
 
 namespace Napi {
 
+// Needs this here since the MaybeUnwrap() functions need to be in the
+// same namespace as their arguments for C++ argument-dependent lookup
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+namespace NAPI_CPP_CUSTOM_NAMESPACE {
+#endif
+
 // Use this when a variable or parameter is unused in order to explicitly
 // silence a compiler warning about that.
 template <typename T>
@@ -57,5 +63,9 @@ inline bool MaybeUnwrapTo(MaybeOrValue<T> maybe, T* out) {
   return true;
 #endif
 }
+
+#ifdef NAPI_CPP_CUSTOM_NAMESPACE
+}  // namespace NAPI_CPP_CUSTOM_NAMESPACE
+#endif
 
 }  // namespace Napi

--- a/test/error_terminating_environment.js
+++ b/test/error_terminating_environment.js
@@ -70,6 +70,7 @@ test(`./build/${buildType}/binding.node`, true);
 test(`./build/${buildType}/binding_noexcept.node`, true);
 test(`./build/${buildType}/binding_swallowexcept.node`, false);
 test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
+test(`./build/${buildType}/binding_custom_namespace.node`, true);
 
 function test(bindingPath, process_should_abort) {
   const number_of_test_cases = 5;

--- a/unit-test/binding.gyp
+++ b/unit-test/binding.gyp
@@ -11,23 +11,23 @@
   },
   'targets': [
     {
-			"target_name": "generateBindingCC",
-			"type": "none",
-			"actions": [ {
-				"action_name": "generateBindingCC",
-				"message": "Generating binding cc file",
-				"outputs": ["generated/binding.cc"],
-				"conditions": [
-					[ "'true'=='true'", {
-						"inputs": [""],
-						"action": [
-							"node",
-							"generate-binding-cc.js",
+      "target_name": "generateBindingCC",
+      "type": "none",
+      "actions": [ {
+        "action_name": "generateBindingCC",
+        "message": "Generating binding cc file",
+        "outputs": ["generated/binding.cc"],
+        "conditions": [
+          [ "'true'=='true'", {
+            "inputs": [""],
+            "action": [
+              "node",
+              "generate-binding-cc.js",
               "<!@(node -p \"require('./injectTestParams').filesForBinding()\" )"
-						]
-					} ]
-				]
-			} ]
+            ]
+          } ]
+        ]
+      } ]
     },
     {
       'target_name': 'binding',
@@ -59,6 +59,13 @@
       'includes': ['../noexcept.gypi'],
       'sources': ['>@(build_sources)'],
       'defines': ['NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS'],
+      'dependencies': [ 'generateBindingCC' ]
+    },
+    {
+      'target_name': 'binding_custom_namespace',
+      'includes': ['../noexcept.gypi'],
+      'sources': ['>@(build_sources)'],
+      'defines': ['NAPI_CPP_CUSTOM_NAMESPACE=cstm'],
       'dependencies': [ 'generateBindingCC' ]
     },
   ],


### PR DESCRIPTION
Enable support for a `NAPI_CPP_CUSTOM_NAMESPACE` that would wrap
the `Napi` namespace in a custom namespace.

This can be helpful when there are multiple parts of a compiled
shared library or executable that depend on `node-addon-api`,
but different versions of it. In order to avoid symbol conflicts
in these cases, namespacing can be used to make sure that the
linker would not merge definitions that the compiler potentially
generates for the node-addon-api methods.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
