### PR TITLE
Remove redundant string creation for PropertyLValue's _key when `object["bar"] = 1`

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1298,9 +1298,9 @@ inline Object::Object() : Value() {
 inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
 }
 
-inline Object::PropertyLValue<std::string> Object::operator[](
+inline Object::PropertyLValue<const char*> Object::operator[](
     const char* utf8name) const {
-  return PropertyLValue<std::string>(*this, utf8name);
+  return PropertyLValue<const char*>(*this, utf8name);
 }
 
 inline Object::PropertyLValue<std::string> Object::operator[](

--- a/napi.h
+++ b/napi.h
@@ -740,7 +740,7 @@ namespace NAPI_CPP_CUSTOM_NAMESPACE {
            napi_value value);  ///< Wraps a Node-API value primitive.
 
     /// Gets or sets a named property.
-    PropertyLValue<std::string> operator[](
+    PropertyLValue<const char*> operator[](
         const char* utf8name  ///< UTF-8 encoded null-terminated property name
     ) const;
 


### PR DESCRIPTION
Could we change
```cpp
inline Object::PropertyLValue<string> Object::operator[](
    const char* utf8name) const {
  return PropertyLValue<string>(*this, utf8name);
}
```

to

```cpp
inline Object::PropertyLValue<const char*> Object::operator[](
    const char* utf8name) const {
  return PropertyLValue<const char*>(*this, utf8name);
}
```

so that no redundant string will be created for PropertyLValue's _key?

```cpp
template <typename Key>
class PropertyLValue {
public:
  /// Converts an L-value to a value.
  operator Value() const;

  /// Assigns a value to the property. The type of value can be
  /// anything supported by `Object::Set`.
  template <typename ValueType>
  PropertyLValue& operator =(ValueType value);

private:
  PropertyLValue() = delete;
  PropertyLValue(Object object, Key key);
  napi_env _env;
  napi_value _object;
  Key _key;

  friend class Napi::Object;
};
```

Subsequent `Object::Set` and `napi_set_named_property` also supports passing `const char*` directly

```cpp
template <typename Key> template <typename ValueType>
inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(ValueType value) {
#ifdef NODE_ADDON_API_ENABLE_MAYBE
  MaybeOrValue<bool> result =
#endif
      Object(_env, _object).Set(_key, value);
#ifdef NODE_ADDON_API_ENABLE_MAYBE
  result.Unwrap();
#endif
  return *this;
}
```

```cpp
template <typename ValueType>
inline MaybeOrValue<bool> Object::Set(const char* utf8name,
                                      const ValueType& value) const {
  napi_status status =
      napi_set_named_property(_env, _value, utf8name, Value::From(_env, value));
  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
}
```

