### PR TITLE
Enable running pre-commit ClangFormat on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /benchmark/build
 /benchmark/src
 /test/addon_build/addons
+/.vscode

--- a/tools/clang-format.js
+++ b/tools/clang-format.js
@@ -20,7 +20,10 @@ function main (args) {
   }
 
   const clangFormatPath = path.dirname(require.resolve('clang-format'));
-  const options = ['--binary=node_modules/.bin/clang-format', '--style=file'];
+  const binary = process.platform === 'win32'
+    ? 'node_modules\\.bin\\clang-format.cmd'
+    : 'node_modules/.bin/clang-format';
+  const options = ['--binary=' + binary, '--style=file'];
   if (fix) {
     options.push(FORMAT_START);
   } else {


### PR DESCRIPTION
When we do a Git commit locally, we automatically run clang-format to ensure proper code formatting.
Unfortunately, the current code doesn't work correctly on Windows.

This PR addresses the issue by detecting the Window OS and adjusting the target binary for clang-format.

There is also a small adjustment to the `.gitignore` file to ignore VS Code local settings.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
