### PR TITLE
doc: clarify ObjectWrap weak ref behavior

### DIFF
--- a/doc/object_wrap.md
+++ b/doc/object_wrap.md
@@ -16,6 +16,10 @@ be directly invoked from JavaScript. The **wrap** word refers to a way of
 grouping methods and state of the class because it will be necessary write
 custom code to bridge each of your C++ class methods.
 
+**Caution:** When the JavaScript object is garbage collected, the call to the
+C++ destructor may be deferred until a later time. Within that period,
+`Value()` will return an empty value.
+
 ## Example
 
 ```cpp


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/42461

We currently defer finalizer callbacks until the loop is idle.

Warn users that the weak reference on `ObjectWrap` isn't guaranteed to be valid just because the object hasn't been finalized (destructed) yet.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
