### PR TITLE
Format all code

### DIFF
--- a/benchmark/function_args.cc
+++ b/benchmark/function_args.cc
@@ -1,8 +1,8 @@
 #include "napi.h"
 
 static napi_value NoArgFunction_Core(napi_env env, napi_callback_info info) {
-  (void) env;
-  (void) info;
+  (void)env;
+  (void)info;
   return nullptr;
 }
 
@@ -12,7 +12,7 @@ static napi_value OneArgFunction_Core(napi_env env, napi_callback_info info) {
   if (napi_get_cb_info(env, info, &argc, &argv, nullptr, nullptr) != napi_ok) {
     return nullptr;
   }
-  (void) argv;
+  (void)argv;
   return nullptr;
 }
 
@@ -22,8 +22,8 @@ static napi_value TwoArgFunction_Core(napi_env env, napi_callback_info info) {
   if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok) {
     return nullptr;
   }
-  (void) argv[0];
-  (void) argv[1];
+  (void)argv[0];
+  (void)argv[1];
   return nullptr;
 }
 
@@ -33,9 +33,9 @@ static napi_value ThreeArgFunction_Core(napi_env env, napi_callback_info info) {
   if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok) {
     return nullptr;
   }
-  (void) argv[0];
-  (void) argv[1];
-  (void) argv[2];
+  (void)argv[0];
+  (void)argv[1];
+  (void)argv[2];
   return nullptr;
 }
 
@@ -45,95 +45,128 @@ static napi_value FourArgFunction_Core(napi_env env, napi_callback_info info) {
   if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok) {
     return nullptr;
   }
-  (void) argv[0];
-  (void) argv[1];
-  (void) argv[2];
-  (void) argv[3];
+  (void)argv[0];
+  (void)argv[1];
+  (void)argv[2];
+  (void)argv[3];
   return nullptr;
 }
 
 static void NoArgFunction(const Napi::CallbackInfo& info) {
-  (void) info;
+  (void)info;
 }
 
 static void OneArgFunction(const Napi::CallbackInfo& info) {
-  Napi::Value argv0 = info[0]; (void) argv0;
+  Napi::Value argv0 = info[0];
+  (void)argv0;
 }
 
 static void TwoArgFunction(const Napi::CallbackInfo& info) {
-  Napi::Value argv0 = info[0]; (void) argv0;
-  Napi::Value argv1 = info[1]; (void) argv1;
+  Napi::Value argv0 = info[0];
+  (void)argv0;
+  Napi::Value argv1 = info[1];
+  (void)argv1;
 }
 
 static void ThreeArgFunction(const Napi::CallbackInfo& info) {
-  Napi::Value argv0 = info[0]; (void) argv0;
-  Napi::Value argv1 = info[1]; (void) argv1;
-  Napi::Value argv2 = info[2]; (void) argv2;
+  Napi::Value argv0 = info[0];
+  (void)argv0;
+  Napi::Value argv1 = info[1];
+  (void)argv1;
+  Napi::Value argv2 = info[2];
+  (void)argv2;
 }
 
 static void FourArgFunction(const Napi::CallbackInfo& info) {
-  Napi::Value argv0 = info[0]; (void) argv0;
-  Napi::Value argv1 = info[1]; (void) argv1;
-  Napi::Value argv2 = info[2]; (void) argv2;
-  Napi::Value argv3 = info[3]; (void) argv3;
+  Napi::Value argv0 = info[0];
+  (void)argv0;
+  Napi::Value argv1 = info[1];
+  (void)argv1;
+  Napi::Value argv2 = info[2];
+  (void)argv2;
+  Napi::Value argv3 = info[3];
+  (void)argv3;
 }
 
 #if NAPI_VERSION > 5
 class FunctionArgsBenchmark : public Napi::Addon<FunctionArgsBenchmark> {
  public:
   FunctionArgsBenchmark(Napi::Env env, Napi::Object exports) {
-    DefineAddon(exports, {
-      InstanceValue("addon", DefineProperties(Napi::Object::New(env), {
-        InstanceMethod("noArgFunction", &FunctionArgsBenchmark::NoArgFunction),
-        InstanceMethod("oneArgFunction",
-                       &FunctionArgsBenchmark::OneArgFunction),
-        InstanceMethod("twoArgFunction",
-                       &FunctionArgsBenchmark::TwoArgFunction),
-        InstanceMethod("threeArgFunction",
-                       &FunctionArgsBenchmark::ThreeArgFunction),
-        InstanceMethod("fourArgFunction",
-                       &FunctionArgsBenchmark::FourArgFunction),
-      }), napi_enumerable),
-      InstanceValue("addon_templated",
-        DefineProperties(Napi::Object::New(env), {
-          InstanceMethod<&FunctionArgsBenchmark::NoArgFunction>(
-                                                            "noArgFunction"),
-          InstanceMethod<&FunctionArgsBenchmark::OneArgFunction>(
-                                                            "oneArgFunction"),
-          InstanceMethod<&FunctionArgsBenchmark::TwoArgFunction>(
-                                                            "twoArgFunction"),
-          InstanceMethod<&FunctionArgsBenchmark::ThreeArgFunction>(
-                                                            "threeArgFunction"),
-          InstanceMethod<&FunctionArgsBenchmark::FourArgFunction>(
-                                                            "fourArgFunction"),
-        }), napi_enumerable),
-    });
-  }
- private:
-  void NoArgFunction(const Napi::CallbackInfo& info) {
-    (void) info;
+    DefineAddon(
+        exports,
+        {
+            InstanceValue(
+                "addon",
+                DefineProperties(
+                    Napi::Object::New(env),
+                    {
+                        InstanceMethod("noArgFunction",
+                                       &FunctionArgsBenchmark::NoArgFunction),
+                        InstanceMethod("oneArgFunction",
+                                       &FunctionArgsBenchmark::OneArgFunction),
+                        InstanceMethod("twoArgFunction",
+                                       &FunctionArgsBenchmark::TwoArgFunction),
+                        InstanceMethod(
+                            "threeArgFunction",
+                            &FunctionArgsBenchmark::ThreeArgFunction),
+                        InstanceMethod("fourArgFunction",
+                                       &FunctionArgsBenchmark::FourArgFunction),
+                    }),
+                napi_enumerable),
+            InstanceValue(
+                "addon_templated",
+                DefineProperties(
+                    Napi::Object::New(env),
+                    {
+                        InstanceMethod<&FunctionArgsBenchmark::NoArgFunction>(
+                            "noArgFunction"),
+                        InstanceMethod<&FunctionArgsBenchmark::OneArgFunction>(
+                            "oneArgFunction"),
+                        InstanceMethod<&FunctionArgsBenchmark::TwoArgFunction>(
+                            "twoArgFunction"),
+                        InstanceMethod<
+                            &FunctionArgsBenchmark::ThreeArgFunction>(
+                            "threeArgFunction"),
+                        InstanceMethod<&FunctionArgsBenchmark::FourArgFunction>(
+                            "fourArgFunction"),
+                    }),
+                napi_enumerable),
+        });
   }
 
+ private:
+  void NoArgFunction(const Napi::CallbackInfo& info) { (void)info; }
+
   void OneArgFunction(const Napi::CallbackInfo& info) {
-    Napi::Value argv0 = info[0]; (void) argv0;
+    Napi::Value argv0 = info[0];
+    (void)argv0;
   }
 
   void TwoArgFunction(const Napi::CallbackInfo& info) {
-    Napi::Value argv0 = info[0]; (void) argv0;
-    Napi::Value argv1 = info[1]; (void) argv1;
+    Napi::Value argv0 = info[0];
+    (void)argv0;
+    Napi::Value argv1 = info[1];
+    (void)argv1;
   }
 
   void ThreeArgFunction(const Napi::CallbackInfo& info) {
-    Napi::Value argv0 = info[0]; (void) argv0;
-    Napi::Value argv1 = info[1]; (void) argv1;
-    Napi::Value argv2 = info[2]; (void) argv2;
+    Napi::Value argv0 = info[0];
+    (void)argv0;
+    Napi::Value argv1 = info[1];
+    (void)argv1;
+    Napi::Value argv2 = info[2];
+    (void)argv2;
   }
 
   void FourArgFunction(const Napi::CallbackInfo& info) {
-    Napi::Value argv0 = info[0]; (void) argv0;
-    Napi::Value argv1 = info[1]; (void) argv1;
-    Napi::Value argv2 = info[2]; (void) argv2;
-    Napi::Value argv3 = info[3]; (void) argv3;
+    Napi::Value argv0 = info[0];
+    (void)argv0;
+    Napi::Value argv1 = info[1];
+    (void)argv1;
+    Napi::Value argv2 = info[2];
+    (void)argv2;
+    Napi::Value argv3 = info[3];
+    (void)argv3;
   }
 };
 #endif  // NAPI_VERSION > 5

--- a/benchmark/function_args.js
+++ b/benchmark/function_args.js
@@ -2,7 +2,7 @@ const path = require('path');
 const Benchmark = require('benchmark');
 const addonName = path.basename(__filename, '.js');
 
-[ addonName, addonName + '_noexcept' ]
+[addonName, addonName + '_noexcept']
   .forEach((addonName) => {
     const rootAddon = require('bindings')({
       bindings: addonName,
@@ -20,7 +20,7 @@ const addonName = path.basename(__filename, '.js');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].noArgFunction;
       return suite.add(implem.padStart(maxNameLength, ' '), () => fn());
-    }, new Benchmark.Suite)
+    }, new Benchmark.Suite())
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
 
@@ -28,7 +28,7 @@ const addonName = path.basename(__filename, '.js');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].oneArgFunction;
       return suite.add(implem.padStart(maxNameLength, ' '), () => fn('x'));
-    }, new Benchmark.Suite)
+    }, new Benchmark.Suite())
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
 
@@ -36,7 +36,7 @@ const addonName = path.basename(__filename, '.js');
     implems.reduce((suite, implem) => {
       const fn = rootAddon[implem].twoArgFunction;
       return suite.add(implem.padStart(maxNameLength, ' '), () => fn('x', 12));
-    }, new Benchmark.Suite)
+    }, new Benchmark.Suite())
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
 
@@ -45,7 +45,7 @@ const addonName = path.basename(__filename, '.js');
       const fn = rootAddon[implem].threeArgFunction;
       return suite.add(implem.padStart(maxNameLength, ' '),
         () => fn('x', 12, true));
-    }, new Benchmark.Suite)
+    }, new Benchmark.Suite())
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
 
@@ -54,7 +54,7 @@ const addonName = path.basename(__filename, '.js');
       const fn = rootAddon[implem].fourArgFunction;
       return suite.add(implem.padStart(maxNameLength, ' '),
         () => fn('x', 12, true, anObject));
-    }, new Benchmark.Suite)
+    }, new Benchmark.Suite())
       .on('cycle', (event) => console.log(String(event.target)))
       .run();
   });

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 let benchmarks = [];
 
-if (!!process.env.npm_config_benchmarks) {
+if (process.env.npm_config_benchmarks) {
   benchmarks = process.env.npm_config_benchmarks
     .split(';')
     .map((item) => (item + '.js'));

--- a/benchmark/property_descriptor.cc
+++ b/benchmark/property_descriptor.cc
@@ -1,7 +1,7 @@
 #include "napi.h"
 
 static napi_value Getter_Core(napi_env env, napi_callback_info info) {
-  (void) info;
+  (void)info;
   napi_value result;
   napi_status status = napi_create_uint32(env, 42, &result);
   NAPI_THROW_IF_FAILED(env, status, nullptr);
@@ -14,7 +14,7 @@ static napi_value Setter_Core(napi_env env, napi_callback_info info) {
   napi_status status =
       napi_get_cb_info(env, info, &argc, &argv, nullptr, nullptr);
   NAPI_THROW_IF_FAILED(env, status, nullptr);
-  (void) argv;
+  (void)argv;
   return nullptr;
 }
 
@@ -23,22 +23,23 @@ static Napi::Value Getter(const Napi::CallbackInfo& info) {
 }
 
 static void Setter(const Napi::CallbackInfo& info) {
-  (void) info[0];
+  (void)info[0];
 }
 
 #if NAPI_VERSION > 5
 class PropDescBenchmark : public Napi::Addon<PropDescBenchmark> {
  public:
   PropDescBenchmark(Napi::Env, Napi::Object exports) {
-    DefineAddon(exports, {
-      InstanceAccessor("addon",
-                       &PropDescBenchmark::Getter,
-                       &PropDescBenchmark::Setter,
-                       napi_enumerable),
-      InstanceAccessor<&PropDescBenchmark::Getter,
-                       &PropDescBenchmark::Setter>("addon_templated",
-                                                   napi_enumerable),
-    });
+    DefineAddon(exports,
+                {
+                    InstanceAccessor("addon",
+                                     &PropDescBenchmark::Getter,
+                                     &PropDescBenchmark::Setter,
+                                     napi_enumerable),
+                    InstanceAccessor<&PropDescBenchmark::Getter,
+                                     &PropDescBenchmark::Setter>(
+                        "addon_templated", napi_enumerable),
+                });
   }
 
  private:
@@ -47,39 +48,31 @@ class PropDescBenchmark : public Napi::Addon<PropDescBenchmark> {
   }
 
   void Setter(const Napi::CallbackInfo& info, const Napi::Value& val) {
-    (void) info[0];
-    (void) val;
+    (void)info[0];
+    (void)val;
   }
 };
 #endif  // NAPI_VERSION > 5
 
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   napi_status status;
-  napi_property_descriptor core_prop = {
-    "core",
-    nullptr,
-    nullptr,
-    Getter_Core,
-    Setter_Core,
-    nullptr,
-    napi_enumerable,
-    nullptr
-  };
+  napi_property_descriptor core_prop = {"core",
+                                        nullptr,
+                                        nullptr,
+                                        Getter_Core,
+                                        Setter_Core,
+                                        nullptr,
+                                        napi_enumerable,
+                                        nullptr};
 
   status = napi_define_properties(env, exports, 1, &core_prop);
   NAPI_THROW_IF_FAILED(env, status, Napi::Object());
 
-  exports.DefineProperty(
-      Napi::PropertyDescriptor::Accessor(env,
-                                         exports,
-                                         "cplusplus",
-                                         Getter,
-                                         Setter,
-                                         napi_enumerable));
+  exports.DefineProperty(Napi::PropertyDescriptor::Accessor(
+      env, exports, "cplusplus", Getter, Setter, napi_enumerable));
 
-  exports.DefineProperty(
-      Napi::PropertyDescriptor::Accessor<Getter, Setter>("templated",
-                                                         napi_enumerable));
+  exports.DefineProperty(Napi::PropertyDescriptor::Accessor<Getter, Setter>(
+      "templated", napi_enumerable));
 
 #if NAPI_VERSION > 5
   PropDescBenchmark::Init(env, exports);

--- a/benchmark/property_descriptor.js
+++ b/benchmark/property_descriptor.js
@@ -18,6 +18,7 @@ const addonName = path.basename(__filename, '.js');
 
     Object.keys(rootAddon).forEach((key) => {
       getters.add(`${key} getter`.padStart(maxNameLength + 7), () => {
+        // eslint-disable-next-line no-unused-vars
         const x = rootAddon[key];
       });
       setters.add(`${key} setter`.padStart(maxNameLength + 7), () => {

--- a/benchmark/property_descriptor.js
+++ b/benchmark/property_descriptor.js
@@ -2,15 +2,15 @@ const path = require('path');
 const Benchmark = require('benchmark');
 const addonName = path.basename(__filename, '.js');
 
-[ addonName, addonName + '_noexcept' ]
+[addonName, addonName + '_noexcept']
   .forEach((addonName) => {
     const rootAddon = require('bindings')({
       bindings: addonName,
       module_root: __dirname
     });
     delete rootAddon.path;
-    const getters = new Benchmark.Suite;
-    const setters = new Benchmark.Suite;
+    const getters = new Benchmark.Suite();
+    const setters = new Benchmark.Suite();
     const maxNameLength = Object.keys(rootAddon)
       .reduce((soFar, value) => Math.max(soFar, value.length), 0);
 
@@ -22,7 +22,7 @@ const addonName = path.basename(__filename, '.js');
       });
       setters.add(`${key} setter`.padStart(maxNameLength + 7), () => {
         rootAddon[key] = 5;
-      })
+      });
     });
 
     getters

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const path = require('path');
 
-const include_dir = path.relative('.', __dirname);
+const includeDir = path.relative('.', __dirname);
 
 module.exports = {
   include: `"${__dirname}"`, // deprecated, can be removed as part of 4.0.0
-  include_dir,
-  gyp: path.join(include_dir, 'node_api.gyp:nothing'),
+  include_dir: includeDir,
+  gyp: path.join(includeDir, 'node_api.gyp:nothing'),
   isNodeApiBuiltin: true,
   needsFlag: false
 };

--- a/napi-inl.deprecated.h
+++ b/napi-inl.deprecated.h
@@ -6,187 +6,181 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename Getter>
-inline PropertyDescriptor
-PropertyDescriptor::Accessor(const char* utf8name,
-                             Getter getter,
-                             napi_property_attributes attributes,
-                             void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    const char* utf8name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using CbData = details::CallbackData<Getter, Napi::Value>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, nullptr });
+  auto callbackData = new CbData({getter, nullptr});
 
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    nullptr,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(const std::string& utf8name,
-                                                       Getter getter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    const std::string& utf8name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* data) {
   return Accessor(utf8name.c_str(), getter, attributes, data);
 }
 
 template <typename Getter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(napi_value name,
-                                                       Getter getter,
-                                                       napi_property_attributes attributes,
-                                                       void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    napi_value name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using CbData = details::CallbackData<Getter, Napi::Value>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, nullptr });
+  auto callbackData = new CbData({getter, nullptr});
 
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    nullptr,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({nullptr,
+                             name,
+                             nullptr,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Name name,
-                                                       Getter getter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Name name, Getter getter, napi_property_attributes attributes, void* data) {
   napi_value nameValue = name;
   return PropertyDescriptor::Accessor(nameValue, getter, attributes, data);
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(const char* utf8name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    const char* utf8name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using CbData = details::AccessorCallbackData<Getter, Setter>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, setter, nullptr });
+  auto callbackData = new CbData({getter, setter, nullptr});
 
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    nullptr,
-    CbData::GetterWrapper,
-    CbData::SetterWrapper,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             CbData::GetterWrapper,
+                             CbData::SetterWrapper,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(const std::string& utf8name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    const std::string& utf8name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* data) {
   return Accessor(utf8name.c_str(), getter, setter, attributes, data);
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(napi_value name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    napi_value name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using CbData = details::AccessorCallbackData<Getter, Setter>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ getter, setter, nullptr });
+  auto callbackData = new CbData({getter, setter, nullptr});
 
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    nullptr,
-    CbData::GetterWrapper,
-    CbData::SetterWrapper,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({nullptr,
+                             name,
+                             nullptr,
+                             CbData::GetterWrapper,
+                             CbData::SetterWrapper,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Name name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Name name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* data) {
   napi_value nameValue = name;
-  return PropertyDescriptor::Accessor(nameValue, getter, setter, attributes, data);
+  return PropertyDescriptor::Accessor(
+      nameValue, getter, setter, attributes, data);
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(const char* utf8name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Function(
+    const char* utf8name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using ReturnType = decltype(cb(CallbackInfo(nullptr, nullptr)));
   using CbData = details::CallbackData<Callable, ReturnType>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ cb, nullptr });
+  auto callbackData = new CbData({cb, nullptr});
 
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(const std::string& utf8name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Function(
+    const std::string& utf8name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* data) {
   return Function(utf8name.c_str(), cb, attributes, data);
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(napi_value name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* /*data*/) {
+inline PropertyDescriptor PropertyDescriptor::Function(
+    napi_value name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* /*data*/) {
   using ReturnType = decltype(cb(CallbackInfo(nullptr, nullptr)));
   using CbData = details::CallbackData<Callable, ReturnType>;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ cb, nullptr });
+  auto callbackData = new CbData({cb, nullptr});
 
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({nullptr,
+                             name,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(Name name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Function(
+    Name name, Callable cb, napi_property_attributes attributes, void* data) {
   napi_value nameValue = name;
   return PropertyDescriptor::Function(nameValue, cb, attributes, data);
 }
 
-#endif // !SRC_NAPI_INL_DEPRECATED_H_
+#endif  // !SRC_NAPI_INL_DEPRECATED_H_

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -45,22 +45,16 @@ static inline napi_status AttachData(napi_env env,
   napi_value symbol, external;
   status = napi_create_symbol(env, nullptr, &symbol);
   if (status == napi_ok) {
-    status = napi_create_external(env,
-                              data,
-                              finalizer,
-                              hint,
-                              &external);
+    status = napi_create_external(env, data, finalizer, hint, &external);
     if (status == napi_ok) {
-      napi_property_descriptor desc = {
-        nullptr,
-        symbol,
-        nullptr,
-        nullptr,
-        nullptr,
-        external,
-        napi_default,
-        nullptr
-      };
+      napi_property_descriptor desc = {nullptr,
+                                       symbol,
+                                       nullptr,
+                                       nullptr,
+                                       nullptr,
+                                       external,
+                                       napi_default,
+                                       nullptr};
       status = napi_define_properties(env, obj, 1, &desc);
     }
   }
@@ -81,16 +75,16 @@ inline napi_value WrapCallback(Callable callback) {
     e.ThrowAsJavaScriptException();
     return nullptr;
   }
-#else // NAPI_CPP_EXCEPTIONS
+#else   // NAPI_CPP_EXCEPTIONS
   // When C++ exceptions are disabled, errors are immediately thrown as JS
   // exceptions, so there is no need to catch and rethrow them here.
   return callback();
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 }
 
 // For use in JS to C++ void callback wrappers to catch any Napi::Error
-// exceptions and rethrow them as JavaScript exceptions before returning from the
-// callback.
+// exceptions and rethrow them as JavaScript exceptions before returning from
+// the callback.
 template <typename Callable>
 inline void WrapVoidCallback(Callable callback) {
 #ifdef NAPI_CPP_EXCEPTIONS
@@ -99,21 +93,20 @@ inline void WrapVoidCallback(Callable callback) {
   } catch (const Error& e) {
     e.ThrowAsJavaScriptException();
   }
-#else // NAPI_CPP_EXCEPTIONS
+#else   // NAPI_CPP_EXCEPTIONS
   // When C++ exceptions are disabled, errors are immediately thrown as JS
   // exceptions, so there is no need to catch and rethrow them here.
   callback();
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 }
 
 template <typename Callable, typename Return>
 struct CallbackData {
-  static inline
-  napi_value Wrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
-        static_cast<CallbackData*>(callbackInfo.Data());
+          static_cast<CallbackData*>(callbackInfo.Data());
       callbackInfo.SetData(callbackData->data);
       return callbackData->callback(callbackInfo);
     });
@@ -125,12 +118,11 @@ struct CallbackData {
 
 template <typename Callable>
 struct CallbackData<Callable, void> {
-  static inline
-  napi_value Wrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
-        static_cast<CallbackData*>(callbackInfo.Data());
+          static_cast<CallbackData*>(callbackInfo.Data());
       callbackInfo.SetData(callbackData->data);
       callbackData->callback(callbackInfo);
       return nullptr;
@@ -142,8 +134,8 @@ struct CallbackData<Callable, void> {
 };
 
 template <void (*Callback)(const CallbackInfo& info)>
-static napi_value
-TemplatedVoidCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+static napi_value TemplatedVoidCallback(napi_env env,
+                                        napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     Callback(cbInfo);
@@ -152,8 +144,8 @@ TemplatedVoidCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
 }
 
 template <Napi::Value (*Callback)(const CallbackInfo& info)>
-static napi_value
-TemplatedCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+static napi_value TemplatedCallback(napi_env env,
+                                    napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     return Callback(cbInfo);
@@ -162,8 +154,8 @@ TemplatedCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
 
 template <typename T,
           Napi::Value (T::*UnwrapCallback)(const CallbackInfo& info)>
-static napi_value
-TemplatedInstanceCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+static napi_value TemplatedInstanceCallback(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -172,9 +164,8 @@ TemplatedInstanceCallback(napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
 }
 
 template <typename T, void (T::*UnwrapCallback)(const CallbackInfo& info)>
-static napi_value
-TemplatedInstanceVoidCallback(napi_env env,
-                              napi_callback_info info) NAPI_NOEXCEPT {
+static napi_value TemplatedInstanceVoidCallback(
+    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -200,7 +191,8 @@ struct FinalizeData {
                                      void* finalizeHint) NAPI_NOEXCEPT {
     WrapVoidCallback([&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
-      finalizeData->callback(Env(env), static_cast<T*>(data), finalizeData->hint);
+      finalizeData->callback(
+          Env(env), static_cast<T*>(data), finalizeData->hint);
       delete finalizeData;
     });
   }
@@ -210,14 +202,14 @@ struct FinalizeData {
 };
 
 #if (NAPI_VERSION > 3 && !defined(__wasm32__))
-template <typename ContextType=void,
-          typename Finalizer=std::function<void(Env, void*, ContextType*)>,
-          typename FinalizerDataType=void>
+template <typename ContextType = void,
+          typename Finalizer = std::function<void(Env, void*, ContextType*)>,
+          typename FinalizerDataType = void>
 struct ThreadSafeFinalize {
-  static inline
-  void Wrapper(napi_env env, void* rawFinalizeData, void* /* rawContext */) {
-    if (rawFinalizeData == nullptr)
-      return;
+  static inline void Wrapper(napi_env env,
+                             void* rawFinalizeData,
+                             void* /* rawContext */) {
+    if (rawFinalizeData == nullptr) return;
 
     ThreadSafeFinalize* finalizeData =
         static_cast<ThreadSafeFinalize*>(rawFinalizeData);
@@ -225,12 +217,10 @@ struct ThreadSafeFinalize {
     delete finalizeData;
   }
 
-  static inline
-  void FinalizeWrapperWithData(napi_env env,
-                               void* rawFinalizeData,
-                               void* /* rawContext */) {
-    if (rawFinalizeData == nullptr)
-      return;
+  static inline void FinalizeWrapperWithData(napi_env env,
+                                             void* rawFinalizeData,
+                                             void* /* rawContext */) {
+    if (rawFinalizeData == nullptr) return;
 
     ThreadSafeFinalize* finalizeData =
         static_cast<ThreadSafeFinalize*>(rawFinalizeData);
@@ -238,12 +228,10 @@ struct ThreadSafeFinalize {
     delete finalizeData;
   }
 
-  static inline
-  void FinalizeWrapperWithContext(napi_env env,
-                                  void* rawFinalizeData,
-                                  void* rawContext) {
-    if (rawFinalizeData == nullptr)
-      return;
+  static inline void FinalizeWrapperWithContext(napi_env env,
+                                                void* rawFinalizeData,
+                                                void* rawContext) {
+    if (rawFinalizeData == nullptr) return;
 
     ThreadSafeFinalize* finalizeData =
         static_cast<ThreadSafeFinalize*>(rawFinalizeData);
@@ -251,17 +239,14 @@ struct ThreadSafeFinalize {
     delete finalizeData;
   }
 
-  static inline
-  void FinalizeFinalizeWrapperWithDataAndContext(napi_env env,
-                                         void* rawFinalizeData,
-                                         void* rawContext) {
-    if (rawFinalizeData == nullptr)
-      return;
+  static inline void FinalizeFinalizeWrapperWithDataAndContext(
+      napi_env env, void* rawFinalizeData, void* rawContext) {
+    if (rawFinalizeData == nullptr) return;
 
     ThreadSafeFinalize* finalizeData =
         static_cast<ThreadSafeFinalize*>(rawFinalizeData);
-    finalizeData->callback(Env(env), finalizeData->data,
-        static_cast<ContextType*>(rawContext));
+    finalizeData->callback(
+        Env(env), finalizeData->data, static_cast<ContextType*>(rawContext));
     delete finalizeData;
   }
 
@@ -311,23 +296,23 @@ napi_value DefaultCallbackWrapper(napi_env env, Napi::Function cb) {
 
 template <typename Getter, typename Setter>
 struct AccessorCallbackData {
-  static inline
-  napi_value GetterWrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value GetterWrapper(napi_env env,
+                                         napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
-        static_cast<AccessorCallbackData*>(callbackInfo.Data());
+          static_cast<AccessorCallbackData*>(callbackInfo.Data());
       callbackInfo.SetData(callbackData->data);
       return callbackData->getterCallback(callbackInfo);
     });
   }
 
-  static inline
-  napi_value SetterWrapper(napi_env env, napi_callback_info info) {
+  static inline napi_value SetterWrapper(napi_env env,
+                                         napi_callback_info info) {
     return details::WrapCallback([&] {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
-        static_cast<AccessorCallbackData*>(callbackInfo.Data());
+          static_cast<AccessorCallbackData*>(callbackInfo.Data());
       callbackInfo.SetData(callbackData->data);
       callbackData->setterCallback(callbackInfo);
       return nullptr;
@@ -342,8 +327,8 @@ struct AccessorCallbackData {
 }  // namespace details
 
 #ifndef NODE_ADDON_API_DISABLE_DEPRECATED
-# include "napi-inl.deprecated.h"
-#endif // !NODE_ADDON_API_DISABLE_DEPRECATED
+#include "napi-inl.deprecated.h"
+#endif  // !NODE_ADDON_API_DISABLE_DEPRECATED
 
 ////////////////////////////////////////////////////////////////////////////////
 // Module registration
@@ -358,16 +343,15 @@ struct AccessorCallbackData {
 
 // Register an add-on based on a subclass of `Addon<T>` with a custom Node.js
 // module name.
-#define NODE_API_NAMED_ADDON(modname, classname)                 \
-  static napi_value __napi_ ## classname(napi_env env,           \
-                                         napi_value exports) {   \
-    return Napi::RegisterModule(env, exports, &classname::Init); \
-  }                                                              \
-  NAPI_MODULE(modname, __napi_ ## classname)
+#define NODE_API_NAMED_ADDON(modname, classname)                               \
+  static napi_value __napi_##classname(napi_env env, napi_value exports) {     \
+    return Napi::RegisterModule(env, exports, &classname::Init);               \
+  }                                                                            \
+  NAPI_MODULE(modname, __napi_##classname)
 
 // Register an add-on based on a subclass of `Addon<T>` with the Node.js module
 // name given by node-gyp from the `target_name` in binding.gyp.
-#define NODE_API_ADDON(classname) \
+#define NODE_API_ADDON(classname)                                              \
   NODE_API_NAMED_ADDON(NODE_GYP_MODULE_NAME, classname)
 
 // Adapt the NAPI_MODULE registration function:
@@ -377,8 +361,8 @@ inline napi_value RegisterModule(napi_env env,
                                  napi_value exports,
                                  ModuleRegisterCallback registerCallback) {
   return details::WrapCallback([&] {
-    return napi_value(registerCallback(Napi::Env(env),
-                                       Napi::Object(env, exports)));
+    return napi_value(
+        registerCallback(Napi::Env(env), Napi::Object(env, exports)));
   });
 }
 
@@ -452,8 +436,7 @@ inline Maybe<T> Just(const T& t) {
 // Env class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline Env::Env(napi_env env) : _env(env) {
-}
+inline Env::Env(napi_env env) : _env(env) {}
 
 inline Env::operator napi_env() const {
   return _env;
@@ -483,7 +466,8 @@ inline Value Env::Null() const {
 inline bool Env::IsExceptionPending() const {
   bool result;
   napi_status status = napi_is_exception_pending(_env, &result);
-  if (status != napi_ok) result = false; // Checking for a pending exception shouldn't throw.
+  if (status != napi_ok)
+    result = false;  // Checking for a pending exception shouldn't throw.
   return result;
 }
 
@@ -536,10 +520,11 @@ void Env::CleanupHook<Hook, Arg>::WrapperWithArg(void* data) NAPI_NOEXCEPT {
 #if NAPI_VERSION > 5
 template <typename T, Env::Finalizer<T> fini>
 inline void Env::SetInstanceData(T* data) const {
-  napi_status status =
-    napi_set_instance_data(_env, data, [](napi_env env, void* data, void*) {
-      fini(env, static_cast<T*>(data));
-    }, nullptr);
+  napi_status status = napi_set_instance_data(
+      _env,
+      data,
+      [](napi_env env, void* data, void*) { fini(env, static_cast<T*>(data)); },
+      nullptr);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
@@ -547,11 +532,13 @@ template <typename DataType,
           typename HintType,
           Napi::Env::FinalizerWithHint<DataType, HintType> fini>
 inline void Env::SetInstanceData(DataType* data, HintType* hint) const {
-  napi_status status =
-    napi_set_instance_data(_env, data,
+  napi_status status = napi_set_instance_data(
+      _env,
+      data,
       [](napi_env env, void* data, void* hint) {
         fini(env, static_cast<DataType*>(data), static_cast<HintType*>(hint));
-      }, hint);
+      },
+      hint);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
@@ -565,7 +552,8 @@ inline T* Env::GetInstanceData() const {
   return static_cast<T*>(data);
 }
 
-template <typename T> void Env::DefaultFini(Env, T* data) {
+template <typename T>
+void Env::DefaultFini(Env, T* data) {
   delete data;
 }
 
@@ -579,22 +567,21 @@ void Env::DefaultFiniWithHint(Env, DataType* data, HintType*) {
 // Value class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline Value::Value() : _env(nullptr), _value(nullptr) {
-}
+inline Value::Value() : _env(nullptr), _value(nullptr) {}
 
-inline Value::Value(napi_env env, napi_value value) : _env(env), _value(value) {
-}
+inline Value::Value(napi_env env, napi_value value)
+    : _env(env), _value(value) {}
 
 inline Value::operator napi_value() const {
   return _value;
 }
 
-inline bool Value::operator ==(const Value& other) const {
+inline bool Value::operator==(const Value& other) const {
   return StrictEquals(other);
 }
 
-inline bool Value::operator !=(const Value& other) const {
-  return !this->operator ==(other);
+inline bool Value::operator!=(const Value& other) const {
+  return !this->operator==(other);
 }
 
 inline bool Value::StrictEquals(const Value& other) const {
@@ -788,11 +775,10 @@ inline Boolean Boolean::New(napi_env env, bool val) {
   return Boolean(env, value);
 }
 
-inline Boolean::Boolean() : Napi::Value() {
-}
+inline Boolean::Boolean() : Napi::Value() {}
 
-inline Boolean::Boolean(napi_env env, napi_value value) : Napi::Value(env, value) {
-}
+inline Boolean::Boolean(napi_env env, napi_value value)
+    : Napi::Value(env, value) {}
 
 inline Boolean::operator bool() const {
   return Value();
@@ -816,11 +802,9 @@ inline Number Number::New(napi_env env, double val) {
   return Number(env, value);
 }
 
-inline Number::Number() : Value() {
-}
+inline Number::Number() : Value() {}
 
-inline Number::Number(napi_env env, napi_value value) : Value(env, value) {
-}
+inline Number::Number(napi_env env, napi_value value) : Value(env, value) {}
 
 inline Number::operator int32_t() const {
   return Int32Value();
@@ -893,46 +877,50 @@ inline BigInt BigInt::New(napi_env env, uint64_t val) {
   return BigInt(env, value);
 }
 
-inline BigInt BigInt::New(napi_env env, int sign_bit, size_t word_count, const uint64_t* words) {
+inline BigInt BigInt::New(napi_env env,
+                          int sign_bit,
+                          size_t word_count,
+                          const uint64_t* words) {
   napi_value value;
-  napi_status status = napi_create_bigint_words(env, sign_bit, word_count, words, &value);
+  napi_status status =
+      napi_create_bigint_words(env, sign_bit, word_count, words, &value);
   NAPI_THROW_IF_FAILED(env, status, BigInt());
   return BigInt(env, value);
 }
 
-inline BigInt::BigInt() : Value() {
-}
+inline BigInt::BigInt() : Value() {}
 
-inline BigInt::BigInt(napi_env env, napi_value value) : Value(env, value) {
-}
+inline BigInt::BigInt(napi_env env, napi_value value) : Value(env, value) {}
 
 inline int64_t BigInt::Int64Value(bool* lossless) const {
   int64_t result;
-  napi_status status = napi_get_value_bigint_int64(
-      _env, _value, &result, lossless);
+  napi_status status =
+      napi_get_value_bigint_int64(_env, _value, &result, lossless);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return result;
 }
 
 inline uint64_t BigInt::Uint64Value(bool* lossless) const {
   uint64_t result;
-  napi_status status = napi_get_value_bigint_uint64(
-      _env, _value, &result, lossless);
+  napi_status status =
+      napi_get_value_bigint_uint64(_env, _value, &result, lossless);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return result;
 }
 
 inline size_t BigInt::WordCount() const {
   size_t word_count;
-  napi_status status = napi_get_value_bigint_words(
-      _env, _value, nullptr, &word_count, nullptr);
+  napi_status status =
+      napi_get_value_bigint_words(_env, _value, nullptr, &word_count, nullptr);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return word_count;
 }
 
-inline void BigInt::ToWords(int* sign_bit, size_t* word_count, uint64_t* words) {
-  napi_status status = napi_get_value_bigint_words(
-      _env, _value, sign_bit, word_count, words);
+inline void BigInt::ToWords(int* sign_bit,
+                            size_t* word_count,
+                            uint64_t* words) {
+  napi_status status =
+      napi_get_value_bigint_words(_env, _value, sign_bit, word_count, words);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 #endif  // NAPI_VERSION > 5
@@ -949,11 +937,9 @@ inline Date Date::New(napi_env env, double val) {
   return Date(env, value);
 }
 
-inline Date::Date() : Value() {
-}
+inline Date::Date() : Value() {}
 
-inline Date::Date(napi_env env, napi_value value) : Value(env, value) {
-}
+inline Date::Date(napi_env env, napi_value value) : Value(env, value) {}
 
 inline Date::operator double() const {
   return ValueOf();
@@ -961,8 +947,7 @@ inline Date::operator double() const {
 
 inline double Date::ValueOf() const {
   double result;
-  napi_status status = napi_get_date_value(
-      _env, _value, &result);
+  napi_status status = napi_get_date_value(_env, _value, &result);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return result;
 }
@@ -972,11 +957,9 @@ inline double Date::ValueOf() const {
 // Name class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline Name::Name() : Value() {
-}
+inline Name::Name() : Value() {}
 
-inline Name::Name(napi_env env, napi_value value) : Value(env, value) {
-}
+inline Name::Name(napi_env env, napi_value value) : Value(env, value) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // String class
@@ -998,7 +981,8 @@ inline String String::New(napi_env env, const char* val) {
     NAPI_THROW_IF_FAILED(env, napi_invalid_arg, String());
   }
   napi_value value;
-  napi_status status = napi_create_string_utf8(env, val, std::strlen(val), &value);
+  napi_status status =
+      napi_create_string_utf8(env, val, std::strlen(val), &value);
   NAPI_THROW_IF_FAILED(env, status, String());
   return String(env, value);
 }
@@ -1011,7 +995,8 @@ inline String String::New(napi_env env, const char16_t* val) {
     // Throw an error that looks like it came from core.
     NAPI_THROW_IF_FAILED(env, napi_invalid_arg, String());
   }
-  napi_status status = napi_create_string_utf16(env, val, std::u16string(val).size(), &value);
+  napi_status status =
+      napi_create_string_utf16(env, val, std::u16string(val).size(), &value);
   NAPI_THROW_IF_FAILED(env, status, String());
   return String(env, value);
 }
@@ -1030,11 +1015,9 @@ inline String String::New(napi_env env, const char16_t* val, size_t length) {
   return String(env, value);
 }
 
-inline String::String() : Name() {
-}
+inline String::String() : Name() {}
 
-inline String::String(napi_env env, napi_value value) : Name(env, value) {
-}
+inline String::String(napi_env env, napi_value value) : Name(env, value) {}
 
 inline String::operator std::string() const {
   return Utf8Value();
@@ -1046,26 +1029,30 @@ inline String::operator std::u16string() const {
 
 inline std::string String::Utf8Value() const {
   size_t length;
-  napi_status status = napi_get_value_string_utf8(_env, _value, nullptr, 0, &length);
+  napi_status status =
+      napi_get_value_string_utf8(_env, _value, nullptr, 0, &length);
   NAPI_THROW_IF_FAILED(_env, status, "");
 
   std::string value;
   value.reserve(length + 1);
   value.resize(length);
-  status = napi_get_value_string_utf8(_env, _value, &value[0], value.capacity(), nullptr);
+  status = napi_get_value_string_utf8(
+      _env, _value, &value[0], value.capacity(), nullptr);
   NAPI_THROW_IF_FAILED(_env, status, "");
   return value;
 }
 
 inline std::u16string String::Utf16Value() const {
   size_t length;
-  napi_status status = napi_get_value_string_utf16(_env, _value, nullptr, 0, &length);
+  napi_status status =
+      napi_get_value_string_utf16(_env, _value, nullptr, 0, &length);
   NAPI_THROW_IF_FAILED(_env, status, NAPI_WIDE_TEXT(""));
 
   std::u16string value;
   value.reserve(length + 1);
   value.resize(length);
-  status = napi_get_value_string_utf16(_env, _value, &value[0], value.capacity(), nullptr);
+  status = napi_get_value_string_utf16(
+      _env, _value, &value[0], value.capacity(), nullptr);
   NAPI_THROW_IF_FAILED(_env, status, NAPI_WIDE_TEXT(""));
   return value;
 }
@@ -1075,8 +1062,9 @@ inline std::u16string String::Utf16Value() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline Symbol Symbol::New(napi_env env, const char* description) {
-  napi_value descriptionValue = description != nullptr ?
-    String::New(env, description) : static_cast<napi_value>(nullptr);
+  napi_value descriptionValue = description != nullptr
+                                    ? String::New(env, description)
+                                    : static_cast<napi_value>(nullptr);
   return Symbol::New(env, descriptionValue);
 }
 
@@ -1108,7 +1096,12 @@ inline MaybeOrValue<Symbol> Symbol::WellKnown(napi_env env,
   }
   return Nothing<Symbol>();
 #else
-  return Napi::Env(env).Global().Get("Symbol").As<Object>().Get(name).As<Symbol>();
+  return Napi::Env(env)
+      .Global()
+      .Get("Symbol")
+      .As<Object>()
+      .Get(name)
+      .As<Symbol>();
 #endif
 }
 
@@ -1149,11 +1142,9 @@ inline MaybeOrValue<Symbol> Symbol::For(napi_env env, napi_value description) {
 #endif
 }
 
-inline Symbol::Symbol() : Name() {
-}
+inline Symbol::Symbol() : Name() {}
 
-inline Symbol::Symbol(napi_env env, napi_value value) : Name(env, value) {
-}
+inline Symbol::Symbol(napi_env env, napi_value value) : Name(env, value) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Automagic value creation
@@ -1167,7 +1158,7 @@ struct vf_number {
   }
 };
 
-template<>
+template <>
 struct vf_number<bool> {
   static Boolean From(napi_env env, bool value) {
     return Boolean::New(env, value);
@@ -1199,36 +1190,33 @@ struct vf_utf16_string {
 
 template <typename T>
 struct vf_fallback {
-  static Value From(napi_env env, const T& value) {
-    return Value(env, value);
-  }
+  static Value From(napi_env env, const T& value) { return Value(env, value); }
 };
 
-template <typename...> struct disjunction : std::false_type {};
-template <typename B> struct disjunction<B> : B {};
+template <typename...>
+struct disjunction : std::false_type {};
+template <typename B>
+struct disjunction<B> : B {};
 template <typename B, typename... Bs>
 struct disjunction<B, Bs...>
     : std::conditional<bool(B::value), B, disjunction<Bs...>>::type {};
 
 template <typename T>
 struct can_make_string
-    : disjunction<typename std::is_convertible<T, const char *>::type,
-                  typename std::is_convertible<T, const char16_t *>::type,
+    : disjunction<typename std::is_convertible<T, const char*>::type,
+                  typename std::is_convertible<T, const char16_t*>::type,
                   typename std::is_convertible<T, std::string>::type,
                   typename std::is_convertible<T, std::u16string>::type> {};
-}
+}  // namespace details
 
 template <typename T>
 Value Value::From(napi_env env, const T& value) {
   using Helper = typename std::conditional<
-    std::is_integral<T>::value || std::is_floating_point<T>::value,
-    details::vf_number<T>,
-    typename std::conditional<
-      details::can_make_string<T>::value,
-      String,
-      details::vf_fallback<T>
-    >::type
-  >::type;
+      std::is_integral<T>::value || std::is_floating_point<T>::value,
+      details::vf_number<T>,
+      typename std::conditional<details::can_make_string<T>::value,
+                                String,
+                                details::vf_fallback<T>>::type>::type;
   return Helper::From(env, value);
 }
 
@@ -1236,22 +1224,18 @@ template <typename T>
 String String::From(napi_env env, const T& value) {
   struct Dummy {};
   using Helper = typename std::conditional<
-    std::is_convertible<T, const char*>::value,
-    details::vf_utf8_charp,
-    typename std::conditional<
-      std::is_convertible<T, const char16_t*>::value,
-      details::vf_utf16_charp,
+      std::is_convertible<T, const char*>::value,
+      details::vf_utf8_charp,
       typename std::conditional<
-        std::is_convertible<T, std::string>::value,
-        details::vf_utf8_string,
-        typename std::conditional<
-          std::is_convertible<T, std::u16string>::value,
-          details::vf_utf16_string,
-          Dummy
-        >::type
-      >::type
-    >::type
-  >::type;
+          std::is_convertible<T, const char16_t*>::value,
+          details::vf_utf16_charp,
+          typename std::conditional<
+              std::is_convertible<T, std::string>::value,
+              details::vf_utf8_string,
+              typename std::conditional<
+                  std::is_convertible<T, std::u16string>::value,
+                  details::vf_utf16_string,
+                  Dummy>::type>::type>::type>::type;
   return Helper::From(env, value);
 }
 
@@ -1269,8 +1253,10 @@ inline Object::PropertyLValue<Key>::operator Value() const {
 #endif
 }
 
-template <typename Key> template <typename ValueType>
-inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(ValueType value) {
+template <typename Key>
+template <typename ValueType>
+inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator=(
+    ValueType value) {
 #ifdef NODE_ADDON_API_ENABLE_MAYBE
   MaybeOrValue<bool> result =
 #endif
@@ -1283,7 +1269,7 @@ inline Object::PropertyLValue<Key>& Object::PropertyLValue<Key>::operator =(Valu
 
 template <typename Key>
 inline Object::PropertyLValue<Key>::PropertyLValue(Object object, Key key)
-  : _env(object.Env()), _object(object), _key(key) {}
+    : _env(object.Env()), _object(object), _key(key) {}
 
 inline Object Object::New(napi_env env) {
   napi_value value;
@@ -1292,11 +1278,9 @@ inline Object Object::New(napi_env env) {
   return Object(env, value);
 }
 
-inline Object::Object() : Value() {
-}
+inline Object::Object() : Value() {}
 
-inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
-}
+inline Object::Object(napi_env env, napi_value value) : Value(env, value) {}
 
 inline Object::PropertyLValue<std::string> Object::operator[](
     const char* utf8name) {
@@ -1365,7 +1349,8 @@ inline MaybeOrValue<bool> Object::HasOwnProperty(Value key) const {
 
 inline MaybeOrValue<bool> Object::HasOwnProperty(const char* utf8name) const {
   napi_value key;
-  napi_status status = napi_create_string_utf8(_env, utf8name, std::strlen(utf8name), &key);
+  napi_status status =
+      napi_create_string_utf8(_env, utf8name, std::strlen(utf8name), &key);
   NAPI_MAYBE_THROW_IF_FAILED(_env, status, bool);
   return HasOwnProperty(key);
 }
@@ -1480,22 +1465,31 @@ inline MaybeOrValue<Array> Object::GetPropertyNames() const {
 
 inline MaybeOrValue<bool> Object::DefineProperty(
     const PropertyDescriptor& property) const {
-  napi_status status = napi_define_properties(_env, _value, 1,
-    reinterpret_cast<const napi_property_descriptor*>(&property));
+  napi_status status = napi_define_properties(
+      _env,
+      _value,
+      1,
+      reinterpret_cast<const napi_property_descriptor*>(&property));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
     const std::initializer_list<PropertyDescriptor>& properties) const {
-  napi_status status = napi_define_properties(_env, _value, properties.size(),
-    reinterpret_cast<const napi_property_descriptor*>(properties.begin()));
+  napi_status status = napi_define_properties(
+      _env,
+      _value,
+      properties.size(),
+      reinterpret_cast<const napi_property_descriptor*>(properties.begin()));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
 inline MaybeOrValue<bool> Object::DefineProperties(
     const std::vector<PropertyDescriptor>& properties) const {
-  napi_status status = napi_define_properties(_env, _value, properties.size(),
-    reinterpret_cast<const napi_property_descriptor*>(properties.data()));
+  napi_status status = napi_define_properties(
+      _env,
+      _value,
+      properties.size(),
+      reinterpret_cast<const napi_property_descriptor*>(properties.data()));
   NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
 }
 
@@ -1530,12 +1524,12 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
   details::FinalizeData<T, Finalizer, Hint>* finalizeData =
       new details::FinalizeData<T, Finalizer, Hint>(
           {std::move(finalizeCallback), finalizeHint});
-  napi_status status =
-      details::AttachData(_env,
-                          *this,
-                          data,
-                          details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
-                          finalizeData);
+  napi_status status = details::AttachData(
+      _env,
+      *this,
+      data,
+      details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
+      finalizeData);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED_VOID(_env, status);
@@ -1638,7 +1632,8 @@ inline MaybeOrValue<bool> Object::Seal() const {
 template <typename T>
 inline External<T> External<T>::New(napi_env env, T* data) {
   napi_value value;
-  napi_status status = napi_create_external(env, data, nullptr, nullptr, &value);
+  napi_status status =
+      napi_create_external(env, data, nullptr, nullptr, &value);
   NAPI_THROW_IF_FAILED(env, status, External());
   return External(env, value);
 }
@@ -1652,12 +1647,12 @@ inline External<T> External<T>::New(napi_env env,
   details::FinalizeData<T, Finalizer>* finalizeData =
       new details::FinalizeData<T, Finalizer>(
           {std::move(finalizeCallback), nullptr});
-  napi_status status = napi_create_external(
-    env,
-    data,
-    details::FinalizeData<T, Finalizer>::Wrapper,
-    finalizeData,
-    &value);
+  napi_status status =
+      napi_create_external(env,
+                           data,
+                           details::FinalizeData<T, Finalizer>::Wrapper,
+                           finalizeData,
+                           &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, External());
@@ -1676,11 +1671,11 @@ inline External<T> External<T>::New(napi_env env,
       new details::FinalizeData<T, Finalizer, Hint>(
           {std::move(finalizeCallback), finalizeHint});
   napi_status status = napi_create_external(
-    env,
-    data,
-    details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
-    finalizeData,
-    &value);
+      env,
+      data,
+      details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
+      finalizeData,
+      &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, External());
@@ -1689,12 +1684,11 @@ inline External<T> External<T>::New(napi_env env,
 }
 
 template <typename T>
-inline External<T>::External() : Value() {
-}
+inline External<T>::External() : Value() {}
 
 template <typename T>
-inline External<T>::External(napi_env env, napi_value value) : Value(env, value) {
-}
+inline External<T>::External(napi_env env, napi_value value)
+    : Value(env, value) {}
 
 template <typename T>
 inline T* External<T>::Data() const {
@@ -1722,11 +1716,9 @@ inline Array Array::New(napi_env env, size_t length) {
   return Array(env, value);
 }
 
-inline Array::Array() : Object() {
-}
+inline Array::Array() : Object() {}
 
-inline Array::Array(napi_env env, napi_value value) : Object(env, value) {
-}
+inline Array::Array(napi_env env, napi_value value) : Object(env, value) {}
 
 inline uint32_t Array::Length() const {
   uint32_t result;
@@ -1753,7 +1745,7 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env,
                                     size_t byteLength) {
   napi_value value;
   napi_status status = napi_create_external_arraybuffer(
-    env, externalData, byteLength, nullptr, nullptr, &value);
+      env, externalData, byteLength, nullptr, nullptr, &value);
   NAPI_THROW_IF_FAILED(env, status, ArrayBuffer());
 
   return ArrayBuffer(env, value);
@@ -1769,12 +1761,12 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env,
       new details::FinalizeData<void, Finalizer>(
           {std::move(finalizeCallback), nullptr});
   napi_status status = napi_create_external_arraybuffer(
-    env,
-    externalData,
-    byteLength,
-    details::FinalizeData<void, Finalizer>::Wrapper,
-    finalizeData,
-    &value);
+      env,
+      externalData,
+      byteLength,
+      details::FinalizeData<void, Finalizer>::Wrapper,
+      finalizeData,
+      &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, ArrayBuffer());
@@ -1794,12 +1786,12 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env,
       new details::FinalizeData<void, Finalizer, Hint>(
           {std::move(finalizeCallback), finalizeHint});
   napi_status status = napi_create_external_arraybuffer(
-    env,
-    externalData,
-    byteLength,
-    details::FinalizeData<void, Finalizer, Hint>::WrapperWithHint,
-    finalizeData,
-    &value);
+      env,
+      externalData,
+      byteLength,
+      details::FinalizeData<void, Finalizer, Hint>::WrapperWithHint,
+      finalizeData,
+      &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, ArrayBuffer());
@@ -1808,12 +1800,10 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env,
   return ArrayBuffer(env, value);
 }
 
-inline ArrayBuffer::ArrayBuffer() : Object() {
-}
+inline ArrayBuffer::ArrayBuffer() : Object() {}
 
 inline ArrayBuffer::ArrayBuffer(napi_env env, napi_value value)
-  : Object(env, value) {
-}
+    : Object(env, value) {}
 
 inline void* ArrayBuffer::Data() {
   void* data;
@@ -1824,7 +1814,8 @@ inline void* ArrayBuffer::Data() {
 
 inline size_t ArrayBuffer::ByteLength() {
   size_t length;
-  napi_status status = napi_get_arraybuffer_info(_env, _value, nullptr, &length);
+  napi_status status =
+      napi_get_arraybuffer_info(_env, _value, nullptr, &length);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return length;
 }
@@ -1846,8 +1837,7 @@ inline void ArrayBuffer::Detach() {
 ////////////////////////////////////////////////////////////////////////////////
 // DataView class
 ////////////////////////////////////////////////////////////////////////////////
-inline DataView DataView::New(napi_env env,
-                              Napi::ArrayBuffer arrayBuffer) {
+inline DataView DataView::New(napi_env env, Napi::ArrayBuffer arrayBuffer) {
   return New(env, arrayBuffer, 0, arrayBuffer.ByteLength());
 }
 
@@ -1855,12 +1845,12 @@ inline DataView DataView::New(napi_env env,
                               Napi::ArrayBuffer arrayBuffer,
                               size_t byteOffset) {
   if (byteOffset > arrayBuffer.ByteLength()) {
-    NAPI_THROW(RangeError::New(env,
-        "Start offset is outside the bounds of the buffer"),
-        DataView());
+    NAPI_THROW(RangeError::New(
+                   env, "Start offset is outside the bounds of the buffer"),
+               DataView());
   }
-  return New(env, arrayBuffer, byteOffset,
-      arrayBuffer.ByteLength() - byteOffset);
+  return New(
+      env, arrayBuffer, byteOffset, arrayBuffer.ByteLength() - byteOffset);
 }
 
 inline DataView DataView::New(napi_env env,
@@ -1868,52 +1858,47 @@ inline DataView DataView::New(napi_env env,
                               size_t byteOffset,
                               size_t byteLength) {
   if (byteOffset + byteLength > arrayBuffer.ByteLength()) {
-    NAPI_THROW(RangeError::New(env, "Invalid DataView length"),
-               DataView());
+    NAPI_THROW(RangeError::New(env, "Invalid DataView length"), DataView());
   }
   napi_value value;
-  napi_status status = napi_create_dataview(
-    env, byteLength, arrayBuffer, byteOffset, &value);
+  napi_status status =
+      napi_create_dataview(env, byteLength, arrayBuffer, byteOffset, &value);
   NAPI_THROW_IF_FAILED(env, status, DataView());
   return DataView(env, value);
 }
 
-inline DataView::DataView() : Object() {
-}
+inline DataView::DataView() : Object() {}
 
 inline DataView::DataView(napi_env env, napi_value value) : Object(env, value) {
-  napi_status status = napi_get_dataview_info(
-    _env,
-    _value   /* dataView */,
-    &_length /* byteLength */,
-    &_data   /* data */,
-    nullptr  /* arrayBuffer */,
-    nullptr  /* byteOffset */);
+  napi_status status = napi_get_dataview_info(_env,
+                                              _value /* dataView */,
+                                              &_length /* byteLength */,
+                                              &_data /* data */,
+                                              nullptr /* arrayBuffer */,
+                                              nullptr /* byteOffset */);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
 inline Napi::ArrayBuffer DataView::ArrayBuffer() const {
   napi_value arrayBuffer;
-  napi_status status = napi_get_dataview_info(
-    _env,
-    _value       /* dataView */,
-    nullptr      /* byteLength */,
-    nullptr      /* data */,
-    &arrayBuffer /* arrayBuffer */,
-    nullptr      /* byteOffset */);
+  napi_status status = napi_get_dataview_info(_env,
+                                              _value /* dataView */,
+                                              nullptr /* byteLength */,
+                                              nullptr /* data */,
+                                              &arrayBuffer /* arrayBuffer */,
+                                              nullptr /* byteOffset */);
   NAPI_THROW_IF_FAILED(_env, status, Napi::ArrayBuffer());
   return Napi::ArrayBuffer(_env, arrayBuffer);
 }
 
 inline size_t DataView::ByteOffset() const {
   size_t byteOffset;
-  napi_status status = napi_get_dataview_info(
-    _env,
-    _value      /* dataView */,
-    nullptr     /* byteLength */,
-    nullptr     /* data */,
-    nullptr     /* arrayBuffer */,
-    &byteOffset /* byteOffset */);
+  napi_status status = napi_get_dataview_info(_env,
+                                              _value /* dataView */,
+                                              nullptr /* byteLength */,
+                                              nullptr /* data */,
+                                              nullptr /* arrayBuffer */,
+                                              &byteOffset /* byteOffset */);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return byteOffset;
 }
@@ -1994,8 +1979,9 @@ template <typename T>
 inline T DataView::ReadData(size_t byteOffset) const {
   if (byteOffset + sizeof(T) > _length ||
       byteOffset + sizeof(T) < byteOffset) {  // overflow
-    NAPI_THROW(RangeError::New(_env,
-        "Offset is outside the bounds of the DataView"), 0);
+    NAPI_THROW(
+        RangeError::New(_env, "Offset is outside the bounds of the DataView"),
+        0);
   }
 
   return *reinterpret_cast<T*>(static_cast<uint8_t*>(_data) + byteOffset);
@@ -2005,8 +1991,8 @@ template <typename T>
 inline void DataView::WriteData(size_t byteOffset, T value) const {
   if (byteOffset + sizeof(T) > _length ||
       byteOffset + sizeof(T) < byteOffset) {  // overflow
-    NAPI_THROW_VOID(RangeError::New(_env,
-        "Offset is outside the bounds of the DataView"));
+    NAPI_THROW_VOID(
+        RangeError::New(_env, "Offset is outside the bounds of the DataView"));
   }
 
   *reinterpret_cast<T*>(static_cast<uint8_t*>(_data) + byteOffset) = value;
@@ -2017,25 +2003,27 @@ inline void DataView::WriteData(size_t byteOffset, T value) const {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline TypedArray::TypedArray()
-  : Object(), _type(TypedArray::unknown_array_type), _length(0) {
-}
+    : Object(), _type(TypedArray::unknown_array_type), _length(0) {}
 
 inline TypedArray::TypedArray(napi_env env, napi_value value)
-  : Object(env, value), _type(TypedArray::unknown_array_type), _length(0) {
-}
+    : Object(env, value), _type(TypedArray::unknown_array_type), _length(0) {}
 
 inline TypedArray::TypedArray(napi_env env,
                               napi_value value,
                               napi_typedarray_type type,
                               size_t length)
-  : Object(env, value), _type(type), _length(length) {
-}
+    : Object(env, value), _type(type), _length(length) {}
 
 inline napi_typedarray_type TypedArray::TypedArrayType() const {
   if (_type == TypedArray::unknown_array_type) {
-    napi_status status = napi_get_typedarray_info(_env, _value,
-      &const_cast<TypedArray*>(this)->_type, &const_cast<TypedArray*>(this)->_length,
-      nullptr, nullptr, nullptr);
+    napi_status status =
+        napi_get_typedarray_info(_env,
+                                 _value,
+                                 &const_cast<TypedArray*>(this)->_type,
+                                 &const_cast<TypedArray*>(this)->_length,
+                                 nullptr,
+                                 nullptr,
+                                 nullptr);
     NAPI_THROW_IF_FAILED(_env, status, napi_int8_array);
   }
 
@@ -2068,9 +2056,14 @@ inline uint8_t TypedArray::ElementSize() const {
 
 inline size_t TypedArray::ElementLength() const {
   if (_type == TypedArray::unknown_array_type) {
-    napi_status status = napi_get_typedarray_info(_env, _value,
-      &const_cast<TypedArray*>(this)->_type, &const_cast<TypedArray*>(this)->_length,
-      nullptr, nullptr, nullptr);
+    napi_status status =
+        napi_get_typedarray_info(_env,
+                                 _value,
+                                 &const_cast<TypedArray*>(this)->_type,
+                                 &const_cast<TypedArray*>(this)->_length,
+                                 nullptr,
+                                 nullptr,
+                                 nullptr);
     NAPI_THROW_IF_FAILED(_env, status, 0);
   }
 
@@ -2080,7 +2073,7 @@ inline size_t TypedArray::ElementLength() const {
 inline size_t TypedArray::ByteOffset() const {
   size_t byteOffset;
   napi_status status = napi_get_typedarray_info(
-    _env, _value, nullptr, nullptr, nullptr, nullptr, &byteOffset);
+      _env, _value, nullptr, nullptr, nullptr, nullptr, &byteOffset);
   NAPI_THROW_IF_FAILED(_env, status, 0);
   return byteOffset;
 }
@@ -2092,7 +2085,7 @@ inline size_t TypedArray::ByteLength() const {
 inline Napi::ArrayBuffer TypedArray::ArrayBuffer() const {
   napi_value arrayBuffer;
   napi_status status = napi_get_typedarray_info(
-    _env, _value, nullptr, nullptr, nullptr, &arrayBuffer, nullptr);
+      _env, _value, nullptr, nullptr, nullptr, &arrayBuffer, nullptr);
   NAPI_THROW_IF_FAILED(_env, status, Napi::ArrayBuffer());
   return Napi::ArrayBuffer(_env, arrayBuffer);
 }
@@ -2105,7 +2098,8 @@ template <typename T>
 inline TypedArrayOf<T> TypedArrayOf<T>::New(napi_env env,
                                             size_t elementLength,
                                             napi_typedarray_type type) {
-  Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(env, elementLength * sizeof (T));
+  Napi::ArrayBuffer arrayBuffer =
+      Napi::ArrayBuffer::New(env, elementLength * sizeof(T));
   return New(env, elementLength, arrayBuffer, 0, type);
 }
 
@@ -2117,21 +2111,24 @@ inline TypedArrayOf<T> TypedArrayOf<T>::New(napi_env env,
                                             napi_typedarray_type type) {
   napi_value value;
   napi_status status = napi_create_typedarray(
-    env, type, elementLength, arrayBuffer, bufferOffset, &value);
+      env, type, elementLength, arrayBuffer, bufferOffset, &value);
   NAPI_THROW_IF_FAILED(env, status, TypedArrayOf<T>());
 
   return TypedArrayOf<T>(
-    env, value, type, elementLength,
-    reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(arrayBuffer.Data()) + bufferOffset));
+      env,
+      value,
+      type,
+      elementLength,
+      reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(arrayBuffer.Data()) +
+                           bufferOffset));
 }
 
 template <typename T>
-inline TypedArrayOf<T>::TypedArrayOf() : TypedArray(), _data(nullptr) {
-}
+inline TypedArrayOf<T>::TypedArrayOf() : TypedArray(), _data(nullptr) {}
 
 template <typename T>
 inline TypedArrayOf<T>::TypedArrayOf(napi_env env, napi_value value)
-  : TypedArray(env, value), _data(nullptr) {
+    : TypedArray(env, value), _data(nullptr) {
   napi_status status = napi_ok;
   if (value != nullptr) {
     void* data = nullptr;
@@ -2151,21 +2148,24 @@ inline TypedArrayOf<T>::TypedArrayOf(napi_env env,
                                      napi_typedarray_type type,
                                      size_t length,
                                      T* data)
-  : TypedArray(env, value, type, length), _data(data) {
+    : TypedArray(env, value, type, length), _data(data) {
   if (!(type == TypedArrayTypeForPrimitiveType<T>() ||
-      (type == napi_uint8_clamped_array && std::is_same<T, uint8_t>::value))) {
-    NAPI_THROW_VOID(TypeError::New(env, "Array type must match the template parameter. "
-      "(Uint8 arrays may optionally have the \"clamped\" array type.)"));
+        (type == napi_uint8_clamped_array &&
+         std::is_same<T, uint8_t>::value))) {
+    NAPI_THROW_VOID(TypeError::New(
+        env,
+        "Array type must match the template parameter. "
+        "(Uint8 arrays may optionally have the \"clamped\" array type.)"));
   }
 }
 
 template <typename T>
-inline T& TypedArrayOf<T>::operator [](size_t index) {
+inline T& TypedArrayOf<T>::operator[](size_t index) {
   return _data[index];
 }
 
 template <typename T>
-inline const T& TypedArrayOf<T>::operator [](size_t index) const {
+inline const T& TypedArrayOf<T>::operator[](size_t index) const {
   return _data[index];
 }
 
@@ -2184,12 +2184,11 @@ inline const T* TypedArrayOf<T>::Data() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename CbData>
-static inline napi_status
-CreateFunction(napi_env env,
-               const char* utf8name,
-               napi_callback cb,
-               CbData* data,
-               napi_value* result) {
+static inline napi_status CreateFunction(napi_env env,
+                                         const char* utf8name,
+                                         napi_callback cb,
+                                         CbData* data,
+                                         napi_value* result) {
   napi_status status =
       napi_create_function(env, utf8name, NAPI_AUTO_LENGTH, cb, data, result);
   if (status == napi_ok) {
@@ -2249,11 +2248,8 @@ inline Function Function::New(napi_env env,
   auto callbackData = new CbData{std::move(cb), data};
 
   napi_value value;
-  napi_status status = CreateFunction(env,
-                                      utf8name,
-                                      CbData::Wrapper,
-                                      callbackData,
-                                      &value);
+  napi_status status =
+      CreateFunction(env, utf8name, CbData::Wrapper, callbackData, &value);
   if (status != napi_ok) {
     delete callbackData;
     NAPI_THROW_IF_FAILED(env, status, Function());
@@ -2270,11 +2266,10 @@ inline Function Function::New(napi_env env,
   return New(env, cb, utf8name.c_str(), data);
 }
 
-inline Function::Function() : Object() {
-}
+inline Function::Function() : Object() {}
 
-inline Function::Function(napi_env env, napi_value value) : Object(env, value) {
-}
+inline Function::Function(napi_env env, napi_value value)
+    : Object(env, value) {}
 
 inline MaybeOrValue<Value> Function::operator()(
     const std::initializer_list<napi_value>& args) const {
@@ -2336,8 +2331,8 @@ inline MaybeOrValue<Value> Function::Call(napi_value recv,
                                           size_t argc,
                                           const napi_value* args) const {
   napi_value result;
-  napi_status status = napi_call_function(
-    _env, recv, _value, argc, args, &result);
+  napi_status status =
+      napi_call_function(_env, recv, _value, argc, args, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
@@ -2362,8 +2357,8 @@ inline MaybeOrValue<Value> Function::MakeCallback(
     const napi_value* args,
     napi_async_context context) const {
   napi_value result;
-  napi_status status = napi_make_callback(
-    _env, context, recv, _value, argc, args, &result);
+  napi_status status =
+      napi_make_callback(_env, context, recv, _value, argc, args, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
@@ -2381,8 +2376,7 @@ inline MaybeOrValue<Object> Function::New(
 inline MaybeOrValue<Object> Function::New(size_t argc,
                                           const napi_value* args) const {
   napi_value result;
-  napi_status status = napi_new_instance(
-    _env, _value, argc, args, &result);
+  napi_status status = napi_new_instance(_env, _value, argc, args, &result);
   NAPI_RETURN_OR_THROW_IF_FAILED(
       _env, status, Napi::Object(_env, result), Napi::Object);
 }
@@ -2418,8 +2412,7 @@ inline void Promise::Deferred::Reject(napi_value value) const {
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
-inline Promise::Promise(napi_env env, napi_value value) : Object(env, value) {
-}
+inline Promise::Promise(napi_env env, napi_value value) : Object(env, value) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Buffer<T> class
@@ -2429,7 +2422,8 @@ template <typename T>
 inline Buffer<T> Buffer<T>::New(napi_env env, size_t length) {
   napi_value value;
   void* data;
-  napi_status status = napi_create_buffer(env, length * sizeof (T), &data, &value);
+  napi_status status =
+      napi_create_buffer(env, length * sizeof(T), &data, &value);
   NAPI_THROW_IF_FAILED(env, status, Buffer<T>());
   return Buffer(env, value, length, static_cast<T*>(data));
 }
@@ -2438,7 +2432,7 @@ template <typename T>
 inline Buffer<T> Buffer<T>::New(napi_env env, T* data, size_t length) {
   napi_value value;
   napi_status status = napi_create_external_buffer(
-    env, length * sizeof (T), data, nullptr, nullptr, &value);
+      env, length * sizeof(T), data, nullptr, nullptr, &value);
   NAPI_THROW_IF_FAILED(env, status, Buffer<T>());
   return Buffer(env, value, length, data);
 }
@@ -2453,13 +2447,13 @@ inline Buffer<T> Buffer<T>::New(napi_env env,
   details::FinalizeData<T, Finalizer>* finalizeData =
       new details::FinalizeData<T, Finalizer>(
           {std::move(finalizeCallback), nullptr});
-  napi_status status = napi_create_external_buffer(
-    env,
-    length * sizeof (T),
-    data,
-    details::FinalizeData<T, Finalizer>::Wrapper,
-    finalizeData,
-    &value);
+  napi_status status =
+      napi_create_external_buffer(env,
+                                  length * sizeof(T),
+                                  data,
+                                  details::FinalizeData<T, Finalizer>::Wrapper,
+                                  finalizeData,
+                                  &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, Buffer());
@@ -2479,12 +2473,12 @@ inline Buffer<T> Buffer<T>::New(napi_env env,
       new details::FinalizeData<T, Finalizer, Hint>(
           {std::move(finalizeCallback), finalizeHint});
   napi_status status = napi_create_external_buffer(
-    env,
-    length * sizeof (T),
-    data,
-    details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
-    finalizeData,
-    &value);
+      env,
+      length * sizeof(T),
+      data,
+      details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
+      finalizeData,
+      &value);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, Buffer());
@@ -2495,25 +2489,22 @@ inline Buffer<T> Buffer<T>::New(napi_env env,
 template <typename T>
 inline Buffer<T> Buffer<T>::Copy(napi_env env, const T* data, size_t length) {
   napi_value value;
-  napi_status status = napi_create_buffer_copy(
-    env, length * sizeof (T), data, nullptr, &value);
+  napi_status status =
+      napi_create_buffer_copy(env, length * sizeof(T), data, nullptr, &value);
   NAPI_THROW_IF_FAILED(env, status, Buffer<T>());
   return Buffer<T>(env, value);
 }
 
 template <typename T>
-inline Buffer<T>::Buffer() : Uint8Array(), _length(0), _data(nullptr) {
-}
+inline Buffer<T>::Buffer() : Uint8Array(), _length(0), _data(nullptr) {}
 
 template <typename T>
 inline Buffer<T>::Buffer(napi_env env, napi_value value)
-  : Uint8Array(env, value), _length(0), _data(nullptr) {
-}
+    : Uint8Array(env, value), _length(0), _data(nullptr) {}
 
 template <typename T>
 inline Buffer<T>::Buffer(napi_env env, napi_value value, size_t length, T* data)
-  : Uint8Array(env, value), _length(length), _data(data) {
-}
+    : Uint8Array(env, value), _length(length), _data(data) {}
 
 template <typename T>
 inline size_t Buffer<T>::Length() const {
@@ -2535,9 +2526,10 @@ inline void Buffer<T>::EnsureInfo() const {
   if (_data == nullptr) {
     size_t byteLength;
     void* voidData;
-    napi_status status = napi_get_buffer_info(_env, _value, &voidData, &byteLength);
+    napi_status status =
+        napi_get_buffer_info(_env, _value, &voidData, &byteLength);
     NAPI_THROW_IF_FAILED_VOID(_env, status);
-    _length = byteLength / sizeof (T);
+    _length = byteLength / sizeof(T);
     _data = static_cast<T*>(voidData);
   }
 }
@@ -2574,19 +2566,16 @@ inline Error Error::New(napi_env env) {
   // A pending exception takes precedence over any internal error status.
   if (is_exception_pending) {
     status = napi_get_and_clear_last_exception(env, &error);
-    NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_get_and_clear_last_exception");
-  }
-  else {
+    NAPI_FATAL_IF_FAILED(
+        status, "Error::New", "napi_get_and_clear_last_exception");
+  } else {
     const char* error_message = last_error_info_copy.error_message != nullptr
                                     ? last_error_info_copy.error_message
                                     : "Error in native callback";
 
     napi_value message;
     status = napi_create_string_utf8(
-      env,
-      error_message,
-      std::strlen(error_message),
-      &message);
+        env, error_message, std::strlen(error_message), &message);
     NAPI_FATAL_IF_FAILED(status, "Error::New", "napi_create_string_utf8");
 
     switch (last_error_info_copy.error_code) {
@@ -2607,21 +2596,24 @@ inline Error Error::New(napi_env env) {
 }
 
 inline Error Error::New(napi_env env, const char* message) {
-  return Error::New<Error>(env, message, std::strlen(message), napi_create_error);
+  return Error::New<Error>(
+      env, message, std::strlen(message), napi_create_error);
 }
 
 inline Error Error::New(napi_env env, const std::string& message) {
-  return Error::New<Error>(env, message.c_str(), message.size(), napi_create_error);
+  return Error::New<Error>(
+      env, message.c_str(), message.size(), napi_create_error);
 }
 
-inline NAPI_NO_RETURN void Error::Fatal(const char* location, const char* message) {
+inline NAPI_NO_RETURN void Error::Fatal(const char* location,
+                                        const char* message) {
   napi_fatal_error(location, NAPI_AUTO_LENGTH, message, NAPI_AUTO_LENGTH);
 }
 
-inline Error::Error() : ObjectReference() {
-}
+inline Error::Error() : ObjectReference() {}
 
-inline Error::Error(napi_env env, napi_value value) : ObjectReference(env, nullptr) {
+inline Error::Error(napi_env env, napi_value value)
+    : ObjectReference(env, nullptr) {
   if (value != nullptr) {
     // Attempting to create a reference on the error object.
     // If it's not a Object/Function/Symbol, this call will return an error
@@ -2699,18 +2691,16 @@ inline Object Error::Value() const {
   return Object(_env, refValue);
 }
 
-inline Error::Error(Error&& other) : ObjectReference(std::move(other)) {
-}
+inline Error::Error(Error&& other) : ObjectReference(std::move(other)) {}
 
-inline Error& Error::operator =(Error&& other) {
+inline Error& Error::operator=(Error&& other) {
   static_cast<Reference<Object>*>(this)->operator=(std::move(other));
   return *this;
 }
 
-inline Error::Error(const Error& other) : ObjectReference(other) {
-}
+inline Error::Error(const Error& other) : ObjectReference(other) {}
 
-inline Error& Error::operator =(const Error& other) {
+inline Error& Error::operator=(const Error& other) {
   Reset();
 
   _env = other.Env();
@@ -2730,12 +2720,11 @@ inline const std::string& Error::Message() const NAPI_NOEXCEPT {
 #ifdef NAPI_CPP_EXCEPTIONS
     try {
       _message = Get("message").As<String>();
-    }
-    catch (...) {
+    } catch (...) {
       // Catch all errors here, to include e.g. a std::bad_alloc from
       // the std::string::operator=, because this method may not throw.
     }
-#else // NAPI_CPP_EXCEPTIONS
+#else  // NAPI_CPP_EXCEPTIONS
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
     Napi::Value message_val;
     if (Get("message").UnwrapTo(&message_val)) {
@@ -2744,7 +2733,7 @@ inline const std::string& Error::Message() const NAPI_NOEXCEPT {
 #else
     _message = Get("message").As<String>();
 #endif
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
   }
   return _message;
 }
@@ -2790,9 +2779,10 @@ inline void Error::ThrowAsJavaScriptException() const {
     if (status != napi_ok) {
       throw Error::New(_env);
     }
-#else // NAPI_CPP_EXCEPTIONS
-    NAPI_FATAL_IF_FAILED(status, "Error::ThrowAsJavaScriptException", "napi_throw");
-#endif // NAPI_CPP_EXCEPTIONS
+#else   // NAPI_CPP_EXCEPTIONS
+    NAPI_FATAL_IF_FAILED(
+        status, "Error::ThrowAsJavaScriptException", "napi_throw");
+#endif  // NAPI_CPP_EXCEPTIONS
   }
 }
 
@@ -2802,7 +2792,7 @@ inline const char* Error::what() const NAPI_NOEXCEPT {
   return Message().c_str();
 }
 
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 
 inline const char* Error::ERROR_WRAP_VALUE() NAPI_NOEXCEPT {
   return "4bda9e7e-4913-4dbc-95de-891cbf66598e-errorVal";
@@ -2825,39 +2815,42 @@ inline TError Error::New(napi_env env,
 }
 
 inline TypeError TypeError::New(napi_env env, const char* message) {
-  return Error::New<TypeError>(env, message, std::strlen(message), napi_create_type_error);
+  return Error::New<TypeError>(
+      env, message, std::strlen(message), napi_create_type_error);
 }
 
 inline TypeError TypeError::New(napi_env env, const std::string& message) {
-  return Error::New<TypeError>(env, message.c_str(), message.size(), napi_create_type_error);
+  return Error::New<TypeError>(
+      env, message.c_str(), message.size(), napi_create_type_error);
 }
 
-inline TypeError::TypeError() : Error() {
-}
+inline TypeError::TypeError() : Error() {}
 
-inline TypeError::TypeError(napi_env env, napi_value value) : Error(env, value) {
-}
+inline TypeError::TypeError(napi_env env, napi_value value)
+    : Error(env, value) {}
 
 inline RangeError RangeError::New(napi_env env, const char* message) {
-  return Error::New<RangeError>(env, message, std::strlen(message), napi_create_range_error);
+  return Error::New<RangeError>(
+      env, message, std::strlen(message), napi_create_range_error);
 }
 
 inline RangeError RangeError::New(napi_env env, const std::string& message) {
-  return Error::New<RangeError>(env, message.c_str(), message.size(), napi_create_range_error);
+  return Error::New<RangeError>(
+      env, message.c_str(), message.size(), napi_create_range_error);
 }
 
-inline RangeError::RangeError() : Error() {
-}
+inline RangeError::RangeError() : Error() {}
 
-inline RangeError::RangeError(napi_env env, napi_value value) : Error(env, value) {
-}
+inline RangeError::RangeError(napi_env env, napi_value value)
+    : Error(env, value) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Reference<T> class
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline Reference<T> Reference<T>::New(const T& value, uint32_t initialRefcount) {
+inline Reference<T> Reference<T>::New(const T& value,
+                                      uint32_t initialRefcount) {
   napi_env env = value.Env();
   napi_value val = value;
 
@@ -2872,15 +2865,13 @@ inline Reference<T> Reference<T>::New(const T& value, uint32_t initialRefcount) 
   return Reference<T>(env, ref);
 }
 
-
 template <typename T>
-inline Reference<T>::Reference() : _env(nullptr), _ref(nullptr), _suppressDestruct(false) {
-}
+inline Reference<T>::Reference()
+    : _env(nullptr), _ref(nullptr), _suppressDestruct(false) {}
 
 template <typename T>
 inline Reference<T>::Reference(napi_env env, napi_ref ref)
-  : _env(env), _ref(ref), _suppressDestruct(false) {
-}
+    : _env(env), _ref(ref), _suppressDestruct(false) {}
 
 template <typename T>
 inline Reference<T>::~Reference() {
@@ -2895,14 +2886,16 @@ inline Reference<T>::~Reference() {
 
 template <typename T>
 inline Reference<T>::Reference(Reference<T>&& other)
-  : _env(other._env), _ref(other._ref), _suppressDestruct(other._suppressDestruct) {
+    : _env(other._env),
+      _ref(other._ref),
+      _suppressDestruct(other._suppressDestruct) {
   other._env = nullptr;
   other._ref = nullptr;
   other._suppressDestruct = false;
 }
 
 template <typename T>
-inline Reference<T>& Reference<T>::operator =(Reference<T>&& other) {
+inline Reference<T>& Reference<T>::operator=(Reference<T>&& other) {
   Reset();
   _env = other._env;
   _ref = other._ref;
@@ -2915,15 +2908,17 @@ inline Reference<T>& Reference<T>::operator =(Reference<T>&& other) {
 
 template <typename T>
 inline Reference<T>::Reference(const Reference<T>& other)
-  : _env(other._env), _ref(nullptr), _suppressDestruct(false) {
+    : _env(other._env), _ref(nullptr), _suppressDestruct(false) {
   HandleScope scope(_env);
 
   napi_value value = other.Value();
   if (value != nullptr) {
-    // Copying is a limited scenario (currently only used for Error object) and always creates a
-    // strong reference to the given value even if the incoming reference is weak.
+    // Copying is a limited scenario (currently only used for Error object) and
+    // always creates a strong reference to the given value even if the incoming
+    // reference is weak.
     napi_status status = napi_create_reference(_env, value, 1, &_ref);
-    NAPI_FATAL_IF_FAILED(status, "Reference<T>::Reference", "napi_create_reference");
+    NAPI_FATAL_IF_FAILED(
+        status, "Reference<T>::Reference", "napi_create_reference");
   }
 }
 
@@ -2933,14 +2928,14 @@ inline Reference<T>::operator napi_ref() const {
 }
 
 template <typename T>
-inline bool Reference<T>::operator ==(const Reference<T> &other) const {
+inline bool Reference<T>::operator==(const Reference<T>& other) const {
   HandleScope scope(_env);
   return this->Value().StrictEquals(other.Value());
 }
 
 template <typename T>
-inline bool Reference<T>::operator !=(const Reference<T> &other) const {
-  return !this->operator ==(other);
+inline bool Reference<T>::operator!=(const Reference<T>& other) const {
+  return !this->operator==(other);
 }
 
 template <typename T>
@@ -3037,33 +3032,29 @@ inline FunctionReference Persistent(Function value) {
 // ObjectReference class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline ObjectReference::ObjectReference(): Reference<Object>() {
-}
+inline ObjectReference::ObjectReference() : Reference<Object>() {}
 
-inline ObjectReference::ObjectReference(napi_env env, napi_ref ref): Reference<Object>(env, ref) {
-}
+inline ObjectReference::ObjectReference(napi_env env, napi_ref ref)
+    : Reference<Object>(env, ref) {}
 
 inline ObjectReference::ObjectReference(Reference<Object>&& other)
-  : Reference<Object>(std::move(other)) {
-}
+    : Reference<Object>(std::move(other)) {}
 
-inline ObjectReference& ObjectReference::operator =(Reference<Object>&& other) {
+inline ObjectReference& ObjectReference::operator=(Reference<Object>&& other) {
   static_cast<Reference<Object>*>(this)->operator=(std::move(other));
   return *this;
 }
 
 inline ObjectReference::ObjectReference(ObjectReference&& other)
-  : Reference<Object>(std::move(other)) {
-}
+    : Reference<Object>(std::move(other)) {}
 
-inline ObjectReference& ObjectReference::operator =(ObjectReference&& other) {
+inline ObjectReference& ObjectReference::operator=(ObjectReference&& other) {
   static_cast<Reference<Object>*>(this)->operator=(std::move(other));
   return *this;
 }
 
 inline ObjectReference::ObjectReference(const ObjectReference& other)
-  : Reference<Object>(other) {
-}
+    : Reference<Object>(other) {}
 
 inline MaybeOrValue<Napi::Value> ObjectReference::Get(
     const char* utf8name) const {
@@ -3215,27 +3206,25 @@ inline MaybeOrValue<bool> ObjectReference::Set(uint32_t index,
 // FunctionReference class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline FunctionReference::FunctionReference(): Reference<Function>() {
-}
+inline FunctionReference::FunctionReference() : Reference<Function>() {}
 
 inline FunctionReference::FunctionReference(napi_env env, napi_ref ref)
-  : Reference<Function>(env, ref) {
-}
+    : Reference<Function>(env, ref) {}
 
 inline FunctionReference::FunctionReference(Reference<Function>&& other)
-  : Reference<Function>(std::move(other)) {
-}
+    : Reference<Function>(std::move(other)) {}
 
-inline FunctionReference& FunctionReference::operator =(Reference<Function>&& other) {
+inline FunctionReference& FunctionReference::operator=(
+    Reference<Function>&& other) {
   static_cast<Reference<Function>*>(this)->operator=(std::move(other));
   return *this;
 }
 
 inline FunctionReference::FunctionReference(FunctionReference&& other)
-  : Reference<Function>(std::move(other)) {
-}
+    : Reference<Function>(std::move(other)) {}
 
-inline FunctionReference& FunctionReference::operator =(FunctionReference&& other) {
+inline FunctionReference& FunctionReference::operator=(
+    FunctionReference&& other) {
   static_cast<Reference<Function>*>(this)->operator=(std::move(other));
   return *this;
 }
@@ -3441,10 +3430,15 @@ inline MaybeOrValue<Object> FunctionReference::New(
 ////////////////////////////////////////////////////////////////////////////////
 
 inline CallbackInfo::CallbackInfo(napi_env env, napi_callback_info info)
-    : _env(env), _info(info), _this(nullptr), _dynamicArgs(nullptr), _data(nullptr) {
+    : _env(env),
+      _info(info),
+      _this(nullptr),
+      _dynamicArgs(nullptr),
+      _data(nullptr) {
   _argc = _staticArgCount;
   _argv = _staticArgs;
-  napi_status status = napi_get_cb_info(env, info, &_argc, _argv, &_this, &_data);
+  napi_status status =
+      napi_get_cb_info(env, info, &_argc, _argv, &_this, &_data);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 
   if (_argc > _staticArgCount) {
@@ -3483,7 +3477,7 @@ inline size_t CallbackInfo::Length() const {
   return _argc;
 }
 
-inline const Value CallbackInfo::operator [](size_t index) const {
+inline const Value CallbackInfo::operator[](size_t index) const {
   return index < _argc ? Value(_env, _argv[index]) : Env().Undefined();
 }
 
@@ -3507,10 +3501,8 @@ inline void CallbackInfo::SetData(void* data) {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename PropertyDescriptor::GetterCallback Getter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(const char* utf8name,
-                             napi_property_attributes attributes,
-                             void* data) {
+PropertyDescriptor PropertyDescriptor::Accessor(
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
 
   desc.utf8name = utf8name;
@@ -3522,18 +3514,16 @@ PropertyDescriptor::Accessor(const char* utf8name,
 }
 
 template <typename PropertyDescriptor::GetterCallback Getter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(const std::string& utf8name,
-                             napi_property_attributes attributes,
-                             void* data) {
+PropertyDescriptor PropertyDescriptor::Accessor(
+    const std::string& utf8name,
+    napi_property_attributes attributes,
+    void* data) {
   return Accessor<Getter>(utf8name.c_str(), attributes, data);
 }
 
 template <typename PropertyDescriptor::GetterCallback Getter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(Name name,
-                             napi_property_attributes attributes,
-                             void* data) {
+PropertyDescriptor PropertyDescriptor::Accessor(
+    Name name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
 
   desc.name = name;
@@ -3544,14 +3534,10 @@ PropertyDescriptor::Accessor(Name name,
   return desc;
 }
 
-template <
-typename PropertyDescriptor::GetterCallback Getter,
-typename PropertyDescriptor::SetterCallback Setter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(const char* utf8name,
-                             napi_property_attributes attributes,
-                             void* data) {
-
+template <typename PropertyDescriptor::GetterCallback Getter,
+          typename PropertyDescriptor::SetterCallback Setter>
+PropertyDescriptor PropertyDescriptor::Accessor(
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
 
   desc.utf8name = utf8name;
@@ -3563,23 +3549,19 @@ PropertyDescriptor::Accessor(const char* utf8name,
   return desc;
 }
 
-template <
-typename PropertyDescriptor::GetterCallback Getter,
-typename PropertyDescriptor::SetterCallback Setter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(const std::string& utf8name,
-                             napi_property_attributes attributes,
-                             void* data) {
+template <typename PropertyDescriptor::GetterCallback Getter,
+          typename PropertyDescriptor::SetterCallback Setter>
+PropertyDescriptor PropertyDescriptor::Accessor(
+    const std::string& utf8name,
+    napi_property_attributes attributes,
+    void* data) {
   return Accessor<Getter, Setter>(utf8name.c_str(), attributes, data);
 }
 
-template <
-typename PropertyDescriptor::GetterCallback Getter,
-typename PropertyDescriptor::SetterCallback Setter>
-PropertyDescriptor
-PropertyDescriptor::Accessor(Name name,
-                             napi_property_attributes attributes,
-                             void* data) {
+template <typename PropertyDescriptor::GetterCallback Getter,
+          typename PropertyDescriptor::SetterCallback Setter>
+PropertyDescriptor PropertyDescriptor::Accessor(
+    Name name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
 
   desc.name = name;
@@ -3592,15 +3574,15 @@ PropertyDescriptor::Accessor(Name name,
 }
 
 template <typename Getter>
-inline PropertyDescriptor
-PropertyDescriptor::Accessor(Napi::Env env,
-                             Napi::Object object,
-                             const char* utf8name,
-                             Getter getter,
-                             napi_property_attributes attributes,
-                             void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    const char* utf8name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* data) {
   using CbData = details::CallbackData<Getter, Napi::Value>;
-  auto callbackData = new CbData({ getter, data });
+  auto callbackData = new CbData({getter, data});
 
   napi_status status = AttachData(env, object, callbackData);
   if (status != napi_ok) {
@@ -3608,37 +3590,37 @@ PropertyDescriptor::Accessor(Napi::Env env,
     NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
   }
 
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    nullptr,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
-                                                       Napi::Object object,
-                                                       const std::string& utf8name,
-                                                       Getter getter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    const std::string& utf8name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* data) {
   return Accessor(env, object, utf8name.c_str(), getter, attributes, data);
 }
 
 template <typename Getter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
-                                                       Napi::Object object,
-                                                       Name name,
-                                                       Getter getter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    Name name,
+    Getter getter,
+    napi_property_attributes attributes,
+    void* data) {
   using CbData = details::CallbackData<Getter, Napi::Value>;
-  auto callbackData = new CbData({ getter, data });
+  auto callbackData = new CbData({getter, data});
 
   napi_status status = AttachData(env, object, callbackData);
   if (status != napi_ok) {
@@ -3646,28 +3628,27 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
     NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
   }
 
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    nullptr,
-    CbData::Wrapper,
-    nullptr,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({nullptr,
+                             name,
+                             nullptr,
+                             CbData::Wrapper,
+                             nullptr,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
-                                                       Napi::Object object,
-                                                       const char* utf8name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    const char* utf8name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* data) {
   using CbData = details::AccessorCallbackData<Getter, Setter>;
-  auto callbackData = new CbData({ getter, setter, data });
+  auto callbackData = new CbData({getter, setter, data});
 
   napi_status status = AttachData(env, object, callbackData);
   if (status != napi_ok) {
@@ -3675,39 +3656,40 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
     NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
   }
 
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    nullptr,
-    CbData::GetterWrapper,
-    CbData::SetterWrapper,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             CbData::GetterWrapper,
+                             CbData::SetterWrapper,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
-                                                       Napi::Object object,
-                                                       const std::string& utf8name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
-  return Accessor(env, object, utf8name.c_str(), getter, setter, attributes, data);
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    const std::string& utf8name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* data) {
+  return Accessor(
+      env, object, utf8name.c_str(), getter, setter, attributes, data);
 }
 
 template <typename Getter, typename Setter>
-inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
-                                                       Napi::Object object,
-                                                       Name name,
-                                                       Getter getter,
-                                                       Setter setter,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Accessor(
+    Napi::Env env,
+    Napi::Object object,
+    Name name,
+    Getter getter,
+    Setter setter,
+    napi_property_attributes attributes,
+    void* data) {
   using CbData = details::AccessorCallbackData<Getter, Setter>;
-  auto callbackData = new CbData({ getter, setter, data });
+  auto callbackData = new CbData({getter, setter, data});
 
   napi_status status = AttachData(env, object, callbackData);
   if (status != napi_ok) {
@@ -3715,99 +3697,99 @@ inline PropertyDescriptor PropertyDescriptor::Accessor(Napi::Env env,
     NAPI_THROW_IF_FAILED(env, status, napi_property_descriptor());
   }
 
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    nullptr,
-    CbData::GetterWrapper,
-    CbData::SetterWrapper,
-    nullptr,
-    attributes,
-    callbackData
-  });
+  return PropertyDescriptor({nullptr,
+                             name,
+                             nullptr,
+                             CbData::GetterWrapper,
+                             CbData::SetterWrapper,
+                             nullptr,
+                             attributes,
+                             callbackData});
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(Napi::Env env,
-                                                       Napi::Object /*object*/,
-                                                       const char* utf8name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
-  return PropertyDescriptor({
-    utf8name,
-    nullptr,
-    nullptr,
-    nullptr,
-    nullptr,
-    Napi::Function::New(env, cb, utf8name, data),
-    attributes,
-    nullptr
-  });
+inline PropertyDescriptor PropertyDescriptor::Function(
+    Napi::Env env,
+    Napi::Object /*object*/,
+    const char* utf8name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* data) {
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             Napi::Function::New(env, cb, utf8name, data),
+                             attributes,
+                             nullptr});
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(Napi::Env env,
-                                                       Napi::Object object,
-                                                       const std::string& utf8name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
+inline PropertyDescriptor PropertyDescriptor::Function(
+    Napi::Env env,
+    Napi::Object object,
+    const std::string& utf8name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* data) {
   return Function(env, object, utf8name.c_str(), cb, attributes, data);
 }
 
 template <typename Callable>
-inline PropertyDescriptor PropertyDescriptor::Function(Napi::Env env,
-                                                       Napi::Object /*object*/,
-                                                       Name name,
-                                                       Callable cb,
-                                                       napi_property_attributes attributes,
-                                                       void* data) {
-  return PropertyDescriptor({
-    nullptr,
-    name,
-    nullptr,
-    nullptr,
-    nullptr,
-    Napi::Function::New(env, cb, nullptr, data),
-    attributes,
-    nullptr
-  });
+inline PropertyDescriptor PropertyDescriptor::Function(
+    Napi::Env env,
+    Napi::Object /*object*/,
+    Name name,
+    Callable cb,
+    napi_property_attributes attributes,
+    void* data) {
+  return PropertyDescriptor({nullptr,
+                             name,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             Napi::Function::New(env, cb, nullptr, data),
+                             attributes,
+                             nullptr});
 }
 
-inline PropertyDescriptor PropertyDescriptor::Value(const char* utf8name,
-                                                    napi_value value,
-                                                    napi_property_attributes attributes) {
-  return PropertyDescriptor({
-    utf8name, nullptr, nullptr, nullptr, nullptr, value, attributes, nullptr
-  });
+inline PropertyDescriptor PropertyDescriptor::Value(
+    const char* utf8name,
+    napi_value value,
+    napi_property_attributes attributes) {
+  return PropertyDescriptor({utf8name,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             nullptr,
+                             value,
+                             attributes,
+                             nullptr});
 }
 
-inline PropertyDescriptor PropertyDescriptor::Value(const std::string& utf8name,
-                                                    napi_value value,
-                                                    napi_property_attributes attributes) {
+inline PropertyDescriptor PropertyDescriptor::Value(
+    const std::string& utf8name,
+    napi_value value,
+    napi_property_attributes attributes) {
   return Value(utf8name.c_str(), value, attributes);
 }
 
-inline PropertyDescriptor PropertyDescriptor::Value(napi_value name,
-                                                    napi_value value,
-                                                    napi_property_attributes attributes) {
-  return PropertyDescriptor({
-    nullptr, name, nullptr, nullptr, nullptr, value, attributes, nullptr
-  });
+inline PropertyDescriptor PropertyDescriptor::Value(
+    napi_value name, napi_value value, napi_property_attributes attributes) {
+  return PropertyDescriptor(
+      {nullptr, name, nullptr, nullptr, nullptr, value, attributes, nullptr});
 }
 
-inline PropertyDescriptor PropertyDescriptor::Value(Name name,
-                                                    Napi::Value value,
-                                                    napi_property_attributes attributes) {
+inline PropertyDescriptor PropertyDescriptor::Value(
+    Name name, Napi::Value value, napi_property_attributes attributes) {
   napi_value nameValue = name;
   napi_value valueValue = value;
   return PropertyDescriptor::Value(nameValue, valueValue, attributes);
 }
 
 inline PropertyDescriptor::PropertyDescriptor(napi_property_descriptor desc)
-  : _desc(desc) {
-}
+    : _desc(desc) {}
 
 inline PropertyDescriptor::operator napi_property_descriptor&() {
   return _desc;
@@ -3822,26 +3804,22 @@ inline PropertyDescriptor::operator const napi_property_descriptor&() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline void InstanceWrap<T>::AttachPropData(napi_env env,
-                                       napi_value value,
-                                       const napi_property_descriptor* prop) {
+inline void InstanceWrap<T>::AttachPropData(
+    napi_env env, napi_value value, const napi_property_descriptor* prop) {
   napi_status status;
   if (!(prop->attributes & napi_static)) {
     if (prop->method == T::InstanceVoidMethodCallbackWrapper) {
-      status = Napi::details::AttachData(env,
-                    value,
-                    static_cast<InstanceVoidMethodCallbackData*>(prop->data));
+      status = Napi::details::AttachData(
+          env, value, static_cast<InstanceVoidMethodCallbackData*>(prop->data));
       NAPI_THROW_IF_FAILED_VOID(env, status);
     } else if (prop->method == T::InstanceMethodCallbackWrapper) {
-      status = Napi::details::AttachData(env,
-                        value,
-                        static_cast<InstanceMethodCallbackData*>(prop->data));
+      status = Napi::details::AttachData(
+          env, value, static_cast<InstanceMethodCallbackData*>(prop->data));
       NAPI_THROW_IF_FAILED_VOID(env, status);
     } else if (prop->getter == T::InstanceGetterCallbackWrapper ||
-        prop->setter == T::InstanceSetterCallbackWrapper) {
-      status = Napi::details::AttachData(env,
-                          value,
-                          static_cast<InstanceAccessorCallbackData*>(prop->data));
+               prop->setter == T::InstanceSetterCallbackWrapper) {
+      status = Napi::details::AttachData(
+          env, value, static_cast<InstanceAccessorCallbackData*>(prop->data));
       NAPI_THROW_IF_FAILED_VOID(env, status);
     }
   }
@@ -3854,7 +3832,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
     napi_property_attributes attributes,
     void* data) {
   InstanceVoidMethodCallbackData* callbackData =
-    new InstanceVoidMethodCallbackData({ method, data});
+      new InstanceVoidMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
@@ -3870,7 +3848,8 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
     InstanceMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  InstanceMethodCallbackData* callbackData = new InstanceMethodCallbackData({ method, data });
+  InstanceMethodCallbackData* callbackData =
+      new InstanceMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
@@ -3887,7 +3866,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
     napi_property_attributes attributes,
     void* data) {
   InstanceVoidMethodCallbackData* callbackData =
-    new InstanceVoidMethodCallbackData({ method, data});
+      new InstanceVoidMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
@@ -3903,7 +3882,8 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
     InstanceMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  InstanceMethodCallbackData* callbackData = new InstanceMethodCallbackData({ method, data });
+  InstanceMethodCallbackData* callbackData =
+      new InstanceMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
@@ -3916,9 +3896,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
 template <typename T>
 template <typename InstanceWrap<T>::InstanceVoidMethodCallback method>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
-    const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = details::TemplatedInstanceVoidCallback<T, method>;
@@ -3930,9 +3908,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
 template <typename T>
 template <typename InstanceWrap<T>::InstanceMethodCallback method>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
-    const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = details::TemplatedInstanceCallback<T, method>;
@@ -3944,9 +3920,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
 template <typename T>
 template <typename InstanceWrap<T>::InstanceVoidMethodCallback method>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
+    Symbol name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = details::TemplatedInstanceVoidCallback<T, method>;
@@ -3958,9 +3932,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
 template <typename T>
 template <typename InstanceWrap<T>::InstanceMethodCallback method>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceMethod(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
+    Symbol name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = details::TemplatedInstanceCallback<T, method>;
@@ -3977,7 +3949,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceAccessor(
     napi_property_attributes attributes,
     void* data) {
   InstanceAccessorCallbackData* callbackData =
-    new InstanceAccessorCallbackData({ getter, setter, data });
+      new InstanceAccessorCallbackData({getter, setter, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
@@ -3996,7 +3968,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceAccessor(
     napi_property_attributes attributes,
     void* data) {
   InstanceAccessorCallbackData* callbackData =
-    new InstanceAccessorCallbackData({ getter, setter, data });
+      new InstanceAccessorCallbackData({getter, setter, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
@@ -4011,9 +3983,7 @@ template <typename T>
 template <typename InstanceWrap<T>::InstanceGetterCallback getter,
           typename InstanceWrap<T>::InstanceSetterCallback setter>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceAccessor(
-    const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.getter = details::TemplatedInstanceCallback<T, getter>;
@@ -4027,9 +3997,7 @@ template <typename T>
 template <typename InstanceWrap<T>::InstanceGetterCallback getter,
           typename InstanceWrap<T>::InstanceSetterCallback setter>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceAccessor(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
+    Symbol name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.getter = details::TemplatedInstanceCallback<T, getter>;
@@ -4053,9 +4021,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceValue(
 
 template <typename T>
 inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceValue(
-    Symbol name,
-    Napi::Value value,
-    napi_property_attributes attributes) {
+    Symbol name, Napi::Value value, napi_property_attributes attributes) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.value = value;
@@ -4065,12 +4031,11 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceValue(
 
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceVoidMethodCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     InstanceVoidMethodCallbackData* callbackData =
-      reinterpret_cast<InstanceVoidMethodCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<InstanceVoidMethodCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->callback;
@@ -4081,12 +4046,11 @@ inline napi_value InstanceWrap<T>::InstanceVoidMethodCallbackWrapper(
 
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceMethodCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     InstanceMethodCallbackData* callbackData =
-      reinterpret_cast<InstanceMethodCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<InstanceMethodCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->callback;
@@ -4096,12 +4060,11 @@ inline napi_value InstanceWrap<T>::InstanceMethodCallbackWrapper(
 
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceGetterCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     InstanceAccessorCallbackData* callbackData =
-      reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->getterCallback;
@@ -4111,12 +4074,11 @@ inline napi_value InstanceWrap<T>::InstanceGetterCallbackWrapper(
 
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     InstanceAccessorCallbackData* callbackData =
-      reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->setterCallback;
@@ -4169,7 +4131,7 @@ inline ObjectWrap<T>::~ObjectWrap() {
   }
 }
 
-template<typename T>
+template <typename T>
 inline T* ObjectWrap<T>::Unwrap(Object wrapper) {
   void* unwrapped;
   napi_status status = napi_unwrap(wrapper.Env(), wrapper, &unwrapped);
@@ -4178,12 +4140,12 @@ inline T* ObjectWrap<T>::Unwrap(Object wrapper) {
 }
 
 template <typename T>
-inline Function
-ObjectWrap<T>::DefineClass(Napi::Env env,
-                           const char* utf8name,
-                           const size_t props_count,
-                           const napi_property_descriptor* descriptors,
-                           void* data) {
+inline Function ObjectWrap<T>::DefineClass(
+    Napi::Env env,
+    const char* utf8name,
+    const size_t props_count,
+    const napi_property_descriptor* descriptors,
+    void* data) {
   napi_status status;
   std::vector<napi_property_descriptor> props(props_count);
 
@@ -4199,16 +4161,18 @@ ObjectWrap<T>::DefineClass(Napi::Env env,
     props[index] = descriptors[index];
     napi_property_descriptor* prop = &props[index];
     if (prop->method == T::StaticMethodCallbackWrapper) {
-      status = CreateFunction(env,
-                             utf8name,
-                             prop->method,
-                             static_cast<StaticMethodCallbackData*>(prop->data),
-               &(prop->value));
+      status =
+          CreateFunction(env,
+                         utf8name,
+                         prop->method,
+                         static_cast<StaticMethodCallbackData*>(prop->data),
+                         &(prop->value));
       NAPI_THROW_IF_FAILED(env, status, Function());
       prop->method = nullptr;
       prop->data = nullptr;
     } else if (prop->method == T::StaticVoidMethodCallbackWrapper) {
-      status = CreateFunction(env,
+      status =
+          CreateFunction(env,
                          utf8name,
                          prop->method,
                          static_cast<StaticVoidMethodCallbackData*>(prop->data),
@@ -4238,9 +4202,8 @@ ObjectWrap<T>::DefineClass(Napi::Env env,
 
     if (prop->getter == T::StaticGetterCallbackWrapper ||
         prop->setter == T::StaticSetterCallbackWrapper) {
-      status = Napi::details::AttachData(env,
-                          value,
-                          static_cast<StaticAccessorCallbackData*>(prop->data));
+      status = Napi::details::AttachData(
+          env, value, static_cast<StaticAccessorCallbackData*>(prop->data));
       NAPI_THROW_IF_FAILED(env, status, Function());
     } else {
       // InstanceWrap<T>::AttachPropData is responsible for attaching the data
@@ -4258,11 +4221,12 @@ inline Function ObjectWrap<T>::DefineClass(
     const char* utf8name,
     const std::initializer_list<ClassPropertyDescriptor<T>>& properties,
     void* data) {
-  return DefineClass(env,
-          utf8name,
-          properties.size(),
-          reinterpret_cast<const napi_property_descriptor*>(properties.begin()),
-          data);
+  return DefineClass(
+      env,
+      utf8name,
+      properties.size(),
+      reinterpret_cast<const napi_property_descriptor*>(properties.begin()),
+      data);
 }
 
 template <typename T>
@@ -4271,11 +4235,12 @@ inline Function ObjectWrap<T>::DefineClass(
     const char* utf8name,
     const std::vector<ClassPropertyDescriptor<T>>& properties,
     void* data) {
-  return DefineClass(env,
-           utf8name,
-           properties.size(),
-           reinterpret_cast<const napi_property_descriptor*>(properties.data()),
-           data);
+  return DefineClass(
+      env,
+      utf8name,
+      properties.size(),
+      reinterpret_cast<const napi_property_descriptor*>(properties.data()),
+      data);
 }
 
 template <typename T>
@@ -4284,13 +4249,15 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
     StaticVoidMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  StaticVoidMethodCallbackData* callbackData = new StaticVoidMethodCallbackData({ method, data });
+  StaticVoidMethodCallbackData* callbackData =
+      new StaticVoidMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::StaticVoidMethodCallbackWrapper;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4300,13 +4267,15 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
     StaticMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  StaticMethodCallbackData* callbackData = new StaticMethodCallbackData({ method, data });
+  StaticMethodCallbackData* callbackData =
+      new StaticMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = T::StaticMethodCallbackWrapper;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4316,13 +4285,15 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
     StaticVoidMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  StaticVoidMethodCallbackData* callbackData = new StaticVoidMethodCallbackData({ method, data });
+  StaticVoidMethodCallbackData* callbackData =
+      new StaticVoidMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = T::StaticVoidMethodCallbackWrapper;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4332,69 +4303,67 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
     StaticMethodCallback method,
     napi_property_attributes attributes,
     void* data) {
-  StaticMethodCallbackData* callbackData = new StaticMethodCallbackData({ method, data });
+  StaticMethodCallbackData* callbackData =
+      new StaticMethodCallbackData({method, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = T::StaticMethodCallbackWrapper;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticVoidMethodCallback method>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
-    const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = details::TemplatedVoidCallback<method>;
   desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticVoidMethodCallback method>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
+    Symbol name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = details::TemplatedVoidCallback<method>;
   desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticMethodCallback method>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
-    const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
+    const char* utf8name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.method = details::TemplatedCallback<method>;
   desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
 template <typename T>
 template <typename ObjectWrap<T>::StaticMethodCallback method>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticMethod(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
+    Symbol name, napi_property_attributes attributes, void* data) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.method = details::TemplatedCallback<method>;
   desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4406,14 +4375,15 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
     napi_property_attributes attributes,
     void* data) {
   StaticAccessorCallbackData* callbackData =
-    new StaticAccessorCallbackData({ getter, setter, data });
+      new StaticAccessorCallbackData({getter, setter, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
   desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4425,14 +4395,15 @@ inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
     napi_property_attributes attributes,
     void* data) {
   StaticAccessorCallbackData* callbackData =
-    new StaticAccessorCallbackData({ getter, setter, data });
+      new StaticAccessorCallbackData({getter, setter, data});
 
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.getter = getter != nullptr ? T::StaticGetterCallbackWrapper : nullptr;
   desc.setter = setter != nullptr ? T::StaticSetterCallbackWrapper : nullptr;
   desc.data = callbackData;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4440,51 +4411,53 @@ template <typename T>
 template <typename ObjectWrap<T>::StaticGetterCallback getter,
           typename ObjectWrap<T>::StaticSetterCallback setter>
 inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
+    const char* utf8name, napi_property_attributes attributes, void* data) {
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.utf8name = utf8name;
+  desc.getter = details::TemplatedCallback<getter>;
+  desc.setter = This::WrapStaticSetter(This::StaticSetterTag<setter>());
+  desc.data = data;
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
+template <typename ObjectWrap<T>::StaticGetterCallback getter,
+          typename ObjectWrap<T>::StaticSetterCallback setter>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
+    Symbol name, napi_property_attributes attributes, void* data) {
+  napi_property_descriptor desc = napi_property_descriptor();
+  desc.name = name;
+  desc.getter = details::TemplatedCallback<getter>;
+  desc.setter = This::WrapStaticSetter(This::StaticSetterTag<setter>());
+  desc.data = data;
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
+  return desc;
+}
+
+template <typename T>
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(
     const char* utf8name,
-    napi_property_attributes attributes,
-    void* data) {
-  napi_property_descriptor desc = napi_property_descriptor();
-  desc.utf8name = utf8name;
-  desc.getter = details::TemplatedCallback<getter>;
-  desc.setter = This::WrapStaticSetter(This::StaticSetterTag<setter>());
-  desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
-  return desc;
-}
-
-template <typename T>
-template <typename ObjectWrap<T>::StaticGetterCallback getter,
-          typename ObjectWrap<T>::StaticSetterCallback setter>
-inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticAccessor(
-    Symbol name,
-    napi_property_attributes attributes,
-    void* data) {
-  napi_property_descriptor desc = napi_property_descriptor();
-  desc.name = name;
-  desc.getter = details::TemplatedCallback<getter>;
-  desc.setter = This::WrapStaticSetter(This::StaticSetterTag<setter>());
-  desc.data = data;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
-  return desc;
-}
-
-template <typename T>
-inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(const char* utf8name,
-    Napi::Value value, napi_property_attributes attributes) {
+    Napi::Value value,
+    napi_property_attributes attributes) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.utf8name = utf8name;
   desc.value = value;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
 template <typename T>
-inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(Symbol name,
-    Napi::Value value, napi_property_attributes attributes) {
+inline ClassPropertyDescriptor<T> ObjectWrap<T>::StaticValue(
+    Symbol name, Napi::Value value, napi_property_attributes attributes) {
   napi_property_descriptor desc = napi_property_descriptor();
   desc.name = name;
   desc.value = value;
-  desc.attributes = static_cast<napi_property_attributes>(attributes | napi_static);
+  desc.attributes =
+      static_cast<napi_property_attributes>(attributes | napi_static);
   return desc;
 }
 
@@ -4502,8 +4475,7 @@ inline void ObjectWrap<T>::Finalize(Napi::Env /*env*/) {}
 
 template <typename T>
 inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   napi_value new_target;
   napi_status status = napi_get_new_target(env, info, &new_target);
   if (status != napi_ok) return nullptr;
@@ -4528,7 +4500,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
     } else {
       instance->_construction_failed = false;
     }
-# endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
     return callbackInfo.This();
   });
 
@@ -4537,12 +4509,11 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
 
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticVoidMethodCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     StaticVoidMethodCallbackData* callbackData =
-      reinterpret_cast<StaticVoidMethodCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<StaticVoidMethodCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     callbackData->callback(callbackInfo);
     return nullptr;
@@ -4551,12 +4522,11 @@ inline napi_value ObjectWrap<T>::StaticVoidMethodCallbackWrapper(
 
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticMethodCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     StaticMethodCallbackData* callbackData =
-      reinterpret_cast<StaticMethodCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<StaticMethodCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     return callbackData->callback(callbackInfo);
   });
@@ -4564,12 +4534,11 @@ inline napi_value ObjectWrap<T>::StaticMethodCallbackWrapper(
 
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticGetterCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     StaticAccessorCallbackData* callbackData =
-      reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     return callbackData->getterCallback(callbackInfo);
   });
@@ -4577,12 +4546,11 @@ inline napi_value ObjectWrap<T>::StaticGetterCallbackWrapper(
 
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticSetterCallbackWrapper(
-    napi_env env,
-    napi_callback_info info) {
+    napi_env env, napi_callback_info info) {
   return details::WrapCallback([&] {
     CallbackInfo callbackInfo(env, info);
     StaticAccessorCallbackData* callbackData =
-      reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
+        reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
     callbackInfo.SetData(callbackData->data);
     callbackData->setterCallback(callbackInfo, callbackInfo[0]);
     return nullptr;
@@ -4590,7 +4558,9 @@ inline napi_value ObjectWrap<T>::StaticSetterCallbackWrapper(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::FinalizeCallback(napi_env env, void* data, void* /*hint*/) {
+inline void ObjectWrap<T>::FinalizeCallback(napi_env env,
+                                            void* data,
+                                            void* /*hint*/) {
   HandleScope scope(env);
   T* instance = static_cast<T*>(data);
   instance->Finalize(Napi::Env(env));
@@ -4613,8 +4583,7 @@ inline napi_value ObjectWrap<T>::WrappedMethod(
 ////////////////////////////////////////////////////////////////////////////////
 
 inline HandleScope::HandleScope(napi_env env, napi_handle_scope scope)
-    : _env(env), _scope(scope) {
-}
+    : _env(env), _scope(scope) {}
 
 inline HandleScope::HandleScope(Napi::Env env) : _env(env) {
   napi_status status = napi_open_handle_scope(_env, &_scope);
@@ -4623,9 +4592,8 @@ inline HandleScope::HandleScope(Napi::Env env) : _env(env) {
 
 inline HandleScope::~HandleScope() {
   napi_status status = napi_close_handle_scope(_env, _scope);
-  NAPI_FATAL_IF_FAILED(status,
-                       "HandleScope::~HandleScope",
-                       "napi_close_handle_scope");
+  NAPI_FATAL_IF_FAILED(
+      status, "HandleScope::~HandleScope", "napi_close_handle_scope");
 }
 
 inline HandleScope::operator napi_handle_scope() const {
@@ -4641,8 +4609,8 @@ inline Napi::Env HandleScope::Env() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline EscapableHandleScope::EscapableHandleScope(
-  napi_env env, napi_escapable_handle_scope scope) : _env(env), _scope(scope) {
-}
+    napi_env env, napi_escapable_handle_scope scope)
+    : _env(env), _scope(scope) {}
 
 inline EscapableHandleScope::EscapableHandleScope(Napi::Env env) : _env(env) {
   napi_status status = napi_open_escapable_handle_scope(_env, &_scope);
@@ -4671,28 +4639,25 @@ inline Value EscapableHandleScope::Escape(napi_value escapee) {
   return Value(_env, result);
 }
 
-
 #if (NAPI_VERSION > 2)
 ////////////////////////////////////////////////////////////////////////////////
 // CallbackScope class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline CallbackScope::CallbackScope(
-  napi_env env, napi_callback_scope scope) : _env(env), _scope(scope) {
-}
+inline CallbackScope::CallbackScope(napi_env env, napi_callback_scope scope)
+    : _env(env), _scope(scope) {}
 
 inline CallbackScope::CallbackScope(napi_env env, napi_async_context context)
     : _env(env) {
-  napi_status status = napi_open_callback_scope(
-      _env, Object::New(env), context, &_scope);
+  napi_status status =
+      napi_open_callback_scope(_env, Object::New(env), context, &_scope);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
 inline CallbackScope::~CallbackScope() {
   napi_status status = napi_close_callback_scope(_env, _scope);
-  NAPI_FATAL_IF_FAILED(status,
-                       "CallbackScope::~CallbackScope",
-                       "napi_close_callback_scope");
+  NAPI_FATAL_IF_FAILED(
+      status, "CallbackScope::~CallbackScope", "napi_close_callback_scope");
 }
 
 inline CallbackScope::operator napi_callback_scope() const {
@@ -4709,8 +4674,7 @@ inline Napi::Env CallbackScope::Env() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline AsyncContext::AsyncContext(napi_env env, const char* resource_name)
-  : AsyncContext(env, resource_name, Object::New(env)) {
-}
+    : AsyncContext(env, resource_name, Object::New(env)) {}
 
 inline AsyncContext::AsyncContext(napi_env env,
                                   const char* resource_name,
@@ -4739,7 +4703,7 @@ inline AsyncContext::AsyncContext(AsyncContext&& other) {
   other._context = nullptr;
 }
 
-inline AsyncContext& AsyncContext::operator =(AsyncContext&& other) {
+inline AsyncContext& AsyncContext::operator=(AsyncContext&& other) {
   _env = other._env;
   other._env = nullptr;
   _context = other._context;
@@ -4760,78 +4724,72 @@ inline Napi::Env AsyncContext::Env() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 inline AsyncWorker::AsyncWorker(const Function& callback)
-  : AsyncWorker(callback, "generic") {
-}
+    : AsyncWorker(callback, "generic") {}
 
 inline AsyncWorker::AsyncWorker(const Function& callback,
                                 const char* resource_name)
-  : AsyncWorker(callback, resource_name, Object::New(callback.Env())) {
-}
+    : AsyncWorker(callback, resource_name, Object::New(callback.Env())) {}
 
 inline AsyncWorker::AsyncWorker(const Function& callback,
                                 const char* resource_name,
                                 const Object& resource)
-  : AsyncWorker(Object::New(callback.Env()),
-                callback,
-                resource_name,
-                resource) {
-}
+    : AsyncWorker(
+          Object::New(callback.Env()), callback, resource_name, resource) {}
 
 inline AsyncWorker::AsyncWorker(const Object& receiver,
                                 const Function& callback)
-  : AsyncWorker(receiver, callback, "generic") {
-}
+    : AsyncWorker(receiver, callback, "generic") {}
 
 inline AsyncWorker::AsyncWorker(const Object& receiver,
                                 const Function& callback,
                                 const char* resource_name)
-  : AsyncWorker(receiver,
-                callback,
-                resource_name,
-                Object::New(callback.Env())) {
-}
+    : AsyncWorker(
+          receiver, callback, resource_name, Object::New(callback.Env())) {}
 
 inline AsyncWorker::AsyncWorker(const Object& receiver,
                                 const Function& callback,
                                 const char* resource_name,
                                 const Object& resource)
-  : _env(callback.Env()),
-    _receiver(Napi::Persistent(receiver)),
-    _callback(Napi::Persistent(callback)),
-    _suppress_destruct(false) {
+    : _env(callback.Env()),
+      _receiver(Napi::Persistent(receiver)),
+      _callback(Napi::Persistent(callback)),
+      _suppress_destruct(false) {
   napi_value resource_id;
   napi_status status = napi_create_string_latin1(
       _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 
-  status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
-                                  OnAsyncWorkComplete, this, &_work);
+  status = napi_create_async_work(_env,
+                                  resource,
+                                  resource_id,
+                                  OnAsyncWorkExecute,
+                                  OnAsyncWorkComplete,
+                                  this,
+                                  &_work);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
-inline AsyncWorker::AsyncWorker(Napi::Env env)
-  : AsyncWorker(env, "generic") {
-}
+inline AsyncWorker::AsyncWorker(Napi::Env env) : AsyncWorker(env, "generic") {}
 
-inline AsyncWorker::AsyncWorker(Napi::Env env,
-                                const char* resource_name)
-  : AsyncWorker(env, resource_name, Object::New(env)) {
-}
+inline AsyncWorker::AsyncWorker(Napi::Env env, const char* resource_name)
+    : AsyncWorker(env, resource_name, Object::New(env)) {}
 
 inline AsyncWorker::AsyncWorker(Napi::Env env,
                                 const char* resource_name,
                                 const Object& resource)
-  : _env(env),
-    _receiver(),
-    _callback(),
-    _suppress_destruct(false) {
+    : _env(env), _receiver(), _callback(), _suppress_destruct(false) {
   napi_value resource_id;
   napi_status status = napi_create_string_latin1(
       _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 
-  status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
-                                  OnAsyncWorkComplete, this, &_work);
+  status = napi_create_async_work(_env,
+                                  resource,
+                                  resource_id,
+                                  OnAsyncWorkExecute,
+                                  OnAsyncWorkComplete,
+                                  this,
+                                  &_work);
   NAPI_THROW_IF_FAILED_VOID(_env, status);
 }
 
@@ -4857,7 +4815,7 @@ inline AsyncWorker::AsyncWorker(AsyncWorker&& other) {
   _suppress_destruct = other._suppress_destruct;
 }
 
-inline AsyncWorker& AsyncWorker::operator =(AsyncWorker&& other) {
+inline AsyncWorker& AsyncWorker::operator=(AsyncWorker&& other) {
   _env = other._env;
   other._env = nullptr;
   _work = other._work;
@@ -4907,7 +4865,8 @@ inline void AsyncWorker::OnOK() {
 
 inline void AsyncWorker::OnError(const Error& e) {
   if (!_callback.IsEmpty()) {
-    _callback.Call(_receiver.Value(), std::initializer_list<napi_value>{ e.Value() });
+    _callback.Call(_receiver.Value(),
+                   std::initializer_list<napi_value>{e.Value()});
   }
 }
 
@@ -4937,9 +4896,9 @@ inline void AsyncWorker::OnExecute(Napi::Env /*DO_NOT_USE*/) {
   } catch (const std::exception& e) {
     SetError(e.what());
   }
-#else // NAPI_CPP_EXCEPTIONS
+#else   // NAPI_CPP_EXCEPTIONS
   Execute();
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 }
 
 inline void AsyncWorker::OnAsyncWorkComplete(napi_env env,
@@ -4954,8 +4913,7 @@ inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
     details::WrapCallback([&] {
       if (_error.size() == 0) {
         OnOK();
-      }
-      else {
+      } else {
         OnError(Error::New(_env, _error));
       }
       return nullptr;
@@ -5458,68 +5416,93 @@ TypedThreadSafeFunction<ContextType, DataType, CallJs>::FunctionOrEmpty(
 // static
 template <typename ResourceString>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount);
+                                                  const Function& callback,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount) {
+  return New(
+      env, callback, Object(), resourceName, maxQueueSize, initialThreadCount);
 }
 
 // static
 template <typename ResourceString, typename ContextType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount, context);
+                                                  const Function& callback,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  ContextType* context) {
+  return New(env,
+             callback,
+             Object(),
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             context);
 }
 
 // static
 template <typename ResourceString, typename Finalizer>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount, finalizeCallback);
+                                                  const Function& callback,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  Finalizer finalizeCallback) {
+  return New(env,
+             callback,
+             Object(),
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             finalizeCallback);
 }
 
 // static
-template <typename ResourceString, typename Finalizer,
+template <typename ResourceString,
+          typename Finalizer,
           typename FinalizerDataType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount, finalizeCallback, data);
+                                                  const Function& callback,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  Finalizer finalizeCallback,
+                                                  FinalizerDataType* data) {
+  return New(env,
+             callback,
+             Object(),
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             finalizeCallback,
+             data);
 }
 
 // static
 template <typename ResourceString, typename ContextType, typename Finalizer>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount, context, finalizeCallback);
+                                                  const Function& callback,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  ContextType* context,
+                                                  Finalizer finalizeCallback) {
+  return New(env,
+             callback,
+             Object(),
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             context,
+             finalizeCallback);
 }
 
 // static
-template <typename ResourceString, typename ContextType,
-          typename Finalizer, typename FinalizerDataType>
+template <typename ResourceString,
+          typename ContextType,
+          typename Finalizer,
+          typename FinalizerDataType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   const Function& callback,
                                                   ResourceString resourceName,
@@ -5528,89 +5511,128 @@ inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   ContextType* context,
                                                   Finalizer finalizeCallback,
                                                   FinalizerDataType* data) {
-  return New(env, callback, Object(), resourceName, maxQueueSize,
-             initialThreadCount, context, finalizeCallback, data);
+  return New(env,
+             callback,
+             Object(),
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             context,
+             finalizeCallback,
+             data);
 }
 
 // static
 template <typename ResourceString>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, static_cast<void*>(nullptr) /* context */);
+                                                  const Function& callback,
+                                                  const Object& resource,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount) {
+  return New(env,
+             callback,
+             resource,
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             static_cast<void*>(nullptr) /* context */);
 }
 
 // static
 template <typename ResourceString, typename ContextType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, context,
+                                                  const Function& callback,
+                                                  const Object& resource,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  ContextType* context) {
+  return New(env,
+             callback,
+             resource,
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             context,
              [](Env, ContextType*) {} /* empty finalizer */);
 }
 
 // static
 template <typename ResourceString, typename Finalizer>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, static_cast<void*>(nullptr) /* context */,
-             finalizeCallback, static_cast<void*>(nullptr) /* data */,
+                                                  const Function& callback,
+                                                  const Object& resource,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  Finalizer finalizeCallback) {
+  return New(env,
+             callback,
+             resource,
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             static_cast<void*>(nullptr) /* context */,
+             finalizeCallback,
+             static_cast<void*>(nullptr) /* data */,
              details::ThreadSafeFinalize<void, Finalizer>::Wrapper);
 }
 
 // static
-template <typename ResourceString, typename Finalizer,
+template <typename ResourceString,
+          typename Finalizer,
           typename FinalizerDataType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, static_cast<void*>(nullptr) /* context */,
-             finalizeCallback, data,
-             details::ThreadSafeFinalize<
-                 void, Finalizer, FinalizerDataType>::FinalizeWrapperWithData);
+                                                  const Function& callback,
+                                                  const Object& resource,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  Finalizer finalizeCallback,
+                                                  FinalizerDataType* data) {
+  return New(env,
+             callback,
+             resource,
+             resourceName,
+             maxQueueSize,
+             initialThreadCount,
+             static_cast<void*>(nullptr) /* context */,
+             finalizeCallback,
+             data,
+             details::ThreadSafeFinalize<void, Finalizer, FinalizerDataType>::
+                 FinalizeWrapperWithData);
 }
 
 // static
 template <typename ResourceString, typename ContextType, typename Finalizer>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, context, finalizeCallback,
-             static_cast<void*>(nullptr) /* data */,
-             details::ThreadSafeFinalize<
-                 ContextType, Finalizer>::FinalizeWrapperWithContext);
+                                                  const Function& callback,
+                                                  const Object& resource,
+                                                  ResourceString resourceName,
+                                                  size_t maxQueueSize,
+                                                  size_t initialThreadCount,
+                                                  ContextType* context,
+                                                  Finalizer finalizeCallback) {
+  return New(
+      env,
+      callback,
+      resource,
+      resourceName,
+      maxQueueSize,
+      initialThreadCount,
+      context,
+      finalizeCallback,
+      static_cast<void*>(nullptr) /* data */,
+      details::ThreadSafeFinalize<ContextType,
+                                  Finalizer>::FinalizeWrapperWithContext);
 }
 
 // static
-template <typename ResourceString, typename ContextType,
-          typename Finalizer, typename FinalizerDataType>
+template <typename ResourceString,
+          typename ContextType,
+          typename Finalizer,
+          typename FinalizerDataType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   const Function& callback,
                                                   const Object& resource,
@@ -5620,20 +5642,24 @@ inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   ContextType* context,
                                                   Finalizer finalizeCallback,
                                                   FinalizerDataType* data) {
-  return New(env, callback, resource, resourceName, maxQueueSize,
-             initialThreadCount, context, finalizeCallback, data,
-             details::ThreadSafeFinalize<ContextType, Finalizer,
-                 FinalizerDataType>::FinalizeFinalizeWrapperWithDataAndContext);
+  return New(
+      env,
+      callback,
+      resource,
+      resourceName,
+      maxQueueSize,
+      initialThreadCount,
+      context,
+      finalizeCallback,
+      data,
+      details::ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>::
+          FinalizeFinalizeWrapperWithDataAndContext);
 }
 
-inline ThreadSafeFunction::ThreadSafeFunction()
-  : _tsfn() {
-}
+inline ThreadSafeFunction::ThreadSafeFunction() : _tsfn() {}
 
-inline ThreadSafeFunction::ThreadSafeFunction(
-    napi_threadsafe_function tsfn)
-  : _tsfn(tsfn) {
-}
+inline ThreadSafeFunction::ThreadSafeFunction(napi_threadsafe_function tsfn)
+    : _tsfn(tsfn) {}
 
 inline ThreadSafeFunction::operator napi_threadsafe_function() const {
   return _tsfn;
@@ -5644,20 +5670,18 @@ inline napi_status ThreadSafeFunction::BlockingCall() const {
 }
 
 template <>
-inline napi_status ThreadSafeFunction::BlockingCall(
-    void* data) const {
+inline napi_status ThreadSafeFunction::BlockingCall(void* data) const {
   return napi_call_threadsafe_function(_tsfn, data, napi_tsfn_blocking);
 }
 
 template <typename Callback>
-inline napi_status ThreadSafeFunction::BlockingCall(
-    Callback callback) const {
+inline napi_status ThreadSafeFunction::BlockingCall(Callback callback) const {
   return CallInternal(new CallbackWrapper(callback), napi_tsfn_blocking);
 }
 
 template <typename DataType, typename Callback>
-inline napi_status ThreadSafeFunction::BlockingCall(
-    DataType* data, Callback callback) const {
+inline napi_status ThreadSafeFunction::BlockingCall(DataType* data,
+                                                    Callback callback) const {
   auto wrapper = [data, callback](Env env, Function jsCallback) {
     callback(env, jsCallback, data);
   };
@@ -5669,8 +5693,7 @@ inline napi_status ThreadSafeFunction::NonBlockingCall() const {
 }
 
 template <>
-inline napi_status ThreadSafeFunction::NonBlockingCall(
-    void* data) const {
+inline napi_status ThreadSafeFunction::NonBlockingCall(void* data) const {
   return napi_call_threadsafe_function(_tsfn, data, napi_tsfn_nonblocking);
 }
 
@@ -5715,17 +5738,21 @@ inline napi_status ThreadSafeFunction::Abort() const {
   return napi_release_threadsafe_function(_tsfn, napi_tsfn_abort);
 }
 
-inline ThreadSafeFunction::ConvertibleContext
-ThreadSafeFunction::GetContext() const {
+inline ThreadSafeFunction::ConvertibleContext ThreadSafeFunction::GetContext()
+    const {
   void* context;
   napi_status status = napi_get_threadsafe_function_context(_tsfn, &context);
-  NAPI_FATAL_IF_FAILED(status, "ThreadSafeFunction::GetContext", "napi_get_threadsafe_function_context");
-  return ConvertibleContext({ context });
+  NAPI_FATAL_IF_FAILED(status,
+                       "ThreadSafeFunction::GetContext",
+                       "napi_get_threadsafe_function_context");
+  return ConvertibleContext({context});
 }
 
 // static
-template <typename ResourceString, typename ContextType,
-          typename Finalizer, typename FinalizerDataType>
+template <typename ResourceString,
+          typename ContextType,
+          typename Finalizer,
+          typename FinalizerDataType>
 inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   const Function& callback,
                                                   const Object& resource,
@@ -5736,16 +5763,26 @@ inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
                                                   Finalizer finalizeCallback,
                                                   FinalizerDataType* data,
                                                   napi_finalize wrapper) {
-  static_assert(details::can_make_string<ResourceString>::value
-      || std::is_convertible<ResourceString, napi_value>::value,
-      "Resource name should be convertible to the string type");
+  static_assert(details::can_make_string<ResourceString>::value ||
+                    std::is_convertible<ResourceString, napi_value>::value,
+                "Resource name should be convertible to the string type");
 
   ThreadSafeFunction tsfn;
-  auto* finalizeData = new details::ThreadSafeFinalize<ContextType, Finalizer,
-      FinalizerDataType>({ data, finalizeCallback });
-  napi_status status = napi_create_threadsafe_function(env, callback, resource,
-      Value::From(env, resourceName), maxQueueSize, initialThreadCount,
-      finalizeData, wrapper, context, CallJS, &tsfn._tsfn);
+  auto* finalizeData = new details::
+      ThreadSafeFinalize<ContextType, Finalizer, FinalizerDataType>(
+          {data, finalizeCallback});
+  napi_status status =
+      napi_create_threadsafe_function(env,
+                                      callback,
+                                      resource,
+                                      Value::From(env, resourceName),
+                                      maxQueueSize,
+                                      initialThreadCount,
+                                      finalizeData,
+                                      wrapper,
+                                      context,
+                                      CallJS,
+                                      &tsfn._tsfn);
   if (status != napi_ok) {
     delete finalizeData;
     NAPI_THROW_IF_FAILED(env, status, ThreadSafeFunction());
@@ -5757,8 +5794,8 @@ inline ThreadSafeFunction ThreadSafeFunction::New(napi_env env,
 inline napi_status ThreadSafeFunction::CallInternal(
     CallbackWrapper* callbackWrapper,
     napi_threadsafe_function_call_mode mode) const {
-  napi_status status = napi_call_threadsafe_function(
-      _tsfn, callbackWrapper, mode);
+  napi_status status =
+      napi_call_threadsafe_function(_tsfn, callbackWrapper, mode);
   if (status != napi_ok && callbackWrapper != nullptr) {
     delete callbackWrapper;
   }
@@ -5788,13 +5825,15 @@ inline void ThreadSafeFunction::CallJS(napi_env env,
 // Async Progress Worker Base class
 ////////////////////////////////////////////////////////////////////////////////
 template <typename DataType>
-inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(const Object& receiver,
-                                                                  const Function& callback,
-                                                                  const char* resource_name,
-                                                                  const Object& resource,
-                                                                  size_t queue_size)
-  : AsyncWorker(receiver, callback, resource_name, resource) {
-  // Fill all possible arguments to work around ambiguous ThreadSafeFunction::New signatures.
+inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(
+    const Object& receiver,
+    const Function& callback,
+    const char* resource_name,
+    const Object& resource,
+    size_t queue_size)
+    : AsyncWorker(receiver, callback, resource_name, resource) {
+  // Fill all possible arguments to work around ambiguous
+  // ThreadSafeFunction::New signatures.
   _tsfn = ThreadSafeFunction::New(callback.Env(),
                                   callback,
                                   resource,
@@ -5808,15 +5847,18 @@ inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(const Object& 
 
 #if NAPI_VERSION > 4
 template <typename DataType>
-inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(Napi::Env env,
-                                                                  const char* resource_name,
-                                                                  const Object& resource,
-                                                                  size_t queue_size)
-  : AsyncWorker(env, resource_name, resource) {
+inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(
+    Napi::Env env,
+    const char* resource_name,
+    const Object& resource,
+    size_t queue_size)
+    : AsyncWorker(env, resource_name, resource) {
   // TODO: Once the changes to make the callback optional for threadsafe
-  // functions are available on all versions we can remove the dummy Function here.
+  // functions are available on all versions we can remove the dummy Function
+  // here.
   Function callback;
-  // Fill all possible arguments to work around ambiguous ThreadSafeFunction::New signatures.
+  // Fill all possible arguments to work around ambiguous
+  // ThreadSafeFunction::New signatures.
   _tsfn = ThreadSafeFunction::New(env,
                                   callback,
                                   resource,
@@ -5829,38 +5871,41 @@ inline AsyncProgressWorkerBase<DataType>::AsyncProgressWorkerBase(Napi::Env env,
 }
 #endif
 
-template<typename DataType>
+template <typename DataType>
 inline AsyncProgressWorkerBase<DataType>::~AsyncProgressWorkerBase() {
   // Abort pending tsfn call.
   // Don't send progress events after we've already completed.
-  // It's ok to call ThreadSafeFunction::Abort and ThreadSafeFunction::Release duplicated.
+  // It's ok to call ThreadSafeFunction::Abort and ThreadSafeFunction::Release
+  // duplicated.
   _tsfn.Abort();
 }
 
 template <typename DataType>
-inline void AsyncProgressWorkerBase<DataType>::OnAsyncWorkProgress(Napi::Env /* env */,
-                                Napi::Function /* jsCallback */,
-                                void* data) {
+inline void AsyncProgressWorkerBase<DataType>::OnAsyncWorkProgress(
+    Napi::Env /* env */, Napi::Function /* jsCallback */, void* data) {
   ThreadSafeData* tsd = static_cast<ThreadSafeData*>(data);
   tsd->asyncprogressworker()->OnWorkProgress(tsd->data());
   delete tsd;
 }
 
 template <typename DataType>
-inline napi_status AsyncProgressWorkerBase<DataType>::NonBlockingCall(DataType* data) {
+inline napi_status AsyncProgressWorkerBase<DataType>::NonBlockingCall(
+    DataType* data) {
   auto tsd = new AsyncProgressWorkerBase::ThreadSafeData(this, data);
   return _tsfn.NonBlockingCall(tsd, OnAsyncWorkProgress);
 }
 
 template <typename DataType>
-inline void AsyncProgressWorkerBase<DataType>::OnWorkComplete(Napi::Env /* env */, napi_status status) {
+inline void AsyncProgressWorkerBase<DataType>::OnWorkComplete(
+    Napi::Env /* env */, napi_status status) {
   _work_completed = true;
   _complete_status = status;
   _tsfn.Release();
 }
 
 template <typename DataType>
-inline void AsyncProgressWorkerBase<DataType>::OnThreadSafeFunctionFinalize(Napi::Env env, void* /* data */, AsyncProgressWorkerBase* context) {
+inline void AsyncProgressWorkerBase<DataType>::OnThreadSafeFunctionFinalize(
+    Napi::Env env, void* /* data */, AsyncProgressWorkerBase* context) {
   if (context->_work_completed) {
     context->AsyncWorker::OnWorkComplete(env, context->_complete_status);
   }
@@ -5869,76 +5914,64 @@ inline void AsyncProgressWorkerBase<DataType>::OnThreadSafeFunctionFinalize(Napi
 ////////////////////////////////////////////////////////////////////////////////
 // Async Progress Worker class
 ////////////////////////////////////////////////////////////////////////////////
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Function& callback)
-  : AsyncProgressWorker(callback, "generic") {
-}
+    : AsyncProgressWorker(callback, "generic") {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Function& callback,
-                                const char* resource_name)
-  : AsyncProgressWorker(callback, resource_name, Object::New(callback.Env())) {
-}
+                                                   const char* resource_name)
+    : AsyncProgressWorker(
+          callback, resource_name, Object::New(callback.Env())) {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Function& callback,
-                                const char* resource_name,
-                                const Object& resource)
-  : AsyncProgressWorker(Object::New(callback.Env()),
-                callback,
-                resource_name,
-                resource) {
-}
+                                                   const char* resource_name,
+                                                   const Object& resource)
+    : AsyncProgressWorker(
+          Object::New(callback.Env()), callback, resource_name, resource) {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Object& receiver,
                                                    const Function& callback)
-  : AsyncProgressWorker(receiver, callback, "generic") {
-}
+    : AsyncProgressWorker(receiver, callback, "generic") {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Object& receiver,
                                                    const Function& callback,
                                                    const char* resource_name)
-  : AsyncProgressWorker(receiver,
-                callback,
-                resource_name,
-                Object::New(callback.Env())) {
-}
+    : AsyncProgressWorker(
+          receiver, callback, resource_name, Object::New(callback.Env())) {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(const Object& receiver,
                                                    const Function& callback,
                                                    const char* resource_name,
                                                    const Object& resource)
-  : AsyncProgressWorkerBase(receiver, callback, resource_name, resource),
-    _asyncdata(nullptr),
-    _asyncsize(0) {
-}
+    : AsyncProgressWorkerBase(receiver, callback, resource_name, resource),
+      _asyncdata(nullptr),
+      _asyncsize(0) {}
 
 #if NAPI_VERSION > 4
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(Napi::Env env)
-  : AsyncProgressWorker(env, "generic") {
-}
+    : AsyncProgressWorker(env, "generic") {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(Napi::Env env,
                                                    const char* resource_name)
-  : AsyncProgressWorker(env, resource_name, Object::New(env)) {
-}
+    : AsyncProgressWorker(env, resource_name, Object::New(env)) {}
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::AsyncProgressWorker(Napi::Env env,
                                                    const char* resource_name,
                                                    const Object& resource)
-  : AsyncProgressWorkerBase(env, resource_name, resource),
-    _asyncdata(nullptr),
-    _asyncsize(0) {
-}
+    : AsyncProgressWorkerBase(env, resource_name, resource),
+      _asyncdata(nullptr),
+      _asyncsize(0) {}
 #endif
 
-template<class T>
+template <class T>
 inline AsyncProgressWorker<T>::~AsyncProgressWorker() {
   {
     std::lock_guard<std::mutex> lock(this->_mutex);
@@ -5947,13 +5980,13 @@ inline AsyncProgressWorker<T>::~AsyncProgressWorker() {
   }
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressWorker<T>::Execute() {
   ExecutionProgress progress(this);
   Execute(progress);
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressWorker<T>::OnWorkProgress(void*) {
   T* data;
   size_t size;
@@ -5980,119 +6013,114 @@ inline void AsyncProgressWorker<T>::OnWorkProgress(void*) {
   delete[] data;
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressWorker<T>::SendProgress_(const T* data, size_t count) {
-    T* new_data = new T[count];
-    std::copy(data, data + count, new_data);
+  T* new_data = new T[count];
+  std::copy(data, data + count, new_data);
 
-    T* old_data;
-    {
-      std::lock_guard<std::mutex> lock(this->_mutex);
-      old_data = _asyncdata;
-      _asyncdata = new_data;
-      _asyncsize = count;
-    }
-    this->NonBlockingCall(nullptr);
+  T* old_data;
+  {
+    std::lock_guard<std::mutex> lock(this->_mutex);
+    old_data = _asyncdata;
+    _asyncdata = new_data;
+    _asyncsize = count;
+  }
+  this->NonBlockingCall(nullptr);
 
-    delete[] old_data;
+  delete[] old_data;
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressWorker<T>::Signal() const {
   this->NonBlockingCall(static_cast<T*>(nullptr));
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressWorker<T>::ExecutionProgress::Signal() const {
   _worker->Signal();
 }
 
-template<class T>
-inline void AsyncProgressWorker<T>::ExecutionProgress::Send(const T* data, size_t count) const {
+template <class T>
+inline void AsyncProgressWorker<T>::ExecutionProgress::Send(
+    const T* data, size_t count) const {
   _worker->SendProgress_(data, count);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Async Progress Queue Worker class
 ////////////////////////////////////////////////////////////////////////////////
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Function& callback)
-  : AsyncProgressQueueWorker(callback, "generic") {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Function& callback)
+    : AsyncProgressQueueWorker(callback, "generic") {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Function& callback,
-                                                             const char* resource_name)
-  : AsyncProgressQueueWorker(callback, resource_name, Object::New(callback.Env())) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Function& callback, const char* resource_name)
+    : AsyncProgressQueueWorker(
+          callback, resource_name, Object::New(callback.Env())) {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Function& callback,
-                                                             const char* resource_name,
-                                                             const Object& resource)
-  : AsyncProgressQueueWorker(Object::New(callback.Env()),
-                             callback,
-                             resource_name,
-                             resource) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Function& callback, const char* resource_name, const Object& resource)
+    : AsyncProgressQueueWorker(
+          Object::New(callback.Env()), callback, resource_name, resource) {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Object& receiver,
-                                                             const Function& callback)
-  : AsyncProgressQueueWorker(receiver, callback, "generic") {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Object& receiver, const Function& callback)
+    : AsyncProgressQueueWorker(receiver, callback, "generic") {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Object& receiver,
-                                                             const Function& callback,
-                                                             const char* resource_name)
-  : AsyncProgressQueueWorker(receiver,
-                             callback,
-                             resource_name,
-                             Object::New(callback.Env())) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Object& receiver, const Function& callback, const char* resource_name)
+    : AsyncProgressQueueWorker(
+          receiver, callback, resource_name, Object::New(callback.Env())) {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(const Object& receiver,
-                                                             const Function& callback,
-                                                             const char* resource_name,
-                                                             const Object& resource)
-  : AsyncProgressWorkerBase<std::pair<T*, size_t>>(receiver, callback, resource_name, resource, /** unlimited queue size */0) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    const Object& receiver,
+    const Function& callback,
+    const char* resource_name,
+    const Object& resource)
+    : AsyncProgressWorkerBase<std::pair<T*, size_t>>(
+          receiver,
+          callback,
+          resource_name,
+          resource,
+          /** unlimited queue size */ 0) {}
 
 #if NAPI_VERSION > 4
-template<class T>
+template <class T>
 inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(Napi::Env env)
-  : AsyncProgressQueueWorker(env, "generic") {
-}
+    : AsyncProgressQueueWorker(env, "generic") {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(Napi::Env env,
-                                const char* resource_name)
-  : AsyncProgressQueueWorker(env, resource_name, Object::New(env)) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    Napi::Env env, const char* resource_name)
+    : AsyncProgressQueueWorker(env, resource_name, Object::New(env)) {}
 
-template<class T>
-inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(Napi::Env env,
-                                                             const char* resource_name,
-                                                             const Object& resource)
-  : AsyncProgressWorkerBase<std::pair<T*, size_t>>(env, resource_name, resource, /** unlimited queue size */0) {
-}
+template <class T>
+inline AsyncProgressQueueWorker<T>::AsyncProgressQueueWorker(
+    Napi::Env env, const char* resource_name, const Object& resource)
+    : AsyncProgressWorkerBase<std::pair<T*, size_t>>(
+          env, resource_name, resource, /** unlimited queue size */ 0) {}
 #endif
 
-template<class T>
+template <class T>
 inline void AsyncProgressQueueWorker<T>::Execute() {
   ExecutionProgress progress(this);
   Execute(progress);
 }
 
-template<class T>
-inline void AsyncProgressQueueWorker<T>::OnWorkProgress(std::pair<T*, size_t>* datapair) {
+template <class T>
+inline void AsyncProgressQueueWorker<T>::OnWorkProgress(
+    std::pair<T*, size_t>* datapair) {
   if (datapair == nullptr) {
     return;
   }
 
-  T *data = datapair->first;
+  T* data = datapair->first;
   size_t size = datapair->second;
 
   this->OnProgress(data, size);
@@ -6100,33 +6128,36 @@ inline void AsyncProgressQueueWorker<T>::OnWorkProgress(std::pair<T*, size_t>* d
   delete[] data;
 }
 
-template<class T>
-inline void AsyncProgressQueueWorker<T>::SendProgress_(const T* data, size_t count) {
-    T* new_data = new T[count];
-    std::copy(data, data + count, new_data);
+template <class T>
+inline void AsyncProgressQueueWorker<T>::SendProgress_(const T* data,
+                                                       size_t count) {
+  T* new_data = new T[count];
+  std::copy(data, data + count, new_data);
 
-    auto pair = new std::pair<T*, size_t>(new_data, count);
-    this->NonBlockingCall(pair);
+  auto pair = new std::pair<T*, size_t>(new_data, count);
+  this->NonBlockingCall(pair);
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressQueueWorker<T>::Signal() const {
   this->NonBlockingCall(nullptr);
 }
 
-template<class T>
-inline void AsyncProgressQueueWorker<T>::OnWorkComplete(Napi::Env env, napi_status status) {
+template <class T>
+inline void AsyncProgressQueueWorker<T>::OnWorkComplete(Napi::Env env,
+                                                        napi_status status) {
   // Draining queued items in TSFN.
   AsyncProgressWorkerBase<std::pair<T*, size_t>>::OnWorkComplete(env, status);
 }
 
-template<class T>
+template <class T>
 inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Signal() const {
   _worker->Signal();
 }
 
-template<class T>
-inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Send(const T* data, size_t count) const {
+template <class T>
+inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Send(
+    const T* data, size_t count) const {
   _worker->SendProgress_(data, count);
 }
 #endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
@@ -6135,9 +6166,11 @@ inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Send(const T* data, 
 // Memory Management class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline int64_t MemoryManagement::AdjustExternalMemory(Env env, int64_t change_in_bytes) {
+inline int64_t MemoryManagement::AdjustExternalMemory(Env env,
+                                                      int64_t change_in_bytes) {
   int64_t result;
-  napi_status status = napi_adjust_external_memory(env, change_in_bytes, &result);
+  napi_status status =
+      napi_adjust_external_memory(env, change_in_bytes, &result);
   NAPI_THROW_IF_FAILED(env, status, 0);
   return result;
 }
@@ -6178,24 +6211,20 @@ inline T* Addon<T>::Unwrap(Object wrapper) {
 }
 
 template <typename T>
-inline void
-Addon<T>::DefineAddon(Object exports,
-                      const std::initializer_list<AddonProp>& props) {
+inline void Addon<T>::DefineAddon(
+    Object exports, const std::initializer_list<AddonProp>& props) {
   DefineProperties(exports, props);
   entry_point_ = exports;
 }
 
 template <typename T>
-inline Napi::Object
-Addon<T>::DefineProperties(Object object,
-                           const std::initializer_list<AddonProp>& props) {
+inline Napi::Object Addon<T>::DefineProperties(
+    Object object, const std::initializer_list<AddonProp>& props) {
   const napi_property_descriptor* properties =
-    reinterpret_cast<const napi_property_descriptor*>(props.begin());
+      reinterpret_cast<const napi_property_descriptor*>(props.begin());
   size_t size = props.size();
-  napi_status status = napi_define_properties(object.Env(),
-                                              object,
-                                              size,
-                                              properties);
+  napi_status status =
+      napi_define_properties(object.Env(), object, size, properties);
   NAPI_THROW_IF_FAILED(object.Env(), status, object);
   for (size_t idx = 0; idx < size; idx++)
     T::AttachPropData(object.Env(), object, &properties[idx]);
@@ -6254,6 +6283,6 @@ bool Env::CleanupHook<Hook, Arg>::IsEmpty() const {
 }  // namespace NAPI_CPP_CUSTOM_NAMESPACE
 #endif
 
-} // namespace Napi
+}  // namespace Napi
 
-#endif // SRC_NAPI_INL_H_
+#endif  // SRC_NAPI_INL_H_

--- a/napi.h
+++ b/napi.h
@@ -9,29 +9,32 @@
 #include <string>
 #include <vector>
 
-// VS2015 RTM has bugs with constexpr, so require min of VS2015 Update 3 (known good version)
+// VS2015 RTM has bugs with constexpr, so require min of VS2015 Update 3 (known
+// good version)
 #if !defined(_MSC_VER) || _MSC_FULL_VER >= 190024210
 #define NAPI_HAS_CONSTEXPR 1
 #endif
 
-// VS2013 does not support char16_t literal strings, so we'll work around it using wchar_t strings
-// and casting them. This is safe as long as the character sizes are the same.
+// VS2013 does not support char16_t literal strings, so we'll work around it
+// using wchar_t strings and casting them. This is safe as long as the character
+// sizes are the same.
 #if defined(_MSC_VER) && _MSC_VER <= 1800
-static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16_t and wchar_t");
-#define NAPI_WIDE_TEXT(x) reinterpret_cast<char16_t*>(L ## x)
+static_assert(sizeof(char16_t) == sizeof(wchar_t),
+              "Size mismatch between char16_t and wchar_t");
+#define NAPI_WIDE_TEXT(x) reinterpret_cast<char16_t*>(L##x)
 #else
-#define NAPI_WIDE_TEXT(x) u ## x
+#define NAPI_WIDE_TEXT(x) u##x
 #endif
 
 // If C++ exceptions are not explicitly enabled or disabled, enable them
 // if exceptions were enabled in the compiler settings.
 #if !defined(NAPI_CPP_EXCEPTIONS) && !defined(NAPI_DISABLE_CPP_EXCEPTIONS)
-  #if defined(_CPPUNWIND) || defined (__EXCEPTIONS)
-    #define NAPI_CPP_EXCEPTIONS
-  #else
-    #error Exception support not detected. \
+#if defined(_CPPUNWIND) || defined(__EXCEPTIONS)
+#define NAPI_CPP_EXCEPTIONS
+#else
+#error Exception support not detected. \
       Define either NAPI_CPP_EXCEPTIONS or NAPI_DISABLE_CPP_EXCEPTIONS.
-  #endif
+#endif
 #endif
 
 // If C++ NAPI_CPP_EXCEPTIONS are enabled, NODE_ADDON_API_ENABLE_MAYBE should
@@ -42,9 +45,9 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 #endif
 
 #ifdef _NOEXCEPT
-  #define NAPI_NOEXCEPT _NOEXCEPT
+#define NAPI_NOEXCEPT _NOEXCEPT
 #else
-  #define NAPI_NOEXCEPT noexcept
+#define NAPI_NOEXCEPT noexcept
 #endif
 
 #ifdef NAPI_CPP_EXCEPTIONS
@@ -55,16 +58,16 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 // We need _VOID versions of the macros to avoid warnings resulting from
 // leaving the NAPI_THROW_* `...` argument empty.
 
-#define NAPI_THROW(e, ...)  throw e
-#define NAPI_THROW_VOID(e)  throw e
+#define NAPI_THROW(e, ...) throw e
+#define NAPI_THROW_VOID(e) throw e
 
-#define NAPI_THROW_IF_FAILED(env, status, ...)           \
+#define NAPI_THROW_IF_FAILED(env, status, ...)                                 \
   if ((status) != napi_ok) throw Napi::Error::New(env);
 
-#define NAPI_THROW_IF_FAILED_VOID(env, status)           \
+#define NAPI_THROW_IF_FAILED_VOID(env, status)                                 \
   if ((status) != napi_ok) throw Napi::Error::New(env);
 
-#else // NAPI_CPP_EXCEPTIONS
+#else  // NAPI_CPP_EXCEPTIONS
 
 // When C++ exceptions are disabled, Errors are thrown as JavaScript exceptions,
 // which are pending until the callback returns to JS.  The variadic parameter
@@ -72,16 +75,16 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
 // We need _VOID versions of the macros to avoid warnings resulting from
 // leaving the NAPI_THROW_* `...` argument empty.
 
-#define NAPI_THROW(e, ...)                               \
-  do {                                                   \
-    (e).ThrowAsJavaScriptException();                    \
-    return __VA_ARGS__;                                  \
+#define NAPI_THROW(e, ...)                                                     \
+  do {                                                                         \
+    (e).ThrowAsJavaScriptException();                                          \
+    return __VA_ARGS__;                                                        \
   } while (0)
 
-#define NAPI_THROW_VOID(e)                               \
-  do {                                                   \
-    (e).ThrowAsJavaScriptException();                    \
-    return;                                              \
+#define NAPI_THROW_VOID(e)                                                     \
+  do {                                                                         \
+    (e).ThrowAsJavaScriptException();                                          \
+    return;                                                                    \
   } while (0)
 
 #define NAPI_THROW_IF_FAILED(env, status, ...)                                 \
@@ -96,7 +99,7 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
     return;                                                                    \
   }
 
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 
 #ifdef NODE_ADDON_API_ENABLE_MAYBE
 #define NAPI_MAYBE_THROW_IF_FAILED(env, status, type)                          \
@@ -114,12 +117,12 @@ static_assert(sizeof(char16_t) == sizeof(wchar_t), "Size mismatch between char16
   return result;
 #endif
 
-# define NAPI_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
-# define NAPI_DISALLOW_COPY(CLASS) CLASS(const CLASS&) = delete;
+#define NAPI_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
+#define NAPI_DISALLOW_COPY(CLASS) CLASS(const CLASS&) = delete;
 
-#define NAPI_DISALLOW_ASSIGN_COPY(CLASS)  \
-    NAPI_DISALLOW_ASSIGN(CLASS)           \
-    NAPI_DISALLOW_COPY(CLASS)
+#define NAPI_DISALLOW_ASSIGN_COPY(CLASS)                                       \
+  NAPI_DISALLOW_ASSIGN(CLASS)                                                  \
+  NAPI_DISALLOW_COPY(CLASS)
 
 #define NAPI_CHECK(condition, location, message)                               \
   do {                                                                         \
@@ -152,2852 +155,2963 @@ using namespace NAPI_CPP_CUSTOM_NAMESPACE;
 namespace NAPI_CPP_CUSTOM_NAMESPACE {
 #endif
 
-  // Forward declarations
-  class Env;
-  class Value;
-  class Boolean;
-  class Number;
+// Forward declarations
+class Env;
+class Value;
+class Boolean;
+class Number;
 #if NAPI_VERSION > 5
-  class BigInt;
+class BigInt;
 #endif  // NAPI_VERSION > 5
 #if (NAPI_VERSION > 4)
-  class Date;
+class Date;
 #endif
-  class String;
-  class Object;
-  class Array;
-  class ArrayBuffer;
-  class Function;
-  class Error;
-  class PropertyDescriptor;
-  class CallbackInfo;
-  class TypedArray;
-  template <typename T> class TypedArrayOf;
+class String;
+class Object;
+class Array;
+class ArrayBuffer;
+class Function;
+class Error;
+class PropertyDescriptor;
+class CallbackInfo;
+class TypedArray;
+template <typename T>
+class TypedArrayOf;
 
-  using Int8Array =
-      TypedArrayOf<int8_t>;  ///< Typed-array of signed 8-bit integers
-  using Uint8Array =
-      TypedArrayOf<uint8_t>;  ///< Typed-array of unsigned 8-bit integers
-  using Int16Array =
-      TypedArrayOf<int16_t>;  ///< Typed-array of signed 16-bit integers
-  using Uint16Array =
-      TypedArrayOf<uint16_t>;  ///< Typed-array of unsigned 16-bit integers
-  using Int32Array =
-      TypedArrayOf<int32_t>;  ///< Typed-array of signed 32-bit integers
-  using Uint32Array =
-      TypedArrayOf<uint32_t>;  ///< Typed-array of unsigned 32-bit integers
-  using Float32Array =
-      TypedArrayOf<float>;  ///< Typed-array of 32-bit floating-point values
-  using Float64Array =
-      TypedArrayOf<double>;  ///< Typed-array of 64-bit floating-point values
+using Int8Array =
+    TypedArrayOf<int8_t>;  ///< Typed-array of signed 8-bit integers
+using Uint8Array =
+    TypedArrayOf<uint8_t>;  ///< Typed-array of unsigned 8-bit integers
+using Int16Array =
+    TypedArrayOf<int16_t>;  ///< Typed-array of signed 16-bit integers
+using Uint16Array =
+    TypedArrayOf<uint16_t>;  ///< Typed-array of unsigned 16-bit integers
+using Int32Array =
+    TypedArrayOf<int32_t>;  ///< Typed-array of signed 32-bit integers
+using Uint32Array =
+    TypedArrayOf<uint32_t>;  ///< Typed-array of unsigned 32-bit integers
+using Float32Array =
+    TypedArrayOf<float>;  ///< Typed-array of 32-bit floating-point values
+using Float64Array =
+    TypedArrayOf<double>;  ///< Typed-array of 64-bit floating-point values
 #if NAPI_VERSION > 5
-  using BigInt64Array =
-      TypedArrayOf<int64_t>;  ///< Typed array of signed 64-bit integers
-  using BigUint64Array =
-      TypedArrayOf<uint64_t>;  ///< Typed array of unsigned 64-bit integers
-#endif  // NAPI_VERSION > 5
+using BigInt64Array =
+    TypedArrayOf<int64_t>;  ///< Typed array of signed 64-bit integers
+using BigUint64Array =
+    TypedArrayOf<uint64_t>;  ///< Typed array of unsigned 64-bit integers
+#endif                       // NAPI_VERSION > 5
 
-  /// Defines the signature of a Node-API C++ module's registration callback
-  /// (init) function.
-  using ModuleRegisterCallback = Object (*)(Env env, Object exports);
+/// Defines the signature of a Node-API C++ module's registration callback
+/// (init) function.
+using ModuleRegisterCallback = Object (*)(Env env, Object exports);
 
-  class MemoryManagement;
+class MemoryManagement;
 
-  /// A simple Maybe type, representing an object which may or may not have a
-  /// value.
-  ///
-  /// If an API method returns a Maybe<>, the API method can potentially fail
-  /// either because an exception is thrown, or because an exception is pending,
-  /// e.g. because a previous API call threw an exception that hasn't been
-  /// caught yet. In that case, a "Nothing" value is returned.
-  template <class T>
-  class Maybe {
-   public:
-    bool IsNothing() const;
-    bool IsJust() const;
+/// A simple Maybe type, representing an object which may or may not have a
+/// value.
+///
+/// If an API method returns a Maybe<>, the API method can potentially fail
+/// either because an exception is thrown, or because an exception is pending,
+/// e.g. because a previous API call threw an exception that hasn't been
+/// caught yet. In that case, a "Nothing" value is returned.
+template <class T>
+class Maybe {
+ public:
+  bool IsNothing() const;
+  bool IsJust() const;
 
-    /// Short-hand for Unwrap(), which doesn't return a value. Could be used
-    /// where the actual value of the Maybe is not needed like Object::Set.
-    /// If this Maybe is nothing (empty), node-addon-api will crash the
-    /// process.
-    void Check() const;
+  /// Short-hand for Unwrap(), which doesn't return a value. Could be used
+  /// where the actual value of the Maybe is not needed like Object::Set.
+  /// If this Maybe is nothing (empty), node-addon-api will crash the
+  /// process.
+  void Check() const;
 
-    /// Return the value of type T contained in the Maybe. If this Maybe is
-    /// nothing (empty), node-addon-api will crash the process.
-    T Unwrap() const;
+  /// Return the value of type T contained in the Maybe. If this Maybe is
+  /// nothing (empty), node-addon-api will crash the process.
+  T Unwrap() const;
 
-    /// Return the value of type T contained in the Maybe, or using a default
-    /// value if this Maybe is nothing (empty).
-    T UnwrapOr(const T& default_value) const;
+  /// Return the value of type T contained in the Maybe, or using a default
+  /// value if this Maybe is nothing (empty).
+  T UnwrapOr(const T& default_value) const;
 
-    /// Converts this Maybe to a value of type T in the out. If this Maybe is
-    /// nothing (empty), `false` is returned and `out` is left untouched.
-    bool UnwrapTo(T* out) const;
+  /// Converts this Maybe to a value of type T in the out. If this Maybe is
+  /// nothing (empty), `false` is returned and `out` is left untouched.
+  bool UnwrapTo(T* out) const;
 
-    bool operator==(const Maybe& other) const;
-    bool operator!=(const Maybe& other) const;
+  bool operator==(const Maybe& other) const;
+  bool operator!=(const Maybe& other) const;
 
-   private:
-    Maybe();
-    explicit Maybe(const T& t);
+ private:
+  Maybe();
+  explicit Maybe(const T& t);
 
-    bool _has_value;
-    T _value;
+  bool _has_value;
+  T _value;
 
-    template <class U>
-    friend Maybe<U> Nothing();
-    template <class U>
-    friend Maybe<U> Just(const U& u);
-  };
+  template <class U>
+  friend Maybe<U> Nothing();
+  template <class U>
+  friend Maybe<U> Just(const U& u);
+};
 
-  template <class T>
-  inline Maybe<T> Nothing();
+template <class T>
+inline Maybe<T> Nothing();
 
-  template <class T>
-  inline Maybe<T> Just(const T& t);
+template <class T>
+inline Maybe<T> Just(const T& t);
 
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
-  template <typename T>
-  using MaybeOrValue = Maybe<T>;
+template <typename T>
+using MaybeOrValue = Maybe<T>;
 #else
-  template <typename T>
-  using MaybeOrValue = T;
+template <typename T>
+using MaybeOrValue = T;
 #endif
 
-  /// Environment for Node-API values and operations.
-  ///
-  /// All Node-API values and operations must be associated with an environment.
-  /// An environment instance is always provided to callback functions; that
-  /// environment must then be used for any creation of Node-API values or other
-  /// Node-API operations within the callback. (Many methods infer the
-  /// environment from the `this` instance that the method is called on.)
-  ///
-  /// In the future, multiple environments per process may be supported,
-  /// although current implementations only support one environment per process.
-  ///
-  /// In the V8 JavaScript engine, a Node-API environment approximately
-  /// corresponds to an Isolate.
-  class Env {
-   private:
+/// Environment for Node-API values and operations.
+///
+/// All Node-API values and operations must be associated with an environment.
+/// An environment instance is always provided to callback functions; that
+/// environment must then be used for any creation of Node-API values or other
+/// Node-API operations within the callback. (Many methods infer the
+/// environment from the `this` instance that the method is called on.)
+///
+/// In the future, multiple environments per process may be supported,
+/// although current implementations only support one environment per process.
+///
+/// In the V8 JavaScript engine, a Node-API environment approximately
+/// corresponds to an Isolate.
+class Env {
+ private:
 #if NAPI_VERSION > 2
-    template <typename Hook, typename Arg = void>
-    class CleanupHook;
+  template <typename Hook, typename Arg = void>
+  class CleanupHook;
 #endif  // NAPI_VERSION > 2
 #if NAPI_VERSION > 5
-    template <typename T> static void DefaultFini(Env, T* data);
-    template <typename DataType, typename HintType>
-    static void DefaultFiniWithHint(Env, DataType* data, HintType* hint);
+  template <typename T>
+  static void DefaultFini(Env, T* data);
+  template <typename DataType, typename HintType>
+  static void DefaultFiniWithHint(Env, DataType* data, HintType* hint);
 #endif  // NAPI_VERSION > 5
-  public:
-    Env(napi_env env);
+ public:
+  Env(napi_env env);
 
-    operator napi_env() const;
+  operator napi_env() const;
 
-    Object Global() const;
-    Value Undefined() const;
-    Value Null() const;
+  Object Global() const;
+  Value Undefined() const;
+  Value Null() const;
 
-    bool IsExceptionPending() const;
-    Error GetAndClearPendingException() const;
+  bool IsExceptionPending() const;
+  Error GetAndClearPendingException() const;
 
-    MaybeOrValue<Value> RunScript(const char* utf8script) const;
-    MaybeOrValue<Value> RunScript(const std::string& utf8script) const;
-    MaybeOrValue<Value> RunScript(String script) const;
+  MaybeOrValue<Value> RunScript(const char* utf8script) const;
+  MaybeOrValue<Value> RunScript(const std::string& utf8script) const;
+  MaybeOrValue<Value> RunScript(String script) const;
 
 #if NAPI_VERSION > 2
-    template <typename Hook>
-    CleanupHook<Hook> AddCleanupHook(Hook hook);
+  template <typename Hook>
+  CleanupHook<Hook> AddCleanupHook(Hook hook);
 
-    template <typename Hook, typename Arg>
-    CleanupHook<Hook, Arg> AddCleanupHook(Hook hook, Arg* arg);
+  template <typename Hook, typename Arg>
+  CleanupHook<Hook, Arg> AddCleanupHook(Hook hook, Arg* arg);
 #endif  // NAPI_VERSION > 2
 
 #if NAPI_VERSION > 5
-    template <typename T>
-    T* GetInstanceData() const;
+  template <typename T>
+  T* GetInstanceData() const;
 
-    template <typename T> using Finalizer = void (*)(Env, T*);
-    template <typename T, Finalizer<T> fini = Env::DefaultFini<T>>
-    void SetInstanceData(T* data) const;
+  template <typename T>
+  using Finalizer = void (*)(Env, T*);
+  template <typename T, Finalizer<T> fini = Env::DefaultFini<T>>
+  void SetInstanceData(T* data) const;
 
-    template <typename DataType, typename HintType>
-    using FinalizerWithHint = void (*)(Env, DataType*, HintType*);
-    template <typename DataType,
-              typename HintType,
-              FinalizerWithHint<DataType, HintType> fini =
-                  Env::DefaultFiniWithHint<DataType, HintType>>
-    void SetInstanceData(DataType* data, HintType* hint) const;
+  template <typename DataType, typename HintType>
+  using FinalizerWithHint = void (*)(Env, DataType*, HintType*);
+  template <typename DataType,
+            typename HintType,
+            FinalizerWithHint<DataType, HintType> fini =
+                Env::DefaultFiniWithHint<DataType, HintType>>
+  void SetInstanceData(DataType* data, HintType* hint) const;
 #endif  // NAPI_VERSION > 5
 
-  private:
-    napi_env _env;
+ private:
+  napi_env _env;
 
 #if NAPI_VERSION > 2
-    template <typename Hook, typename Arg>
-    class CleanupHook {
-     public:
-      CleanupHook(Env env, Hook hook, Arg* arg);
-      CleanupHook(Env env, Hook hook);
-      bool Remove(Env env);
-      bool IsEmpty() const;
-
-     private:
-      static inline void Wrapper(void* data) NAPI_NOEXCEPT;
-      static inline void WrapperWithArg(void* data) NAPI_NOEXCEPT;
-
-      void (*wrapper)(void* arg);
-      struct CleanupData {
-        Hook hook;
-        Arg* arg;
-      } * data;
-    };
-  };
-#endif  // NAPI_VERSION > 2
-
-  /// A JavaScript value of unknown type.
-  ///
-  /// For type-specific operations, convert to one of the Value subclasses using a `To*` or `As()`
-  /// method. The `To*` methods do type coercion; the `As()` method does not.
-  ///
-  ///     Napi::Value value = ...
-  ///     if (!value.IsString()) throw Napi::TypeError::New(env, "Invalid arg...");
-  ///     Napi::String str = value.As<Napi::String>(); // Cast to a string value
-  ///
-  ///     Napi::Value anotherValue = ...
-  ///     bool isTruthy = anotherValue.ToBoolean(); // Coerce to a boolean value
-  class Value {
-  public:
-    Value();                               ///< Creates a new _empty_ Value instance.
-    Value(napi_env env,
-          napi_value value);  ///< Wraps a Node-API value primitive.
-
-    /// Creates a JS value from a C++ primitive.
-    ///
-    /// `value` may be any of:
-    /// - bool
-    /// - Any integer type
-    /// - Any floating point type
-    /// - const char* (encoded using UTF-8, null-terminated)
-    /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
-    /// - std::string (encoded using UTF-8)
-    /// - std::u16string
-    /// - napi::Value
-    /// - napi_value
-    template <typename T>
-    static Value From(napi_env env, const T& value);
-
-    /// Converts to a Node-API value primitive.
-    ///
-    /// If the instance is _empty_, this returns `nullptr`.
-    operator napi_value() const;
-
-    /// Tests if this value strictly equals another value.
-    bool operator ==(const Value& other) const;
-
-    /// Tests if this value does not strictly equal another value.
-    bool operator !=(const Value& other) const;
-
-    /// Tests if this value strictly equals another value.
-    bool StrictEquals(const Value& other) const;
-
-    /// Gets the environment the value is associated with.
-    Napi::Env Env() const;
-
-    /// Checks if the value is empty (uninitialized).
-    ///
-    /// An empty value is invalid, and most attempts to perform an operation on an empty value
-    /// will result in an exception. Note an empty value is distinct from JavaScript `null` or
-    /// `undefined`, which are valid values.
-    ///
-    /// When C++ exceptions are disabled at compile time, a method with a `Value` return type may
-    /// return an empty value to indicate a pending exception. So when not using C++ exceptions,
-    /// callers should check whether the value is empty before attempting to use it.
+  template <typename Hook, typename Arg>
+  class CleanupHook {
+   public:
+    CleanupHook(Env env, Hook hook, Arg* arg);
+    CleanupHook(Env env, Hook hook);
+    bool Remove(Env env);
     bool IsEmpty() const;
 
-    napi_valuetype Type() const; ///< Gets the type of the value.
+   private:
+    static inline void Wrapper(void* data) NAPI_NOEXCEPT;
+    static inline void WrapperWithArg(void* data) NAPI_NOEXCEPT;
 
-    bool IsUndefined() const;   ///< Tests if a value is an undefined JavaScript value.
-    bool IsNull() const;        ///< Tests if a value is a null JavaScript value.
-    bool IsBoolean() const;     ///< Tests if a value is a JavaScript boolean.
-    bool IsNumber() const;      ///< Tests if a value is a JavaScript number.
+    void (*wrapper)(void* arg);
+    struct CleanupData {
+      Hook hook;
+      Arg* arg;
+    } * data;
+  };
+};
+#endif  // NAPI_VERSION > 2
+
+/// A JavaScript value of unknown type.
+///
+/// For type-specific operations, convert to one of the Value subclasses using a
+/// `To*` or `As()` method. The `To*` methods do type coercion; the `As()`
+/// method does not.
+///
+///     Napi::Value value = ...
+///     if (!value.IsString()) throw Napi::TypeError::New(env, "Invalid
+///     arg..."); Napi::String str = value.As<Napi::String>(); // Cast to a
+///     string value
+///
+///     Napi::Value anotherValue = ...
+///     bool isTruthy = anotherValue.ToBoolean(); // Coerce to a boolean value
+class Value {
+ public:
+  Value();  ///< Creates a new _empty_ Value instance.
+  Value(napi_env env,
+        napi_value value);  ///< Wraps a Node-API value primitive.
+
+  /// Creates a JS value from a C++ primitive.
+  ///
+  /// `value` may be any of:
+  /// - bool
+  /// - Any integer type
+  /// - Any floating point type
+  /// - const char* (encoded using UTF-8, null-terminated)
+  /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
+  /// - std::string (encoded using UTF-8)
+  /// - std::u16string
+  /// - napi::Value
+  /// - napi_value
+  template <typename T>
+  static Value From(napi_env env, const T& value);
+
+  /// Converts to a Node-API value primitive.
+  ///
+  /// If the instance is _empty_, this returns `nullptr`.
+  operator napi_value() const;
+
+  /// Tests if this value strictly equals another value.
+  bool operator==(const Value& other) const;
+
+  /// Tests if this value does not strictly equal another value.
+  bool operator!=(const Value& other) const;
+
+  /// Tests if this value strictly equals another value.
+  bool StrictEquals(const Value& other) const;
+
+  /// Gets the environment the value is associated with.
+  Napi::Env Env() const;
+
+  /// Checks if the value is empty (uninitialized).
+  ///
+  /// An empty value is invalid, and most attempts to perform an operation on an
+  /// empty value will result in an exception. Note an empty value is distinct
+  /// from JavaScript `null` or `undefined`, which are valid values.
+  ///
+  /// When C++ exceptions are disabled at compile time, a method with a `Value`
+  /// return type may return an empty value to indicate a pending exception. So
+  /// when not using C++ exceptions, callers should check whether the value is
+  /// empty before attempting to use it.
+  bool IsEmpty() const;
+
+  napi_valuetype Type() const;  ///< Gets the type of the value.
+
+  bool IsUndefined()
+      const;            ///< Tests if a value is an undefined JavaScript value.
+  bool IsNull() const;  ///< Tests if a value is a null JavaScript value.
+  bool IsBoolean() const;  ///< Tests if a value is a JavaScript boolean.
+  bool IsNumber() const;   ///< Tests if a value is a JavaScript number.
 #if NAPI_VERSION > 5
-    bool IsBigInt() const;      ///< Tests if a value is a JavaScript bigint.
-#endif  // NAPI_VERSION > 5
+  bool IsBigInt() const;  ///< Tests if a value is a JavaScript bigint.
+#endif                    // NAPI_VERSION > 5
 #if (NAPI_VERSION > 4)
-    bool IsDate() const;        ///< Tests if a value is a JavaScript date.
+  bool IsDate() const;  ///< Tests if a value is a JavaScript date.
 #endif
-    bool IsString() const;      ///< Tests if a value is a JavaScript string.
-    bool IsSymbol() const;      ///< Tests if a value is a JavaScript symbol.
-    bool IsArray() const;       ///< Tests if a value is a JavaScript array.
-    bool IsArrayBuffer() const; ///< Tests if a value is a JavaScript array buffer.
-    bool IsTypedArray() const;  ///< Tests if a value is a JavaScript typed array.
-    bool IsObject() const;      ///< Tests if a value is a JavaScript object.
-    bool IsFunction() const;    ///< Tests if a value is a JavaScript function.
-    bool IsPromise() const;     ///< Tests if a value is a JavaScript promise.
-    bool IsDataView() const;    ///< Tests if a value is a JavaScript data view.
-    bool IsBuffer() const;      ///< Tests if a value is a Node buffer.
-    bool IsExternal() const;    ///< Tests if a value is a pointer to external data.
+  bool IsString() const;  ///< Tests if a value is a JavaScript string.
+  bool IsSymbol() const;  ///< Tests if a value is a JavaScript symbol.
+  bool IsArray() const;   ///< Tests if a value is a JavaScript array.
+  bool IsArrayBuffer()
+      const;  ///< Tests if a value is a JavaScript array buffer.
+  bool IsTypedArray() const;  ///< Tests if a value is a JavaScript typed array.
+  bool IsObject() const;      ///< Tests if a value is a JavaScript object.
+  bool IsFunction() const;    ///< Tests if a value is a JavaScript function.
+  bool IsPromise() const;     ///< Tests if a value is a JavaScript promise.
+  bool IsDataView() const;    ///< Tests if a value is a JavaScript data view.
+  bool IsBuffer() const;      ///< Tests if a value is a Node buffer.
+  bool IsExternal() const;  ///< Tests if a value is a pointer to external data.
 
-    /// Casts to another type of `Napi::Value`, when the actual type is known or assumed.
-    ///
-    /// This conversion does NOT coerce the type. Calling any methods inappropriate for the actual
-    /// value type will throw `Napi::Error`.
-    template <typename T> T As() const;
+  /// Casts to another type of `Napi::Value`, when the actual type is known or
+  /// assumed.
+  ///
+  /// This conversion does NOT coerce the type. Calling any methods
+  /// inappropriate for the actual value type will throw `Napi::Error`.
+  template <typename T>
+  T As() const;
 
-    MaybeOrValue<Boolean> ToBoolean()
-        const;  ///< Coerces a value to a JavaScript boolean.
-    MaybeOrValue<Number> ToNumber()
-        const;  ///< Coerces a value to a JavaScript number.
-    MaybeOrValue<String> ToString()
-        const;  ///< Coerces a value to a JavaScript string.
-    MaybeOrValue<Object> ToObject()
-        const;  ///< Coerces a value to a JavaScript object.
+  MaybeOrValue<Boolean> ToBoolean()
+      const;  ///< Coerces a value to a JavaScript boolean.
+  MaybeOrValue<Number> ToNumber()
+      const;  ///< Coerces a value to a JavaScript number.
+  MaybeOrValue<String> ToString()
+      const;  ///< Coerces a value to a JavaScript string.
+  MaybeOrValue<Object> ToObject()
+      const;  ///< Coerces a value to a JavaScript object.
 
-   protected:
-    /// !cond INTERNAL
-    napi_env _env;
-    napi_value _value;
-    /// !endcond
-  };
+ protected:
+  /// !cond INTERNAL
+  napi_env _env;
+  napi_value _value;
+  /// !endcond
+};
 
-  /// A JavaScript boolean value.
-  class Boolean : public Value {
-  public:
-   static Boolean New(napi_env env,  ///< Node-API environment
-                      bool value     ///< Boolean value
-   );
+/// A JavaScript boolean value.
+class Boolean : public Value {
+ public:
+  static Boolean New(napi_env env,  ///< Node-API environment
+                     bool value     ///< Boolean value
+  );
 
-   Boolean();  ///< Creates a new _empty_ Boolean instance.
-   Boolean(napi_env env,
-           napi_value value);  ///< Wraps a Node-API value primitive.
-
-   operator bool() const;  ///< Converts a Boolean value to a boolean primitive.
-   bool Value() const;     ///< Converts a Boolean value to a boolean primitive.
-  };
-
-  /// A JavaScript number value.
-  class Number : public Value {
-  public:
-   static Number New(napi_env env,  ///< Node-API environment
-                     double value   ///< Number value
-   );
-
-   Number();  ///< Creates a new _empty_ Number instance.
-   Number(napi_env env,
+  Boolean();  ///< Creates a new _empty_ Boolean instance.
+  Boolean(napi_env env,
           napi_value value);  ///< Wraps a Node-API value primitive.
 
-   operator int32_t()
-       const;  ///< Converts a Number value to a 32-bit signed integer value.
-   operator uint32_t()
-       const;  ///< Converts a Number value to a 32-bit unsigned integer value.
-   operator int64_t()
-       const;  ///< Converts a Number value to a 64-bit signed integer value.
-   operator float()
-       const;  ///< Converts a Number value to a 32-bit floating-point value.
-   operator double()
-       const;  ///< Converts a Number value to a 64-bit floating-point value.
+  operator bool() const;  ///< Converts a Boolean value to a boolean primitive.
+  bool Value() const;     ///< Converts a Boolean value to a boolean primitive.
+};
 
-   int32_t Int32Value()
-       const;  ///< Converts a Number value to a 32-bit signed integer value.
-   uint32_t Uint32Value()
-       const;  ///< Converts a Number value to a 32-bit unsigned integer value.
-   int64_t Int64Value()
-       const;  ///< Converts a Number value to a 64-bit signed integer value.
-   float FloatValue()
-       const;  ///< Converts a Number value to a 32-bit floating-point value.
-   double DoubleValue()
-       const;  ///< Converts a Number value to a 64-bit floating-point value.
-  };
+/// A JavaScript number value.
+class Number : public Value {
+ public:
+  static Number New(napi_env env,  ///< Node-API environment
+                    double value   ///< Number value
+  );
+
+  Number();  ///< Creates a new _empty_ Number instance.
+  Number(napi_env env,
+         napi_value value);  ///< Wraps a Node-API value primitive.
+
+  operator int32_t()
+      const;  ///< Converts a Number value to a 32-bit signed integer value.
+  operator uint32_t()
+      const;  ///< Converts a Number value to a 32-bit unsigned integer value.
+  operator int64_t()
+      const;  ///< Converts a Number value to a 64-bit signed integer value.
+  operator float()
+      const;  ///< Converts a Number value to a 32-bit floating-point value.
+  operator double()
+      const;  ///< Converts a Number value to a 64-bit floating-point value.
+
+  int32_t Int32Value()
+      const;  ///< Converts a Number value to a 32-bit signed integer value.
+  uint32_t Uint32Value()
+      const;  ///< Converts a Number value to a 32-bit unsigned integer value.
+  int64_t Int64Value()
+      const;  ///< Converts a Number value to a 64-bit signed integer value.
+  float FloatValue()
+      const;  ///< Converts a Number value to a 32-bit floating-point value.
+  double DoubleValue()
+      const;  ///< Converts a Number value to a 64-bit floating-point value.
+};
 
 #if NAPI_VERSION > 5
-  /// A JavaScript bigint value.
-  class BigInt : public Value {
-  public:
-   static BigInt New(napi_env env,  ///< Node-API environment
-                     int64_t value  ///< Number value
-   );
-   static BigInt New(napi_env env,   ///< Node-API environment
-                     uint64_t value  ///< Number value
-   );
+/// A JavaScript bigint value.
+class BigInt : public Value {
+ public:
+  static BigInt New(napi_env env,  ///< Node-API environment
+                    int64_t value  ///< Number value
+  );
+  static BigInt New(napi_env env,   ///< Node-API environment
+                    uint64_t value  ///< Number value
+  );
 
-   /// Creates a new BigInt object using a specified sign bit and a
-   /// specified list of digits/words.
-   /// The resulting number is calculated as:
-   /// (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
-   static BigInt New(napi_env env,          ///< Node-API environment
-                     int sign_bit,          ///< Sign bit. 1 if negative.
-                     size_t word_count,     ///< Number of words in array
-                     const uint64_t* words  ///< Array of words
-   );
+  /// Creates a new BigInt object using a specified sign bit and a
+  /// specified list of digits/words.
+  /// The resulting number is calculated as:
+  /// (-1)^sign_bit * (words[0] * (2^64)^0 + words[1] * (2^64)^1 + ...)
+  static BigInt New(napi_env env,          ///< Node-API environment
+                    int sign_bit,          ///< Sign bit. 1 if negative.
+                    size_t word_count,     ///< Number of words in array
+                    const uint64_t* words  ///< Array of words
+  );
 
-   BigInt();  ///< Creates a new _empty_ BigInt instance.
-   BigInt(napi_env env,
-          napi_value value);  ///< Wraps a Node-API value primitive.
+  BigInt();  ///< Creates a new _empty_ BigInt instance.
+  BigInt(napi_env env,
+         napi_value value);  ///< Wraps a Node-API value primitive.
 
-   int64_t Int64Value(bool* lossless)
-       const;  ///< Converts a BigInt value to a 64-bit signed integer value.
-   uint64_t Uint64Value(bool* lossless)
-       const;  ///< Converts a BigInt value to a 64-bit unsigned integer value.
+  int64_t Int64Value(bool* lossless)
+      const;  ///< Converts a BigInt value to a 64-bit signed integer value.
+  uint64_t Uint64Value(bool* lossless)
+      const;  ///< Converts a BigInt value to a 64-bit unsigned integer value.
 
-   size_t WordCount() const;  ///< The number of 64-bit words needed to store
-                              ///< the result of ToWords().
+  size_t WordCount() const;  ///< The number of 64-bit words needed to store
+                             ///< the result of ToWords().
 
-   /// Writes the contents of this BigInt to a specified memory location.
-   /// `sign_bit` must be provided and will be set to 1 if this BigInt is
-   /// negative.
-   /// `*word_count` has to be initialized to the length of the `words` array.
-   /// Upon return, it will be set to the actual number of words that would
-   /// be needed to store this BigInt (i.e. the return value of `WordCount()`).
-   void ToWords(int* sign_bit, size_t* word_count, uint64_t* words);
-  };
+  /// Writes the contents of this BigInt to a specified memory location.
+  /// `sign_bit` must be provided and will be set to 1 if this BigInt is
+  /// negative.
+  /// `*word_count` has to be initialized to the length of the `words` array.
+  /// Upon return, it will be set to the actual number of words that would
+  /// be needed to store this BigInt (i.e. the return value of `WordCount()`).
+  void ToWords(int* sign_bit, size_t* word_count, uint64_t* words);
+};
 #endif  // NAPI_VERSION > 5
 
 #if (NAPI_VERSION > 4)
-  /// A JavaScript date value.
-  class Date : public Value {
-  public:
-    /// Creates a new Date value from a double primitive.
-   static Date New(napi_env env,  ///< Node-API environment
-                   double value   ///< Number value
-   );
+/// A JavaScript date value.
+class Date : public Value {
+ public:
+  /// Creates a new Date value from a double primitive.
+  static Date New(napi_env env,  ///< Node-API environment
+                  double value   ///< Number value
+  );
 
-   Date();  ///< Creates a new _empty_ Date instance.
-   Date(napi_env env, napi_value value);  ///< Wraps a Node-API value primitive.
-   operator double() const;  ///< Converts a Date value to double primitive
+  Date();  ///< Creates a new _empty_ Date instance.
+  Date(napi_env env, napi_value value);  ///< Wraps a Node-API value primitive.
+  operator double() const;  ///< Converts a Date value to double primitive
 
-   double ValueOf() const;  ///< Converts a Date value to a double primitive.
-  };
-  #endif
+  double ValueOf() const;  ///< Converts a Date value to a double primitive.
+};
+#endif
 
-  /// A JavaScript string or symbol value (that can be used as a property name).
-  class Name : public Value {
-  public:
-    Name();                               ///< Creates a new _empty_ Name instance.
-    Name(napi_env env,
+/// A JavaScript string or symbol value (that can be used as a property name).
+class Name : public Value {
+ public:
+  Name();  ///< Creates a new _empty_ Name instance.
+  Name(napi_env env,
+       napi_value value);  ///< Wraps a Node-API value primitive.
+};
+
+/// A JavaScript string value.
+class String : public Name {
+ public:
+  /// Creates a new String value from a UTF-8 encoded C++ string.
+  static String New(napi_env env,             ///< Node-API environment
+                    const std::string& value  ///< UTF-8 encoded C++ string
+  );
+
+  /// Creates a new String value from a UTF-16 encoded C++ string.
+  static String New(napi_env env,                ///< Node-API environment
+                    const std::u16string& value  ///< UTF-16 encoded C++ string
+  );
+
+  /// Creates a new String value from a UTF-8 encoded C string.
+  static String New(
+      napi_env env,      ///< Node-API environment
+      const char* value  ///< UTF-8 encoded null-terminated C string
+  );
+
+  /// Creates a new String value from a UTF-16 encoded C string.
+  static String New(
+      napi_env env,          ///< Node-API environment
+      const char16_t* value  ///< UTF-16 encoded null-terminated C string
+  );
+
+  /// Creates a new String value from a UTF-8 encoded C string with specified
+  /// length.
+  static String New(napi_env env,       ///< Node-API environment
+                    const char* value,  ///< UTF-8 encoded C string (not
+                                        ///< necessarily null-terminated)
+                    size_t length       ///< length of the string in bytes
+  );
+
+  /// Creates a new String value from a UTF-16 encoded C string with specified
+  /// length.
+  static String New(
+      napi_env env,           ///< Node-API environment
+      const char16_t* value,  ///< UTF-16 encoded C string (not necessarily
+                              ///< null-terminated)
+      size_t length           ///< Length of the string in 2-byte code units
+  );
+
+  /// Creates a new String based on the original object's type.
+  ///
+  /// `value` may be any of:
+  /// - const char* (encoded using UTF-8, null-terminated)
+  /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
+  /// - std::string (encoded using UTF-8)
+  /// - std::u16string
+  template <typename T>
+  static String From(napi_env env, const T& value);
+
+  String();  ///< Creates a new _empty_ String instance.
+  String(napi_env env,
          napi_value value);  ///< Wraps a Node-API value primitive.
+
+  operator std::string()
+      const;  ///< Converts a String value to a UTF-8 encoded C++ string.
+  operator std::u16string()
+      const;  ///< Converts a String value to a UTF-16 encoded C++ string.
+  std::string Utf8Value()
+      const;  ///< Converts a String value to a UTF-8 encoded C++ string.
+  std::u16string Utf16Value()
+      const;  ///< Converts a String value to a UTF-16 encoded C++ string.
+};
+
+/// A JavaScript symbol value.
+class Symbol : public Name {
+ public:
+  /// Creates a new Symbol value with an optional description.
+  static Symbol New(
+      napi_env env,  ///< Node-API environment
+      const char* description =
+          nullptr  ///< Optional UTF-8 encoded null-terminated C string
+                   ///  describing the symbol
+  );
+
+  /// Creates a new Symbol value with a description.
+  static Symbol New(
+      napi_env env,  ///< Node-API environment
+      const std::string&
+          description  ///< UTF-8 encoded C++ string describing the symbol
+  );
+
+  /// Creates a new Symbol value with a description.
+  static Symbol New(napi_env env,       ///< Node-API environment
+                    String description  ///< String value describing the symbol
+  );
+
+  /// Creates a new Symbol value with a description.
+  static Symbol New(
+      napi_env env,           ///< Node-API environment
+      napi_value description  ///< String value describing the symbol
+  );
+
+  /// Get a public Symbol (e.g. Symbol.iterator).
+  static MaybeOrValue<Symbol> WellKnown(napi_env, const std::string& name);
+
+  // Create a symbol in the global registry, UTF-8 Encoded cpp string
+  static MaybeOrValue<Symbol> For(napi_env env, const std::string& description);
+
+  // Create a symbol in the global registry, C style string (null terminated)
+  static MaybeOrValue<Symbol> For(napi_env env, const char* description);
+
+  // Create a symbol in the global registry, String value describing the symbol
+  static MaybeOrValue<Symbol> For(napi_env env, String description);
+
+  // Create a symbol in the global registry, napi_value describing the symbol
+  static MaybeOrValue<Symbol> For(napi_env env, napi_value description);
+
+  Symbol();  ///< Creates a new _empty_ Symbol instance.
+  Symbol(napi_env env,
+         napi_value value);  ///< Wraps a Node-API value primitive.
+};
+
+/// A JavaScript object value.
+class Object : public Value {
+ public:
+  /// Enables property and element assignments using indexing syntax.
+  ///
+  /// This is a convenient helper to get and set object properties. As
+  /// getting and setting object properties may throw with JavaScript
+  /// exceptions, it is notable that these operations may fail.
+  /// When NODE_ADDON_API_ENABLE_MAYBE is defined, the process will abort
+  /// on JavaScript exceptions.
+  ///
+  /// Example:
+  ///
+  ///     Napi::Value propertyValue = object1['A'];
+  ///     object2['A'] = propertyValue;
+  ///     Napi::Value elementValue = array[0];
+  ///     array[1] = elementValue;
+  template <typename Key>
+  class PropertyLValue {
+   public:
+    /// Converts an L-value to a value.
+    operator Value() const;
+
+    /// Assigns a value to the property. The type of value can be
+    /// anything supported by `Object::Set`.
+    template <typename ValueType>
+    PropertyLValue& operator=(ValueType value);
+
+   private:
+    PropertyLValue() = delete;
+    PropertyLValue(Object object, Key key);
+    napi_env _env;
+    napi_value _object;
+    Key _key;
+
+    friend class Napi::Object;
   };
 
-  /// A JavaScript string value.
-  class String : public Name {
-  public:
-    /// Creates a new String value from a UTF-8 encoded C++ string.
-   static String New(napi_env env,             ///< Node-API environment
-                     const std::string& value  ///< UTF-8 encoded C++ string
-   );
+  /// Creates a new Object value.
+  static Object New(napi_env env  ///< Node-API environment
+  );
 
-   /// Creates a new String value from a UTF-16 encoded C++ string.
-   static String New(napi_env env,                ///< Node-API environment
-                     const std::u16string& value  ///< UTF-16 encoded C++ string
-   );
+  Object();  ///< Creates a new _empty_ Object instance.
+  Object(napi_env env,
+         napi_value value);  ///< Wraps a Node-API value primitive.
 
-   /// Creates a new String value from a UTF-8 encoded C string.
-   static String New(
-       napi_env env,      ///< Node-API environment
-       const char* value  ///< UTF-8 encoded null-terminated C string
-   );
+  /// Gets or sets a named property.
+  PropertyLValue<std::string> operator[](
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  );
 
-   /// Creates a new String value from a UTF-16 encoded C string.
-   static String New(
-       napi_env env,          ///< Node-API environment
-       const char16_t* value  ///< UTF-16 encoded null-terminated C string
-   );
+  /// Gets or sets a named property.
+  PropertyLValue<std::string> operator[](
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  );
 
-   /// Creates a new String value from a UTF-8 encoded C string with specified
-   /// length.
-   static String New(napi_env env,       ///< Node-API environment
-                     const char* value,  ///< UTF-8 encoded C string (not
-                                         ///< necessarily null-terminated)
-                     size_t length       ///< length of the string in bytes
-   );
+  /// Gets or sets an indexed property or array element.
+  PropertyLValue<uint32_t> operator[](
+      uint32_t index  /// Property / element index
+  );
 
-   /// Creates a new String value from a UTF-16 encoded C string with specified
-   /// length.
-   static String New(
-       napi_env env,           ///< Node-API environment
-       const char16_t* value,  ///< UTF-16 encoded C string (not necessarily
-                               ///< null-terminated)
-       size_t length           ///< Length of the string in 2-byte code units
-   );
+  /// Gets or sets an indexed property or array element.
+  PropertyLValue<Value> operator[](Value index  /// Property / element index
+  ) const;
 
-   /// Creates a new String based on the original object's type.
-   ///
-   /// `value` may be any of:
-   /// - const char* (encoded using UTF-8, null-terminated)
-   /// - const char16_t* (encoded using UTF-16-LE, null-terminated)
-   /// - std::string (encoded using UTF-8)
-   /// - std::u16string
-   template <typename T>
-   static String From(napi_env env, const T& value);
+  /// Gets a named property.
+  MaybeOrValue<Value> operator[](
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  ) const;
 
-   String();  ///< Creates a new _empty_ String instance.
-   String(napi_env env,
-          napi_value value);  ///< Wraps a Node-API value primitive.
+  /// Gets a named property.
+  MaybeOrValue<Value> operator[](
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  ) const;
 
-   operator std::string()
-       const;  ///< Converts a String value to a UTF-8 encoded C++ string.
-   operator std::u16string()
-       const;  ///< Converts a String value to a UTF-16 encoded C++ string.
-   std::string Utf8Value()
-       const;  ///< Converts a String value to a UTF-8 encoded C++ string.
-   std::u16string Utf16Value()
-       const;  ///< Converts a String value to a UTF-16 encoded C++ string.
-  };
+  /// Gets an indexed property or array element.
+  MaybeOrValue<Value> operator[](uint32_t index  ///< Property / element index
+  ) const;
 
-  /// A JavaScript symbol value.
-  class Symbol : public Name {
-  public:
-    /// Creates a new Symbol value with an optional description.
-   static Symbol New(
-       napi_env env,  ///< Node-API environment
-       const char* description =
-           nullptr  ///< Optional UTF-8 encoded null-terminated C string
-                    ///  describing the symbol
-   );
+  /// Checks whether a property is present.
+  MaybeOrValue<bool> Has(napi_value key  ///< Property key primitive
+  ) const;
 
-   /// Creates a new Symbol value with a description.
-   static Symbol New(
-       napi_env env,  ///< Node-API environment
-       const std::string&
-           description  ///< UTF-8 encoded C++ string describing the symbol
-   );
+  /// Checks whether a property is present.
+  MaybeOrValue<bool> Has(Value key  ///< Property key
+  ) const;
 
-   /// Creates a new Symbol value with a description.
-   static Symbol New(napi_env env,       ///< Node-API environment
-                     String description  ///< String value describing the symbol
-   );
+  /// Checks whether a named property is present.
+  MaybeOrValue<bool> Has(
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  ) const;
 
-   /// Creates a new Symbol value with a description.
-   static Symbol New(
-       napi_env env,           ///< Node-API environment
-       napi_value description  ///< String value describing the symbol
-   );
+  /// Checks whether a named property is present.
+  MaybeOrValue<bool> Has(
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  ) const;
 
-   /// Get a public Symbol (e.g. Symbol.iterator).
-   static MaybeOrValue<Symbol> WellKnown(napi_env, const std::string& name);
+  /// Checks whether a own property is present.
+  MaybeOrValue<bool> HasOwnProperty(napi_value key  ///< Property key primitive
+  ) const;
 
-   // Create a symbol in the global registry, UTF-8 Encoded cpp string
-   static MaybeOrValue<Symbol> For(napi_env env,
-                                   const std::string& description);
+  /// Checks whether a own property is present.
+  MaybeOrValue<bool> HasOwnProperty(Value key  ///< Property key
+  ) const;
 
-   // Create a symbol in the global registry, C style string (null terminated)
-   static MaybeOrValue<Symbol> For(napi_env env, const char* description);
+  /// Checks whether a own property is present.
+  MaybeOrValue<bool> HasOwnProperty(
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  ) const;
 
-   // Create a symbol in the global registry, String value describing the symbol
-   static MaybeOrValue<Symbol> For(napi_env env, String description);
+  /// Checks whether a own property is present.
+  MaybeOrValue<bool> HasOwnProperty(
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  ) const;
 
-   // Create a symbol in the global registry, napi_value describing the symbol
-   static MaybeOrValue<Symbol> For(napi_env env, napi_value description);
+  /// Gets a property.
+  MaybeOrValue<Value> Get(napi_value key  ///< Property key primitive
+  ) const;
 
-   Symbol();  ///< Creates a new _empty_ Symbol instance.
-   Symbol(napi_env env,
-          napi_value value);  ///< Wraps a Node-API value primitive.
-  };
+  /// Gets a property.
+  MaybeOrValue<Value> Get(Value key  ///< Property key
+  ) const;
 
-  /// A JavaScript object value.
-  class Object : public Value {
-  public:
-   /// Enables property and element assignments using indexing syntax.
-   ///
-   /// This is a convenient helper to get and set object properties. As
-   /// getting and setting object properties may throw with JavaScript
-   /// exceptions, it is notable that these operations may fail.
-   /// When NODE_ADDON_API_ENABLE_MAYBE is defined, the process will abort
-   /// on JavaScript exceptions.
-   ///
-   /// Example:
-   ///
-   ///     Napi::Value propertyValue = object1['A'];
-   ///     object2['A'] = propertyValue;
-   ///     Napi::Value elementValue = array[0];
-   ///     array[1] = elementValue;
-   template <typename Key>
-   class PropertyLValue {
-    public:
-      /// Converts an L-value to a value.
-      operator Value() const;
+  /// Gets a named property.
+  MaybeOrValue<Value> Get(
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  ) const;
 
-      /// Assigns a value to the property. The type of value can be
-      /// anything supported by `Object::Set`.
-      template <typename ValueType>
-      PropertyLValue& operator =(ValueType value);
+  /// Gets a named property.
+  MaybeOrValue<Value> Get(
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  ) const;
 
-    private:
-      PropertyLValue() = delete;
-      PropertyLValue(Object object, Key key);
-      napi_env _env;
-      napi_value _object;
-      Key _key;
+  /// Sets a property.
+  template <typename ValueType>
+  MaybeOrValue<bool> Set(napi_value key,         ///< Property key primitive
+                         const ValueType& value  ///< Property value primitive
+  ) const;
 
-      friend class Napi::Object;
-   };
+  /// Sets a property.
+  template <typename ValueType>
+  MaybeOrValue<bool> Set(Value key,              ///< Property key
+                         const ValueType& value  ///< Property value
+  ) const;
 
-    /// Creates a new Object value.
-    static Object New(napi_env env  ///< Node-API environment
-    );
+  /// Sets a named property.
+  template <typename ValueType>
+  MaybeOrValue<bool> Set(
+      const char* utf8name,  ///< UTF-8 encoded null-terminated property name
+      const ValueType& value) const;
 
-    Object();                               ///< Creates a new _empty_ Object instance.
-    Object(napi_env env,
-           napi_value value);  ///< Wraps a Node-API value primitive.
+  /// Sets a named property.
+  template <typename ValueType>
+  MaybeOrValue<bool> Set(
+      const std::string& utf8name,  ///< UTF-8 encoded property name
+      const ValueType& value        ///< Property value primitive
+  ) const;
 
-    /// Gets or sets a named property.
-    PropertyLValue<std::string> operator[](
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    );
+  /// Delete property.
+  MaybeOrValue<bool> Delete(napi_value key  ///< Property key primitive
+  ) const;
 
-    /// Gets or sets a named property.
-    PropertyLValue<std::string> operator[](
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    );
+  /// Delete property.
+  MaybeOrValue<bool> Delete(Value key  ///< Property key
+  ) const;
 
-    /// Gets or sets an indexed property or array element.
-    PropertyLValue<uint32_t> operator[](
-        uint32_t index  /// Property / element index
-    );
+  /// Delete property.
+  MaybeOrValue<bool> Delete(
+      const char* utf8name  ///< UTF-8 encoded null-terminated property name
+  ) const;
 
-    /// Gets or sets an indexed property or array element.
-    PropertyLValue<Value> operator[](Value index  /// Property / element index
-    ) const;
+  /// Delete property.
+  MaybeOrValue<bool> Delete(
+      const std::string& utf8name  ///< UTF-8 encoded property name
+  ) const;
 
-    /// Gets a named property.
-    MaybeOrValue<Value> operator[](
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    ) const;
+  /// Checks whether an indexed property is present.
+  MaybeOrValue<bool> Has(uint32_t index  ///< Property / element index
+  ) const;
 
-    /// Gets a named property.
-    MaybeOrValue<Value> operator[](
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    ) const;
+  /// Gets an indexed property or array element.
+  MaybeOrValue<Value> Get(uint32_t index  ///< Property / element index
+  ) const;
 
-    /// Gets an indexed property or array element.
-    MaybeOrValue<Value> operator[](uint32_t index  ///< Property / element index
-    ) const;
+  /// Sets an indexed property or array element.
+  template <typename ValueType>
+  MaybeOrValue<bool> Set(uint32_t index,         ///< Property / element index
+                         const ValueType& value  ///< Property value primitive
+  ) const;
 
-    /// Checks whether a property is present.
-    MaybeOrValue<bool> Has(napi_value key  ///< Property key primitive
-    ) const;
+  /// Deletes an indexed property or array element.
+  MaybeOrValue<bool> Delete(uint32_t index  ///< Property / element index
+  ) const;
 
-    /// Checks whether a property is present.
-    MaybeOrValue<bool> Has(Value key  ///< Property key
-    ) const;
+  /// This operation can fail in case of Proxy.[[OwnPropertyKeys]] and
+  /// Proxy.[[GetOwnProperty]] calling into JavaScript. See:
+  /// -
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
+  /// -
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
+  MaybeOrValue<Array> GetPropertyNames() const;  ///< Get all property names
 
-    /// Checks whether a named property is present.
-    MaybeOrValue<bool> Has(
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    ) const;
+  /// Defines a property on the object.
+  ///
+  /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+  /// into JavaScript. See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+  MaybeOrValue<bool> DefineProperty(
+      const PropertyDescriptor&
+          property  ///< Descriptor for the property to be defined
+  ) const;
 
-    /// Checks whether a named property is present.
-    MaybeOrValue<bool> Has(
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    ) const;
+  /// Defines properties on the object.
+  ///
+  /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+  /// into JavaScript. See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+  MaybeOrValue<bool> DefineProperties(
+      const std::initializer_list<PropertyDescriptor>& properties
+      ///< List of descriptors for the properties to be defined
+  ) const;
 
-    /// Checks whether a own property is present.
-    MaybeOrValue<bool> HasOwnProperty(
-        napi_value key  ///< Property key primitive
-    ) const;
+  /// Defines properties on the object.
+  ///
+  /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
+  /// into JavaScript. See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
+  MaybeOrValue<bool> DefineProperties(
+      const std::vector<PropertyDescriptor>& properties
+      ///< Vector of descriptors for the properties to be defined
+  ) const;
 
-    /// Checks whether a own property is present.
-    MaybeOrValue<bool> HasOwnProperty(Value key  ///< Property key
-    ) const;
+  /// Checks if an object is an instance created by a constructor function.
+  ///
+  /// This is equivalent to the JavaScript `instanceof` operator.
+  ///
+  /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+  /// JavaScript.
+  /// See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+  MaybeOrValue<bool> InstanceOf(
+      const Function& constructor  ///< Constructor function
+  ) const;
 
-    /// Checks whether a own property is present.
-    MaybeOrValue<bool> HasOwnProperty(
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    ) const;
+  template <typename Finalizer, typename T>
+  inline void AddFinalizer(Finalizer finalizeCallback, T* data) const;
 
-    /// Checks whether a own property is present.
-    MaybeOrValue<bool> HasOwnProperty(
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    ) const;
-
-    /// Gets a property.
-    MaybeOrValue<Value> Get(napi_value key  ///< Property key primitive
-    ) const;
-
-    /// Gets a property.
-    MaybeOrValue<Value> Get(Value key  ///< Property key
-    ) const;
-
-    /// Gets a named property.
-    MaybeOrValue<Value> Get(
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    ) const;
-
-    /// Gets a named property.
-    MaybeOrValue<Value> Get(
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    ) const;
-
-    /// Sets a property.
-    template <typename ValueType>
-    MaybeOrValue<bool> Set(napi_value key,         ///< Property key primitive
-                           const ValueType& value  ///< Property value primitive
-    ) const;
-
-    /// Sets a property.
-    template <typename ValueType>
-    MaybeOrValue<bool> Set(Value key,              ///< Property key
-                           const ValueType& value  ///< Property value
-    ) const;
-
-    /// Sets a named property.
-    template <typename ValueType>
-    MaybeOrValue<bool> Set(
-        const char* utf8name,  ///< UTF-8 encoded null-terminated property name
-        const ValueType& value) const;
-
-    /// Sets a named property.
-    template <typename ValueType>
-    MaybeOrValue<bool> Set(
-        const std::string& utf8name,  ///< UTF-8 encoded property name
-        const ValueType& value        ///< Property value primitive
-    ) const;
-
-    /// Delete property.
-    MaybeOrValue<bool> Delete(napi_value key  ///< Property key primitive
-    ) const;
-
-    /// Delete property.
-    MaybeOrValue<bool> Delete(Value key  ///< Property key
-    ) const;
-
-    /// Delete property.
-    MaybeOrValue<bool> Delete(
-        const char* utf8name  ///< UTF-8 encoded null-terminated property name
-    ) const;
-
-    /// Delete property.
-    MaybeOrValue<bool> Delete(
-        const std::string& utf8name  ///< UTF-8 encoded property name
-    ) const;
-
-    /// Checks whether an indexed property is present.
-    MaybeOrValue<bool> Has(uint32_t index  ///< Property / element index
-    ) const;
-
-    /// Gets an indexed property or array element.
-    MaybeOrValue<Value> Get(uint32_t index  ///< Property / element index
-    ) const;
-
-    /// Sets an indexed property or array element.
-    template <typename ValueType>
-    MaybeOrValue<bool> Set(uint32_t index,         ///< Property / element index
-                           const ValueType& value  ///< Property value primitive
-    ) const;
-
-    /// Deletes an indexed property or array element.
-    MaybeOrValue<bool> Delete(uint32_t index  ///< Property / element index
-    ) const;
-
-    /// This operation can fail in case of Proxy.[[OwnPropertyKeys]] and
-    /// Proxy.[[GetOwnProperty]] calling into JavaScript. See:
-    /// -
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
-    /// -
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
-    MaybeOrValue<Array> GetPropertyNames() const;  ///< Get all property names
-
-    /// Defines a property on the object.
-    ///
-    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
-    /// into JavaScript. See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    MaybeOrValue<bool> DefineProperty(
-        const PropertyDescriptor&
-            property  ///< Descriptor for the property to be defined
-    ) const;
-
-    /// Defines properties on the object.
-    ///
-    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
-    /// into JavaScript. See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    MaybeOrValue<bool> DefineProperties(
-        const std::initializer_list<PropertyDescriptor>& properties
-        ///< List of descriptors for the properties to be defined
-    ) const;
-
-    /// Defines properties on the object.
-    ///
-    /// This operation can fail in case of Proxy.[[DefineOwnProperty]] calling
-    /// into JavaScript. See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    MaybeOrValue<bool> DefineProperties(
-        const std::vector<PropertyDescriptor>& properties
-        ///< Vector of descriptors for the properties to be defined
-    ) const;
-
-    /// Checks if an object is an instance created by a constructor function.
-    ///
-    /// This is equivalent to the JavaScript `instanceof` operator.
-    ///
-    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
-    /// JavaScript.
-    /// See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
-    MaybeOrValue<bool> InstanceOf(
-        const Function& constructor  ///< Constructor function
-    ) const;
-
-    template <typename Finalizer, typename T>
-    inline void AddFinalizer(Finalizer finalizeCallback, T* data) const;
-
-    template <typename Finalizer, typename T, typename Hint>
-    inline void AddFinalizer(Finalizer finalizeCallback,
-                             T* data,
-                             Hint* finalizeHint) const;
+  template <typename Finalizer, typename T, typename Hint>
+  inline void AddFinalizer(Finalizer finalizeCallback,
+                           T* data,
+                           Hint* finalizeHint) const;
 
 #ifdef NAPI_CPP_EXCEPTIONS
-    class const_iterator;
+  class const_iterator;
 
-    inline const_iterator begin() const;
+  inline const_iterator begin() const;
 
-    inline const_iterator end() const;
+  inline const_iterator end() const;
 
-    class iterator;
+  class iterator;
 
-    inline iterator begin();
+  inline iterator begin();
 
-    inline iterator end();
+  inline iterator end();
 #endif  // NAPI_CPP_EXCEPTIONS
 
 #if NAPI_VERSION >= 8
-    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
-    /// JavaScript.
-    /// See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
-    MaybeOrValue<bool> Freeze() const;
-    /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
-    /// JavaScript.
-    /// See
-    /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
-    MaybeOrValue<bool> Seal() const;
+  /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+  /// JavaScript.
+  /// See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+  MaybeOrValue<bool> Freeze() const;
+  /// This operation can fail in case of Proxy.[[GetPrototypeOf]] calling into
+  /// JavaScript.
+  /// See
+  /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
+  MaybeOrValue<bool> Seal() const;
 #endif  // NAPI_VERSION >= 8
-  };
+};
 
-  template <typename T>
-  class External : public Value {
-  public:
-    static External New(napi_env env, T* data);
+template <typename T>
+class External : public Value {
+ public:
+  static External New(napi_env env, T* data);
 
-    // Finalizer must implement `void operator()(Env env, T* data)`.
-    template <typename Finalizer>
-    static External New(napi_env env,
-                        T* data,
-                        Finalizer finalizeCallback);
-    // Finalizer must implement `void operator()(Env env, T* data, Hint* hint)`.
-    template <typename Finalizer, typename Hint>
-    static External New(napi_env env,
-                        T* data,
-                        Finalizer finalizeCallback,
-                        Hint* finalizeHint);
+  // Finalizer must implement `void operator()(Env env, T* data)`.
+  template <typename Finalizer>
+  static External New(napi_env env, T* data, Finalizer finalizeCallback);
+  // Finalizer must implement `void operator()(Env env, T* data, Hint* hint)`.
+  template <typename Finalizer, typename Hint>
+  static External New(napi_env env,
+                      T* data,
+                      Finalizer finalizeCallback,
+                      Hint* finalizeHint);
 
-    External();
-    External(napi_env env, napi_value value);
+  External();
+  External(napi_env env, napi_value value);
 
-    T* Data() const;
-  };
+  T* Data() const;
+};
 
-  class Array : public Object {
-  public:
-    static Array New(napi_env env);
-    static Array New(napi_env env, size_t length);
+class Array : public Object {
+ public:
+  static Array New(napi_env env);
+  static Array New(napi_env env, size_t length);
 
-    Array();
-    Array(napi_env env, napi_value value);
+  Array();
+  Array(napi_env env, napi_value value);
 
-    uint32_t Length() const;
-  };
+  uint32_t Length() const;
+};
 
 #ifdef NAPI_CPP_EXCEPTIONS
-  class Object::const_iterator {
-   private:
-    enum class Type { BEGIN, END };
+class Object::const_iterator {
+ private:
+  enum class Type { BEGIN, END };
 
-    inline const_iterator(const Object* object, const Type type);
+  inline const_iterator(const Object* object, const Type type);
 
-   public:
-    inline const_iterator& operator++();
+ public:
+  inline const_iterator& operator++();
 
-    inline bool operator==(const const_iterator& other) const;
+  inline bool operator==(const const_iterator& other) const;
 
-    inline bool operator!=(const const_iterator& other) const;
+  inline bool operator!=(const const_iterator& other) const;
 
-    inline const std::pair<Value, Object::PropertyLValue<Value>> operator*()
-        const;
+  inline const std::pair<Value, Object::PropertyLValue<Value>> operator*()
+      const;
 
-   private:
-    const Napi::Object* _object;
-    Array _keys;
-    uint32_t _index;
+ private:
+  const Napi::Object* _object;
+  Array _keys;
+  uint32_t _index;
 
-    friend class Object;
-  };
+  friend class Object;
+};
 
-  class Object::iterator {
-   private:
-    enum class Type { BEGIN, END };
+class Object::iterator {
+ private:
+  enum class Type { BEGIN, END };
 
-    inline iterator(Object* object, const Type type);
+  inline iterator(Object* object, const Type type);
 
-   public:
-    inline iterator& operator++();
+ public:
+  inline iterator& operator++();
 
-    inline bool operator==(const iterator& other) const;
+  inline bool operator==(const iterator& other) const;
 
-    inline bool operator!=(const iterator& other) const;
+  inline bool operator!=(const iterator& other) const;
 
-    inline std::pair<Value, Object::PropertyLValue<Value>> operator*();
+  inline std::pair<Value, Object::PropertyLValue<Value>> operator*();
 
-   private:
-    Napi::Object* _object;
-    Array _keys;
-    uint32_t _index;
+ private:
+  Napi::Object* _object;
+  Array _keys;
+  uint32_t _index;
 
-    friend class Object;
-  };
+  friend class Object;
+};
 #endif  // NAPI_CPP_EXCEPTIONS
 
-  /// A JavaScript array buffer value.
-  class ArrayBuffer : public Object {
-  public:
-    /// Creates a new ArrayBuffer instance over a new automatically-allocated buffer.
-   static ArrayBuffer New(
-       napi_env env,      ///< Node-API environment
-       size_t byteLength  ///< Length of the buffer to be allocated, in bytes
-   );
+/// A JavaScript array buffer value.
+class ArrayBuffer : public Object {
+ public:
+  /// Creates a new ArrayBuffer instance over a new automatically-allocated
+  /// buffer.
+  static ArrayBuffer New(
+      napi_env env,      ///< Node-API environment
+      size_t byteLength  ///< Length of the buffer to be allocated, in bytes
+  );
 
-   /// Creates a new ArrayBuffer instance, using an external buffer with
-   /// specified byte length.
-   static ArrayBuffer New(
-       napi_env env,        ///< Node-API environment
-       void* externalData,  ///< Pointer to the external buffer to be used by
-                            ///< the array
-       size_t byteLength    ///< Length of the external buffer to be used by the
-                            ///< array, in bytes
-   );
+  /// Creates a new ArrayBuffer instance, using an external buffer with
+  /// specified byte length.
+  static ArrayBuffer New(
+      napi_env env,        ///< Node-API environment
+      void* externalData,  ///< Pointer to the external buffer to be used by
+                           ///< the array
+      size_t byteLength    ///< Length of the external buffer to be used by the
+                           ///< array, in bytes
+  );
 
-   /// Creates a new ArrayBuffer instance, using an external buffer with
-   /// specified byte length.
-   template <typename Finalizer>
-   static ArrayBuffer New(
-       napi_env env,        ///< Node-API environment
-       void* externalData,  ///< Pointer to the external buffer to be used by
-                            ///< the array
-       size_t byteLength,   ///< Length of the external buffer to be used by the
-                            ///< array,
-                            ///  in bytes
-       Finalizer finalizeCallback  ///< Function to be called when the array
+  /// Creates a new ArrayBuffer instance, using an external buffer with
+  /// specified byte length.
+  template <typename Finalizer>
+  static ArrayBuffer New(
+      napi_env env,        ///< Node-API environment
+      void* externalData,  ///< Pointer to the external buffer to be used by
+                           ///< the array
+      size_t byteLength,   ///< Length of the external buffer to be used by the
+                           ///< array,
+                           ///  in bytes
+      Finalizer finalizeCallback  ///< Function to be called when the array
+                                  ///< buffer is destroyed;
+                                  ///  must implement `void operator()(Env env,
+                                  ///  void* externalData)`
+  );
+
+  /// Creates a new ArrayBuffer instance, using an external buffer with
+  /// specified byte length.
+  template <typename Finalizer, typename Hint>
+  static ArrayBuffer New(
+      napi_env env,        ///< Node-API environment
+      void* externalData,  ///< Pointer to the external buffer to be used by
+                           ///< the array
+      size_t byteLength,   ///< Length of the external buffer to be used by the
+                           ///< array,
+                           ///  in bytes
+      Finalizer finalizeCallback,  ///< Function to be called when the array
                                    ///< buffer is destroyed;
-                                   ///  must implement `void operator()(Env env,
-                                   ///  void* externalData)`
-   );
+                                   ///  must implement `void operator()(Env
+                                   ///  env, void* externalData, Hint* hint)`
+      Hint* finalizeHint  ///< Hint (second parameter) to be passed to the
+                          ///< finalize callback
+  );
 
-   /// Creates a new ArrayBuffer instance, using an external buffer with
-   /// specified byte length.
-   template <typename Finalizer, typename Hint>
-   static ArrayBuffer New(
-       napi_env env,        ///< Node-API environment
-       void* externalData,  ///< Pointer to the external buffer to be used by
-                            ///< the array
-       size_t byteLength,   ///< Length of the external buffer to be used by the
-                            ///< array,
-                            ///  in bytes
-       Finalizer finalizeCallback,  ///< Function to be called when the array
-                                    ///< buffer is destroyed;
-                                    ///  must implement `void operator()(Env
-                                    ///  env, void* externalData, Hint* hint)`
-       Hint* finalizeHint  ///< Hint (second parameter) to be passed to the
-                           ///< finalize callback
-   );
+  ArrayBuffer();  ///< Creates a new _empty_ ArrayBuffer instance.
+  ArrayBuffer(napi_env env,
+              napi_value value);  ///< Wraps a Node-API value primitive.
 
-   ArrayBuffer();  ///< Creates a new _empty_ ArrayBuffer instance.
-   ArrayBuffer(napi_env env,
-               napi_value value);  ///< Wraps a Node-API value primitive.
-
-   void* Data();         ///< Gets a pointer to the data buffer.
-   size_t ByteLength();  ///< Gets the length of the array buffer in bytes.
+  void* Data();         ///< Gets a pointer to the data buffer.
+  size_t ByteLength();  ///< Gets the length of the array buffer in bytes.
 
 #if NAPI_VERSION >= 7
-    bool IsDetached() const;
-    void Detach();
+  bool IsDetached() const;
+  void Detach();
 #endif  // NAPI_VERSION >= 7
-  };
+};
 
-  /// A JavaScript typed-array value with unknown array type.
-  ///
-  /// For type-specific operations, cast to a `TypedArrayOf<T>` instance using the `As()`
-  /// method:
-  ///
-  ///     Napi::TypedArray array = ...
-  ///     if (t.TypedArrayType() == napi_int32_array) {
-  ///         Napi::Int32Array int32Array = t.As<Napi::Int32Array>();
-  ///     }
-  class TypedArray : public Object {
-  public:
-    TypedArray();                               ///< Creates a new _empty_ TypedArray instance.
-    TypedArray(napi_env env,
-               napi_value value);  ///< Wraps a Node-API value primitive.
-
-    napi_typedarray_type TypedArrayType() const; ///< Gets the type of this typed-array.
-    Napi::ArrayBuffer ArrayBuffer() const;       ///< Gets the backing array buffer.
-
-    uint8_t ElementSize() const;  ///< Gets the size in bytes of one element in the array.
-    size_t ElementLength() const; ///< Gets the number of elements in the array.
-    size_t ByteOffset() const;    ///< Gets the offset into the buffer where the array starts.
-    size_t ByteLength() const;    ///< Gets the length of the array in bytes.
-
-  protected:
-    /// !cond INTERNAL
-    napi_typedarray_type _type;
-    size_t _length;
-
-    TypedArray(napi_env env, napi_value value, napi_typedarray_type type, size_t length);
-
-    static const napi_typedarray_type unknown_array_type = static_cast<napi_typedarray_type>(-1);
-
-    template <typename T>
-    static
-#if defined(NAPI_HAS_CONSTEXPR)
-    constexpr
-#endif
-    napi_typedarray_type TypedArrayTypeForPrimitiveType() {
-      return std::is_same<T, int8_t>::value ? napi_int8_array
-        : std::is_same<T, uint8_t>::value ? napi_uint8_array
-        : std::is_same<T, int16_t>::value ? napi_int16_array
-        : std::is_same<T, uint16_t>::value ? napi_uint16_array
-        : std::is_same<T, int32_t>::value ? napi_int32_array
-        : std::is_same<T, uint32_t>::value ? napi_uint32_array
-        : std::is_same<T, float>::value ? napi_float32_array
-        : std::is_same<T, double>::value ? napi_float64_array
-#if NAPI_VERSION > 5
-        : std::is_same<T, int64_t>::value ? napi_bigint64_array
-        : std::is_same<T, uint64_t>::value ? napi_biguint64_array
-#endif  // NAPI_VERSION > 5
-        : unknown_array_type;
-    }
-    /// !endcond
-  };
-
-  /// A JavaScript typed-array value with known array type.
-  ///
-  /// Note while it is possible to create and access Uint8 "clamped" arrays using this class,
-  /// the _clamping_ behavior is only applied in JavaScript.
-  template <typename T>
-  class TypedArrayOf : public TypedArray {
-  public:
-    /// Creates a new TypedArray instance over a new automatically-allocated array buffer.
-    ///
-    /// The array type parameter can normally be omitted (because it is inferred from the template
-    /// parameter T), except when creating a "clamped" array:
-    ///
-    ///     Uint8Array::New(env, length, napi_uint8_clamped_array)
-   static TypedArrayOf New(
-       napi_env env,          ///< Node-API environment
-       size_t elementLength,  ///< Length of the created array, as a number of
-                              ///< elements
-#if defined(NAPI_HAS_CONSTEXPR)
-       napi_typedarray_type type =
-           TypedArray::TypedArrayTypeForPrimitiveType<T>()
-#else
-       napi_typedarray_type type
-#endif
-       ///< Type of array, if different from the default array type for the
-       ///< template parameter T.
-   );
-
-    /// Creates a new TypedArray instance over a provided array buffer.
-    ///
-    /// The array type parameter can normally be omitted (because it is inferred from the template
-    /// parameter T), except when creating a "clamped" array:
-    ///
-    ///     Uint8Array::New(env, length, buffer, 0, napi_uint8_clamped_array)
-   static TypedArrayOf New(
-       napi_env env,          ///< Node-API environment
-       size_t elementLength,  ///< Length of the created array, as a number of
-                              ///< elements
-       Napi::ArrayBuffer arrayBuffer,  ///< Backing array buffer instance to use
-       size_t bufferOffset,  ///< Offset into the array buffer where the
-                             ///< typed-array starts
-#if defined(NAPI_HAS_CONSTEXPR)
-       napi_typedarray_type type =
-           TypedArray::TypedArrayTypeForPrimitiveType<T>()
-#else
-       napi_typedarray_type type
-#endif
-       ///< Type of array, if different from the default array type for the
-       ///< template parameter T.
-   );
-
-    TypedArrayOf();                               ///< Creates a new _empty_ TypedArrayOf instance.
-    TypedArrayOf(napi_env env,
-                 napi_value value);  ///< Wraps a Node-API value primitive.
-
-    T& operator [](size_t index);             ///< Gets or sets an element in the array.
-    const T& operator [](size_t index) const; ///< Gets an element in the array.
-
-    /// Gets a pointer to the array's backing buffer.
-    ///
-    /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer, because the
-    /// typed-array may have a non-zero `ByteOffset()` into the `ArrayBuffer`.
-    T* Data();
-
-    /// Gets a pointer to the array's backing buffer.
-    ///
-    /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer, because the
-    /// typed-array may have a non-zero `ByteOffset()` into the `ArrayBuffer`.
-    const T* Data() const;
-
-  private:
-    T* _data;
-
-    TypedArrayOf(napi_env env,
-                 napi_value value,
-                 napi_typedarray_type type,
-                 size_t length,
-                 T* data);
-  };
-
-  /// The DataView provides a low-level interface for reading/writing multiple
-  /// number types in an ArrayBuffer irrespective of the platform's endianness.
-  class DataView : public Object {
-  public:
-    static DataView New(napi_env env,
-                        Napi::ArrayBuffer arrayBuffer);
-    static DataView New(napi_env env,
-                        Napi::ArrayBuffer arrayBuffer,
-                        size_t byteOffset);
-    static DataView New(napi_env env,
-                        Napi::ArrayBuffer arrayBuffer,
-                        size_t byteOffset,
-                        size_t byteLength);
-
-    DataView();                               ///< Creates a new _empty_ DataView instance.
-    DataView(napi_env env,
+/// A JavaScript typed-array value with unknown array type.
+///
+/// For type-specific operations, cast to a `TypedArrayOf<T>` instance using the
+/// `As()` method:
+///
+///     Napi::TypedArray array = ...
+///     if (t.TypedArrayType() == napi_int32_array) {
+///         Napi::Int32Array int32Array = t.As<Napi::Int32Array>();
+///     }
+class TypedArray : public Object {
+ public:
+  TypedArray();  ///< Creates a new _empty_ TypedArray instance.
+  TypedArray(napi_env env,
              napi_value value);  ///< Wraps a Node-API value primitive.
 
-    Napi::ArrayBuffer ArrayBuffer() const;    ///< Gets the backing array buffer.
-    size_t ByteOffset() const;    ///< Gets the offset into the buffer where the array starts.
-    size_t ByteLength() const;    ///< Gets the length of the array in bytes.
+  napi_typedarray_type TypedArrayType()
+      const;  ///< Gets the type of this typed-array.
+  Napi::ArrayBuffer ArrayBuffer() const;  ///< Gets the backing array buffer.
 
-    void* Data() const;
+  uint8_t ElementSize()
+      const;  ///< Gets the size in bytes of one element in the array.
+  size_t ElementLength() const;  ///< Gets the number of elements in the array.
+  size_t ByteOffset()
+      const;  ///< Gets the offset into the buffer where the array starts.
+  size_t ByteLength() const;  ///< Gets the length of the array in bytes.
 
-    float GetFloat32(size_t byteOffset) const;
-    double GetFloat64(size_t byteOffset) const;
-    int8_t GetInt8(size_t byteOffset) const;
-    int16_t GetInt16(size_t byteOffset) const;
-    int32_t GetInt32(size_t byteOffset) const;
-    uint8_t GetUint8(size_t byteOffset) const;
-    uint16_t GetUint16(size_t byteOffset) const;
-    uint32_t GetUint32(size_t byteOffset) const;
+ protected:
+  /// !cond INTERNAL
+  napi_typedarray_type _type;
+  size_t _length;
 
-    void SetFloat32(size_t byteOffset, float value) const;
-    void SetFloat64(size_t byteOffset, double value) const;
-    void SetInt8(size_t byteOffset, int8_t value) const;
-    void SetInt16(size_t byteOffset, int16_t value) const;
-    void SetInt32(size_t byteOffset, int32_t value) const;
-    void SetUint8(size_t byteOffset, uint8_t value) const;
-    void SetUint16(size_t byteOffset, uint16_t value) const;
-    void SetUint32(size_t byteOffset, uint32_t value) const;
+  TypedArray(napi_env env,
+             napi_value value,
+             napi_typedarray_type type,
+             size_t length);
 
-  private:
-    template <typename T>
-    T ReadData(size_t byteOffset) const;
-
-    template <typename T>
-    void WriteData(size_t byteOffset, T value) const;
-
-    void* _data;
-    size_t _length;
-  };
-
-  class Function : public Object {
-  public:
-   using VoidCallback = void (*)(const CallbackInfo& info);
-   using Callback = Value (*)(const CallbackInfo& info);
-
-   template <VoidCallback cb>
-   static Function New(napi_env env,
-                       const char* utf8name = nullptr,
-                       void* data = nullptr);
-
-   template <Callback cb>
-   static Function New(napi_env env,
-                       const char* utf8name = nullptr,
-                       void* data = nullptr);
-
-   template <VoidCallback cb>
-   static Function New(napi_env env,
-                       const std::string& utf8name,
-                       void* data = nullptr);
-
-   template <Callback cb>
-   static Function New(napi_env env,
-                       const std::string& utf8name,
-                       void* data = nullptr);
-
-   /// Callable must implement operator() accepting a const CallbackInfo&
-   /// and return either void or Value.
-   template <typename Callable>
-   static Function New(napi_env env,
-                       Callable cb,
-                       const char* utf8name = nullptr,
-                       void* data = nullptr);
-   /// Callable must implement operator() accepting a const CallbackInfo&
-   /// and return either void or Value.
-   template <typename Callable>
-   static Function New(napi_env env,
-                       Callable cb,
-                       const std::string& utf8name,
-                       void* data = nullptr);
-
-   Function();
-   Function(napi_env env, napi_value value);
-
-   MaybeOrValue<Value> operator()(
-       const std::initializer_list<napi_value>& args) const;
-
-   MaybeOrValue<Value> Call(
-       const std::initializer_list<napi_value>& args) const;
-   MaybeOrValue<Value> Call(const std::vector<napi_value>& args) const;
-   MaybeOrValue<Value> Call(const std::vector<Value>& args) const;
-   MaybeOrValue<Value> Call(size_t argc, const napi_value* args) const;
-   MaybeOrValue<Value> Call(
-       napi_value recv, const std::initializer_list<napi_value>& args) const;
-   MaybeOrValue<Value> Call(napi_value recv,
-                            const std::vector<napi_value>& args) const;
-   MaybeOrValue<Value> Call(napi_value recv,
-                            const std::vector<Value>& args) const;
-   MaybeOrValue<Value> Call(napi_value recv,
-                            size_t argc,
-                            const napi_value* args) const;
-
-   MaybeOrValue<Value> MakeCallback(
-       napi_value recv,
-       const std::initializer_list<napi_value>& args,
-       napi_async_context context = nullptr) const;
-   MaybeOrValue<Value> MakeCallback(napi_value recv,
-                                    const std::vector<napi_value>& args,
-                                    napi_async_context context = nullptr) const;
-   MaybeOrValue<Value> MakeCallback(napi_value recv,
-                                    size_t argc,
-                                    const napi_value* args,
-                                    napi_async_context context = nullptr) const;
-
-   MaybeOrValue<Object> New(
-       const std::initializer_list<napi_value>& args) const;
-   MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
-   MaybeOrValue<Object> New(size_t argc, const napi_value* args) const;
-  };
-
-  class Promise : public Object {
-  public:
-    class Deferred {
-    public:
-      static Deferred New(napi_env env);
-      Deferred(napi_env env);
-
-      Napi::Promise Promise() const;
-      Napi::Env Env() const;
-
-      void Resolve(napi_value value) const;
-      void Reject(napi_value value) const;
-
-    private:
-      napi_env _env;
-      napi_deferred _deferred;
-      napi_value _promise;
-    };
-
-    Promise(napi_env env, napi_value value);
-  };
+  static const napi_typedarray_type unknown_array_type =
+      static_cast<napi_typedarray_type>(-1);
 
   template <typename T>
-  class Buffer : public Uint8Array {
-  public:
-    static Buffer<T> New(napi_env env, size_t length);
-    static Buffer<T> New(napi_env env, T* data, size_t length);
+  static
+#if defined(NAPI_HAS_CONSTEXPR)
+      constexpr
+#endif
+      napi_typedarray_type
+      TypedArrayTypeForPrimitiveType() {
+    return std::is_same<T, int8_t>::value     ? napi_int8_array
+           : std::is_same<T, uint8_t>::value  ? napi_uint8_array
+           : std::is_same<T, int16_t>::value  ? napi_int16_array
+           : std::is_same<T, uint16_t>::value ? napi_uint16_array
+           : std::is_same<T, int32_t>::value  ? napi_int32_array
+           : std::is_same<T, uint32_t>::value ? napi_uint32_array
+           : std::is_same<T, float>::value    ? napi_float32_array
+           : std::is_same<T, double>::value   ? napi_float64_array
+#if NAPI_VERSION > 5
+           : std::is_same<T, int64_t>::value  ? napi_bigint64_array
+           : std::is_same<T, uint64_t>::value ? napi_biguint64_array
+#endif  // NAPI_VERSION > 5
+                                              : unknown_array_type;
+  }
+  /// !endcond
+};
 
-    // Finalizer must implement `void operator()(Env env, T* data)`.
-    template <typename Finalizer>
-    static Buffer<T> New(napi_env env, T* data,
-                         size_t length,
-                         Finalizer finalizeCallback);
-    // Finalizer must implement `void operator()(Env env, T* data, Hint* hint)`.
-    template <typename Finalizer, typename Hint>
-    static Buffer<T> New(napi_env env, T* data,
-                         size_t length,
-                         Finalizer finalizeCallback,
-                         Hint* finalizeHint);
-
-    static Buffer<T> Copy(napi_env env, const T* data, size_t length);
-
-    Buffer();
-    Buffer(napi_env env, napi_value value);
-    size_t Length() const;
-    T* Data() const;
-
-  private:
-    mutable size_t _length;
-    mutable T* _data;
-
-    Buffer(napi_env env, napi_value value, size_t length, T* data);
-    void EnsureInfo() const;
-  };
-
-  /// Holds a counted reference to a value; initially a weak reference unless otherwise specified,
-  /// may be changed to/from a strong reference by adjusting the refcount.
+/// A JavaScript typed-array value with known array type.
+///
+/// Note while it is possible to create and access Uint8 "clamped" arrays using
+/// this class, the _clamping_ behavior is only applied in JavaScript.
+template <typename T>
+class TypedArrayOf : public TypedArray {
+ public:
+  /// Creates a new TypedArray instance over a new automatically-allocated array
+  /// buffer.
   ///
-  /// The referenced value is not immediately destroyed when the reference count is zero; it is
-  /// merely then eligible for garbage-collection if there are no other references to the value.
+  /// The array type parameter can normally be omitted (because it is inferred
+  /// from the template parameter T), except when creating a "clamped" array:
+  ///
+  ///     Uint8Array::New(env, length, napi_uint8_clamped_array)
+  static TypedArrayOf New(
+      napi_env env,          ///< Node-API environment
+      size_t elementLength,  ///< Length of the created array, as a number of
+                             ///< elements
+#if defined(NAPI_HAS_CONSTEXPR)
+      napi_typedarray_type type =
+          TypedArray::TypedArrayTypeForPrimitiveType<T>()
+#else
+        napi_typedarray_type type
+#endif
+      ///< Type of array, if different from the default array type for the
+      ///< template parameter T.
+  );
+
+  /// Creates a new TypedArray instance over a provided array buffer.
+  ///
+  /// The array type parameter can normally be omitted (because it is inferred
+  /// from the template parameter T), except when creating a "clamped" array:
+  ///
+  ///     Uint8Array::New(env, length, buffer, 0, napi_uint8_clamped_array)
+  static TypedArrayOf New(
+      napi_env env,          ///< Node-API environment
+      size_t elementLength,  ///< Length of the created array, as a number of
+                             ///< elements
+      Napi::ArrayBuffer arrayBuffer,  ///< Backing array buffer instance to use
+      size_t bufferOffset,  ///< Offset into the array buffer where the
+                            ///< typed-array starts
+#if defined(NAPI_HAS_CONSTEXPR)
+      napi_typedarray_type type =
+          TypedArray::TypedArrayTypeForPrimitiveType<T>()
+#else
+        napi_typedarray_type type
+#endif
+      ///< Type of array, if different from the default array type for the
+      ///< template parameter T.
+  );
+
+  TypedArrayOf();  ///< Creates a new _empty_ TypedArrayOf instance.
+  TypedArrayOf(napi_env env,
+               napi_value value);  ///< Wraps a Node-API value primitive.
+
+  T& operator[](size_t index);  ///< Gets or sets an element in the array.
+  const T& operator[](size_t index) const;  ///< Gets an element in the array.
+
+  /// Gets a pointer to the array's backing buffer.
+  ///
+  /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer,
+  /// because the typed-array may have a non-zero `ByteOffset()` into the
+  /// `ArrayBuffer`.
+  T* Data();
+
+  /// Gets a pointer to the array's backing buffer.
+  ///
+  /// This is not necessarily the same as the `ArrayBuffer::Data()` pointer,
+  /// because the typed-array may have a non-zero `ByteOffset()` into the
+  /// `ArrayBuffer`.
+  const T* Data() const;
+
+ private:
+  T* _data;
+
+  TypedArrayOf(napi_env env,
+               napi_value value,
+               napi_typedarray_type type,
+               size_t length,
+               T* data);
+};
+
+/// The DataView provides a low-level interface for reading/writing multiple
+/// number types in an ArrayBuffer irrespective of the platform's endianness.
+class DataView : public Object {
+ public:
+  static DataView New(napi_env env, Napi::ArrayBuffer arrayBuffer);
+  static DataView New(napi_env env,
+                      Napi::ArrayBuffer arrayBuffer,
+                      size_t byteOffset);
+  static DataView New(napi_env env,
+                      Napi::ArrayBuffer arrayBuffer,
+                      size_t byteOffset,
+                      size_t byteLength);
+
+  DataView();  ///< Creates a new _empty_ DataView instance.
+  DataView(napi_env env,
+           napi_value value);  ///< Wraps a Node-API value primitive.
+
+  Napi::ArrayBuffer ArrayBuffer() const;  ///< Gets the backing array buffer.
+  size_t ByteOffset()
+      const;  ///< Gets the offset into the buffer where the array starts.
+  size_t ByteLength() const;  ///< Gets the length of the array in bytes.
+
+  void* Data() const;
+
+  float GetFloat32(size_t byteOffset) const;
+  double GetFloat64(size_t byteOffset) const;
+  int8_t GetInt8(size_t byteOffset) const;
+  int16_t GetInt16(size_t byteOffset) const;
+  int32_t GetInt32(size_t byteOffset) const;
+  uint8_t GetUint8(size_t byteOffset) const;
+  uint16_t GetUint16(size_t byteOffset) const;
+  uint32_t GetUint32(size_t byteOffset) const;
+
+  void SetFloat32(size_t byteOffset, float value) const;
+  void SetFloat64(size_t byteOffset, double value) const;
+  void SetInt8(size_t byteOffset, int8_t value) const;
+  void SetInt16(size_t byteOffset, int16_t value) const;
+  void SetInt32(size_t byteOffset, int32_t value) const;
+  void SetUint8(size_t byteOffset, uint8_t value) const;
+  void SetUint16(size_t byteOffset, uint16_t value) const;
+  void SetUint32(size_t byteOffset, uint32_t value) const;
+
+ private:
   template <typename T>
-  class Reference {
-  public:
-    static Reference<T> New(const T& value, uint32_t initialRefcount = 0);
+  T ReadData(size_t byteOffset) const;
 
-    Reference();
-    Reference(napi_env env, napi_ref ref);
-    ~Reference();
+  template <typename T>
+  void WriteData(size_t byteOffset, T value) const;
 
-    // A reference can be moved but cannot be copied.
-    Reference(Reference<T>&& other);
-    Reference<T>& operator =(Reference<T>&& other);
-    NAPI_DISALLOW_ASSIGN(Reference<T>)
+  void* _data;
+  size_t _length;
+};
 
-    operator napi_ref() const;
-    bool operator ==(const Reference<T> &other) const;
-    bool operator !=(const Reference<T> &other) const;
+class Function : public Object {
+ public:
+  using VoidCallback = void (*)(const CallbackInfo& info);
+  using Callback = Value (*)(const CallbackInfo& info);
 
-    Napi::Env Env() const;
-    bool IsEmpty() const;
+  template <VoidCallback cb>
+  static Function New(napi_env env,
+                      const char* utf8name = nullptr,
+                      void* data = nullptr);
 
-    // Note when getting the value of a Reference it is usually correct to do so
-    // within a HandleScope so that the value handle gets cleaned up efficiently.
-    T Value() const;
+  template <Callback cb>
+  static Function New(napi_env env,
+                      const char* utf8name = nullptr,
+                      void* data = nullptr);
 
-    uint32_t Ref() const;
-    uint32_t Unref() const;
-    void Reset();
-    void Reset(const T& value, uint32_t refcount = 0);
+  template <VoidCallback cb>
+  static Function New(napi_env env,
+                      const std::string& utf8name,
+                      void* data = nullptr);
 
-    // Call this on a reference that is declared as static data, to prevent its
-    // destructor from running at program shutdown time, which would attempt to
-    // reset the reference when the environment is no longer valid. Avoid using
-    // this if at all possible. If you do need to use static data, MAKE SURE to
-    // warn your users that your addon is NOT threadsafe.
-    void SuppressDestruct();
+  template <Callback cb>
+  static Function New(napi_env env,
+                      const std::string& utf8name,
+                      void* data = nullptr);
 
-  protected:
-    Reference(const Reference<T>&);
+  /// Callable must implement operator() accepting a const CallbackInfo&
+  /// and return either void or Value.
+  template <typename Callable>
+  static Function New(napi_env env,
+                      Callable cb,
+                      const char* utf8name = nullptr,
+                      void* data = nullptr);
+  /// Callable must implement operator() accepting a const CallbackInfo&
+  /// and return either void or Value.
+  template <typename Callable>
+  static Function New(napi_env env,
+                      Callable cb,
+                      const std::string& utf8name,
+                      void* data = nullptr);
 
-    /// !cond INTERNAL
-    napi_env _env;
-    napi_ref _ref;
-    /// !endcond
+  Function();
+  Function(napi_env env, napi_value value);
 
-  private:
-    bool _suppressDestruct;
-  };
+  MaybeOrValue<Value> operator()(
+      const std::initializer_list<napi_value>& args) const;
 
-  class ObjectReference: public Reference<Object> {
-  public:
-    ObjectReference();
-    ObjectReference(napi_env env, napi_ref ref);
+  MaybeOrValue<Value> Call(const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Value> Call(const std::vector<napi_value>& args) const;
+  MaybeOrValue<Value> Call(const std::vector<Value>& args) const;
+  MaybeOrValue<Value> Call(size_t argc, const napi_value* args) const;
+  MaybeOrValue<Value> Call(napi_value recv,
+                           const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Value> Call(napi_value recv,
+                           const std::vector<napi_value>& args) const;
+  MaybeOrValue<Value> Call(napi_value recv,
+                           const std::vector<Value>& args) const;
+  MaybeOrValue<Value> Call(napi_value recv,
+                           size_t argc,
+                           const napi_value* args) const;
 
-    // A reference can be moved but cannot be copied.
-    ObjectReference(Reference<Object>&& other);
-    ObjectReference& operator =(Reference<Object>&& other);
-    ObjectReference(ObjectReference&& other);
-    ObjectReference& operator =(ObjectReference&& other);
-    NAPI_DISALLOW_ASSIGN(ObjectReference)
-
-    MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
-    MaybeOrValue<Napi::Value> Get(const std::string& utf8name) const;
-    MaybeOrValue<bool> Set(const char* utf8name, napi_value value) const;
-    MaybeOrValue<bool> Set(const char* utf8name, Napi::Value value) const;
-    MaybeOrValue<bool> Set(const char* utf8name, const char* utf8value) const;
-    MaybeOrValue<bool> Set(const char* utf8name, bool boolValue) const;
-    MaybeOrValue<bool> Set(const char* utf8name, double numberValue) const;
-    MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value) const;
-    MaybeOrValue<bool> Set(const std::string& utf8name,
-                           Napi::Value value) const;
-    MaybeOrValue<bool> Set(const std::string& utf8name,
-                           std::string& utf8value) const;
-    MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue) const;
-    MaybeOrValue<bool> Set(const std::string& utf8name,
-                           double numberValue) const;
-
-    MaybeOrValue<Napi::Value> Get(uint32_t index) const;
-    MaybeOrValue<bool> Set(uint32_t index, const napi_value value) const;
-    MaybeOrValue<bool> Set(uint32_t index, const Napi::Value value) const;
-    MaybeOrValue<bool> Set(uint32_t index, const char* utf8value) const;
-    MaybeOrValue<bool> Set(uint32_t index, const std::string& utf8value) const;
-    MaybeOrValue<bool> Set(uint32_t index, bool boolValue) const;
-    MaybeOrValue<bool> Set(uint32_t index, double numberValue) const;
-
-   protected:
-    ObjectReference(const ObjectReference&);
-  };
-
-  class FunctionReference: public Reference<Function> {
-  public:
-    FunctionReference();
-    FunctionReference(napi_env env, napi_ref ref);
-
-    // A reference can be moved but cannot be copied.
-    FunctionReference(Reference<Function>&& other);
-    FunctionReference& operator =(Reference<Function>&& other);
-    FunctionReference(FunctionReference&& other);
-    FunctionReference& operator =(FunctionReference&& other);
-    NAPI_DISALLOW_ASSIGN_COPY(FunctionReference)
-
-    MaybeOrValue<Napi::Value> operator()(
-        const std::initializer_list<napi_value>& args) const;
-
-    MaybeOrValue<Napi::Value> Call(
-        const std::initializer_list<napi_value>& args) const;
-    MaybeOrValue<Napi::Value> Call(const std::vector<napi_value>& args) const;
-    MaybeOrValue<Napi::Value> Call(
-        napi_value recv, const std::initializer_list<napi_value>& args) const;
-    MaybeOrValue<Napi::Value> Call(napi_value recv,
-                                   const std::vector<napi_value>& args) const;
-    MaybeOrValue<Napi::Value> Call(napi_value recv,
+  MaybeOrValue<Value> MakeCallback(
+      napi_value recv,
+      const std::initializer_list<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Value> MakeCallback(napi_value recv,
+                                   const std::vector<napi_value>& args,
+                                   napi_async_context context = nullptr) const;
+  MaybeOrValue<Value> MakeCallback(napi_value recv,
                                    size_t argc,
-                                   const napi_value* args) const;
+                                   const napi_value* args,
+                                   napi_async_context context = nullptr) const;
 
-    MaybeOrValue<Napi::Value> MakeCallback(
-        napi_value recv,
-        const std::initializer_list<napi_value>& args,
-        napi_async_context context = nullptr) const;
-    MaybeOrValue<Napi::Value> MakeCallback(
-        napi_value recv,
-        const std::vector<napi_value>& args,
-        napi_async_context context = nullptr) const;
-    MaybeOrValue<Napi::Value> MakeCallback(
-        napi_value recv,
-        size_t argc,
-        const napi_value* args,
-        napi_async_context context = nullptr) const;
+  MaybeOrValue<Object> New(const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
+  MaybeOrValue<Object> New(size_t argc, const napi_value* args) const;
+};
 
-    MaybeOrValue<Object> New(
-        const std::initializer_list<napi_value>& args) const;
-    MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
-  };
+class Promise : public Object {
+ public:
+  class Deferred {
+   public:
+    static Deferred New(napi_env env);
+    Deferred(napi_env env);
 
-  // Shortcuts to creating a new reference with inferred type and refcount = 0.
-  template <typename T> Reference<T> Weak(T value);
-  ObjectReference Weak(Object value);
-  FunctionReference Weak(Function value);
-
-  // Shortcuts to creating a new reference with inferred type and refcount = 1.
-  template <typename T> Reference<T> Persistent(T value);
-  ObjectReference Persistent(Object value);
-  FunctionReference Persistent(Function value);
-
-  /// A persistent reference to a JavaScript error object. Use of this class
-  /// depends somewhat on whether C++ exceptions are enabled at compile time.
-  ///
-  /// ### Handling Errors With C++ Exceptions
-  ///
-  /// If C++ exceptions are enabled, then the `Error` class extends
-  /// `std::exception` and enables integrated error-handling for C++ exceptions
-  /// and JavaScript exceptions.
-  ///
-  /// If a Node-API call fails without executing any JavaScript code (for
-  /// example due to an invalid argument), then the Node-API wrapper
-  /// automatically converts and throws the error as a C++ exception of type
-  /// `Napi::Error`. Or if a JavaScript function called by C++ code via Node-API
-  /// throws a JavaScript exception, then the Node-API wrapper automatically
-  /// converts and throws it as a C++ exception of type `Napi::Error`.
-  ///
-  /// If a C++ exception of type `Napi::Error` escapes from a Node-API C++
-  /// callback, then the Node-API wrapper automatically converts and throws it
-  /// as a JavaScript exception. Therefore, catching a C++ exception of type
-  /// `Napi::Error` prevents a JavaScript exception from being thrown.
-  ///
-  /// #### Example 1A - Throwing a C++ exception:
-  ///
-  ///     Napi::Env env = ...
-  ///     throw Napi::Error::New(env, "Example exception");
-  ///
-  /// Following C++ statements will not be executed. The exception will bubble
-  /// up as a C++ exception of type `Napi::Error`, until it is either caught
-  /// while still in C++, or else automatically propataged as a JavaScript
-  /// exception when the callback returns to JavaScript.
-  ///
-  /// #### Example 2A - Propagating a Node-API C++ exception:
-  ///
-  ///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
-  ///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
-  ///
-  /// Following C++ statements will not be executed. The exception will bubble
-  /// up as a C++ exception of type `Napi::Error`, until it is either caught
-  /// while still in C++, or else automatically propagated as a JavaScript
-  /// exception when the callback returns to JavaScript.
-  ///
-  /// #### Example 3A - Handling a Node-API C++ exception:
-  ///
-  ///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
-  ///     Napi::Value result;
-  ///     try {
-  ///        result = jsFunctionThatThrows({ arg1, arg2 });
-  ///     } catch (const Napi::Error& e) {
-  ///       cerr << "Caught JavaScript exception: " + e.what();
-  ///     }
-  ///
-  /// Since the exception was caught here, it will not be propagated as a
-  /// JavaScript exception.
-  ///
-  /// ### Handling Errors Without C++ Exceptions
-  ///
-  /// If C++ exceptions are disabled (by defining `NAPI_DISABLE_CPP_EXCEPTIONS`)
-  /// then this class does not extend `std::exception`, and APIs in the `Napi`
-  /// namespace do not throw C++ exceptions when they fail. Instead, they raise
-  /// _pending_ JavaScript exceptions and return _empty_ `Value`s. Calling code
-  /// should check `Value::IsEmpty()` before attempting to use a returned value,
-  /// and may use methods on the `Env` class to check for, get, and clear a
-  /// pending JavaScript exception. If the pending exception is not cleared, it
-  /// will be thrown when the native callback returns to JavaScript.
-  ///
-  /// #### Example 1B - Throwing a JS exception
-  ///
-  ///     Napi::Env env = ...
-  ///     Napi::Error::New(env, "Example
-  ///     exception").ThrowAsJavaScriptException(); return;
-  ///
-  /// After throwing a JS exception, the code should generally return
-  /// immediately from the native callback, after performing any necessary
-  /// cleanup.
-  ///
-  /// #### Example 2B - Propagating a Node-API JS exception:
-  ///
-  ///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
-  ///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
-  ///     if (result.IsEmpty()) return;
-  ///
-  /// An empty value result from a Node-API call indicates an error occurred,
-  /// and a JavaScript exception is pending. To let the exception propagate, the
-  /// code should generally return immediately from the native callback, after
-  /// performing any necessary cleanup.
-  ///
-  /// #### Example 3B - Handling a Node-API JS exception:
-  ///
-  ///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
-  ///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
-  ///     if (result.IsEmpty()) {
-  ///       Napi::Error e = env.GetAndClearPendingException();
-  ///       cerr << "Caught JavaScript exception: " + e.Message();
-  ///     }
-  ///
-  /// Since the exception was cleared here, it will not be propagated as a
-  /// JavaScript exception after the native callback returns.
-  class Error : public ObjectReference
-#ifdef NAPI_CPP_EXCEPTIONS
-    , public std::exception
-#endif // NAPI_CPP_EXCEPTIONS
-    {
-  public:
-    static Error New(napi_env env);
-    static Error New(napi_env env, const char* message);
-    static Error New(napi_env env, const std::string& message);
-
-    static NAPI_NO_RETURN void Fatal(const char* location, const char* message);
-
-    Error();
-    Error(napi_env env, napi_value value);
-
-    // An error can be moved or copied.
-    Error(Error&& other);
-    Error& operator =(Error&& other);
-    Error(const Error&);
-    Error& operator =(const Error&);
-
-    const std::string& Message() const NAPI_NOEXCEPT;
-    void ThrowAsJavaScriptException() const;
-
-    Object Value() const;
-
-#ifdef NAPI_CPP_EXCEPTIONS
-    const char* what() const NAPI_NOEXCEPT override;
-#endif // NAPI_CPP_EXCEPTIONS
-
-  protected:
-    /// !cond INTERNAL
-   using create_error_fn = napi_status (*)(napi_env envb,
-                                           napi_value code,
-                                           napi_value msg,
-                                           napi_value* result);
-
-   template <typename TError>
-   static TError New(napi_env env,
-                     const char* message,
-                     size_t length,
-                     create_error_fn create_error);
-   /// !endcond
-
-  private:
-   static inline const char* ERROR_WRAP_VALUE() NAPI_NOEXCEPT;
-   mutable std::string _message;
-  };
-
-  class TypeError : public Error {
-  public:
-    static TypeError New(napi_env env, const char* message);
-    static TypeError New(napi_env env, const std::string& message);
-
-    TypeError();
-    TypeError(napi_env env, napi_value value);
-  };
-
-  class RangeError : public Error {
-  public:
-    static RangeError New(napi_env env, const char* message);
-    static RangeError New(napi_env env, const std::string& message);
-
-    RangeError();
-    RangeError(napi_env env, napi_value value);
-  };
-
-  class CallbackInfo {
-  public:
-    CallbackInfo(napi_env env, napi_callback_info info);
-    ~CallbackInfo();
-
-    // Disallow copying to prevent multiple free of _dynamicArgs
-    NAPI_DISALLOW_ASSIGN_COPY(CallbackInfo)
-
+    Napi::Promise Promise() const;
     Napi::Env Env() const;
-    Value NewTarget() const;
-    bool IsConstructCall() const;
-    size_t Length() const;
-    const Value operator [](size_t index) const;
-    Value This() const;
-    void* Data() const;
-    void SetData(void* data);
 
-  private:
-    const size_t _staticArgCount = 6;
+    void Resolve(napi_value value) const;
+    void Reject(napi_value value) const;
+
+   private:
     napi_env _env;
-    napi_callback_info _info;
-    napi_value _this;
-    size_t _argc;
-    napi_value* _argv;
-    napi_value _staticArgs[6];
-    napi_value* _dynamicArgs;
-    void* _data;
+    napi_deferred _deferred;
+    napi_value _promise;
   };
 
-  class PropertyDescriptor {
-  public:
-   using GetterCallback = Napi::Value (*)(const Napi::CallbackInfo& info);
-   using SetterCallback = void (*)(const Napi::CallbackInfo& info);
+  Promise(napi_env env, napi_value value);
+};
+
+template <typename T>
+class Buffer : public Uint8Array {
+ public:
+  static Buffer<T> New(napi_env env, size_t length);
+  static Buffer<T> New(napi_env env, T* data, size_t length);
+
+  // Finalizer must implement `void operator()(Env env, T* data)`.
+  template <typename Finalizer>
+  static Buffer<T> New(napi_env env,
+                       T* data,
+                       size_t length,
+                       Finalizer finalizeCallback);
+  // Finalizer must implement `void operator()(Env env, T* data, Hint* hint)`.
+  template <typename Finalizer, typename Hint>
+  static Buffer<T> New(napi_env env,
+                       T* data,
+                       size_t length,
+                       Finalizer finalizeCallback,
+                       Hint* finalizeHint);
+
+  static Buffer<T> Copy(napi_env env, const T* data, size_t length);
+
+  Buffer();
+  Buffer(napi_env env, napi_value value);
+  size_t Length() const;
+  T* Data() const;
+
+ private:
+  mutable size_t _length;
+  mutable T* _data;
+
+  Buffer(napi_env env, napi_value value, size_t length, T* data);
+  void EnsureInfo() const;
+};
+
+/// Holds a counted reference to a value; initially a weak reference unless
+/// otherwise specified, may be changed to/from a strong reference by adjusting
+/// the refcount.
+///
+/// The referenced value is not immediately destroyed when the reference count
+/// is zero; it is merely then eligible for garbage-collection if there are no
+/// other references to the value.
+template <typename T>
+class Reference {
+ public:
+  static Reference<T> New(const T& value, uint32_t initialRefcount = 0);
+
+  Reference();
+  Reference(napi_env env, napi_ref ref);
+  ~Reference();
+
+  // A reference can be moved but cannot be copied.
+  Reference(Reference<T>&& other);
+  Reference<T>& operator=(Reference<T>&& other);
+  NAPI_DISALLOW_ASSIGN(Reference<T>)
+
+  operator napi_ref() const;
+  bool operator==(const Reference<T>& other) const;
+  bool operator!=(const Reference<T>& other) const;
+
+  Napi::Env Env() const;
+  bool IsEmpty() const;
+
+  // Note when getting the value of a Reference it is usually correct to do so
+  // within a HandleScope so that the value handle gets cleaned up efficiently.
+  T Value() const;
+
+  uint32_t Ref() const;
+  uint32_t Unref() const;
+  void Reset();
+  void Reset(const T& value, uint32_t refcount = 0);
+
+  // Call this on a reference that is declared as static data, to prevent its
+  // destructor from running at program shutdown time, which would attempt to
+  // reset the reference when the environment is no longer valid. Avoid using
+  // this if at all possible. If you do need to use static data, MAKE SURE to
+  // warn your users that your addon is NOT threadsafe.
+  void SuppressDestruct();
+
+ protected:
+  Reference(const Reference<T>&);
+
+  /// !cond INTERNAL
+  napi_env _env;
+  napi_ref _ref;
+  /// !endcond
+
+ private:
+  bool _suppressDestruct;
+};
+
+class ObjectReference : public Reference<Object> {
+ public:
+  ObjectReference();
+  ObjectReference(napi_env env, napi_ref ref);
+
+  // A reference can be moved but cannot be copied.
+  ObjectReference(Reference<Object>&& other);
+  ObjectReference& operator=(Reference<Object>&& other);
+  ObjectReference(ObjectReference&& other);
+  ObjectReference& operator=(ObjectReference&& other);
+  NAPI_DISALLOW_ASSIGN(ObjectReference)
+
+  MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
+  MaybeOrValue<Napi::Value> Get(const std::string& utf8name) const;
+  MaybeOrValue<bool> Set(const char* utf8name, napi_value value) const;
+  MaybeOrValue<bool> Set(const char* utf8name, Napi::Value value) const;
+  MaybeOrValue<bool> Set(const char* utf8name, const char* utf8value) const;
+  MaybeOrValue<bool> Set(const char* utf8name, bool boolValue) const;
+  MaybeOrValue<bool> Set(const char* utf8name, double numberValue) const;
+  MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value) const;
+  MaybeOrValue<bool> Set(const std::string& utf8name, Napi::Value value) const;
+  MaybeOrValue<bool> Set(const std::string& utf8name,
+                         std::string& utf8value) const;
+  MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue) const;
+  MaybeOrValue<bool> Set(const std::string& utf8name, double numberValue) const;
+
+  MaybeOrValue<Napi::Value> Get(uint32_t index) const;
+  MaybeOrValue<bool> Set(uint32_t index, const napi_value value) const;
+  MaybeOrValue<bool> Set(uint32_t index, const Napi::Value value) const;
+  MaybeOrValue<bool> Set(uint32_t index, const char* utf8value) const;
+  MaybeOrValue<bool> Set(uint32_t index, const std::string& utf8value) const;
+  MaybeOrValue<bool> Set(uint32_t index, bool boolValue) const;
+  MaybeOrValue<bool> Set(uint32_t index, double numberValue) const;
+
+ protected:
+  ObjectReference(const ObjectReference&);
+};
+
+class FunctionReference : public Reference<Function> {
+ public:
+  FunctionReference();
+  FunctionReference(napi_env env, napi_ref ref);
+
+  // A reference can be moved but cannot be copied.
+  FunctionReference(Reference<Function>&& other);
+  FunctionReference& operator=(Reference<Function>&& other);
+  FunctionReference(FunctionReference&& other);
+  FunctionReference& operator=(FunctionReference&& other);
+  NAPI_DISALLOW_ASSIGN_COPY(FunctionReference)
+
+  MaybeOrValue<Napi::Value> operator()(
+      const std::initializer_list<napi_value>& args) const;
+
+  MaybeOrValue<Napi::Value> Call(
+      const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Napi::Value> Call(const std::vector<napi_value>& args) const;
+  MaybeOrValue<Napi::Value> Call(
+      napi_value recv, const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Napi::Value> Call(napi_value recv,
+                                 const std::vector<napi_value>& args) const;
+  MaybeOrValue<Napi::Value> Call(napi_value recv,
+                                 size_t argc,
+                                 const napi_value* args) const;
+
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      const std::initializer_list<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      const std::vector<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      size_t argc,
+      const napi_value* args,
+      napi_async_context context = nullptr) const;
+
+  MaybeOrValue<Object> New(const std::initializer_list<napi_value>& args) const;
+  MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
+};
+
+// Shortcuts to creating a new reference with inferred type and refcount = 0.
+template <typename T>
+Reference<T> Weak(T value);
+ObjectReference Weak(Object value);
+FunctionReference Weak(Function value);
+
+// Shortcuts to creating a new reference with inferred type and refcount = 1.
+template <typename T>
+Reference<T> Persistent(T value);
+ObjectReference Persistent(Object value);
+FunctionReference Persistent(Function value);
+
+/// A persistent reference to a JavaScript error object. Use of this class
+/// depends somewhat on whether C++ exceptions are enabled at compile time.
+///
+/// ### Handling Errors With C++ Exceptions
+///
+/// If C++ exceptions are enabled, then the `Error` class extends
+/// `std::exception` and enables integrated error-handling for C++ exceptions
+/// and JavaScript exceptions.
+///
+/// If a Node-API call fails without executing any JavaScript code (for
+/// example due to an invalid argument), then the Node-API wrapper
+/// automatically converts and throws the error as a C++ exception of type
+/// `Napi::Error`. Or if a JavaScript function called by C++ code via Node-API
+/// throws a JavaScript exception, then the Node-API wrapper automatically
+/// converts and throws it as a C++ exception of type `Napi::Error`.
+///
+/// If a C++ exception of type `Napi::Error` escapes from a Node-API C++
+/// callback, then the Node-API wrapper automatically converts and throws it
+/// as a JavaScript exception. Therefore, catching a C++ exception of type
+/// `Napi::Error` prevents a JavaScript exception from being thrown.
+///
+/// #### Example 1A - Throwing a C++ exception:
+///
+///     Napi::Env env = ...
+///     throw Napi::Error::New(env, "Example exception");
+///
+/// Following C++ statements will not be executed. The exception will bubble
+/// up as a C++ exception of type `Napi::Error`, until it is either caught
+/// while still in C++, or else automatically propataged as a JavaScript
+/// exception when the callback returns to JavaScript.
+///
+/// #### Example 2A - Propagating a Node-API C++ exception:
+///
+///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
+///
+/// Following C++ statements will not be executed. The exception will bubble
+/// up as a C++ exception of type `Napi::Error`, until it is either caught
+/// while still in C++, or else automatically propagated as a JavaScript
+/// exception when the callback returns to JavaScript.
+///
+/// #### Example 3A - Handling a Node-API C++ exception:
+///
+///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+///     Napi::Value result;
+///     try {
+///        result = jsFunctionThatThrows({ arg1, arg2 });
+///     } catch (const Napi::Error& e) {
+///       cerr << "Caught JavaScript exception: " + e.what();
+///     }
+///
+/// Since the exception was caught here, it will not be propagated as a
+/// JavaScript exception.
+///
+/// ### Handling Errors Without C++ Exceptions
+///
+/// If C++ exceptions are disabled (by defining `NAPI_DISABLE_CPP_EXCEPTIONS`)
+/// then this class does not extend `std::exception`, and APIs in the `Napi`
+/// namespace do not throw C++ exceptions when they fail. Instead, they raise
+/// _pending_ JavaScript exceptions and return _empty_ `Value`s. Calling code
+/// should check `Value::IsEmpty()` before attempting to use a returned value,
+/// and may use methods on the `Env` class to check for, get, and clear a
+/// pending JavaScript exception. If the pending exception is not cleared, it
+/// will be thrown when the native callback returns to JavaScript.
+///
+/// #### Example 1B - Throwing a JS exception
+///
+///     Napi::Env env = ...
+///     Napi::Error::New(env, "Example
+///     exception").ThrowAsJavaScriptException(); return;
+///
+/// After throwing a JS exception, the code should generally return
+/// immediately from the native callback, after performing any necessary
+/// cleanup.
+///
+/// #### Example 2B - Propagating a Node-API JS exception:
+///
+///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
+///     if (result.IsEmpty()) return;
+///
+/// An empty value result from a Node-API call indicates an error occurred,
+/// and a JavaScript exception is pending. To let the exception propagate, the
+/// code should generally return immediately from the native callback, after
+/// performing any necessary cleanup.
+///
+/// #### Example 3B - Handling a Node-API JS exception:
+///
+///     Napi::Function jsFunctionThatThrows = someObj.As<Napi::Function>();
+///     Napi::Value result = jsFunctionThatThrows({ arg1, arg2 });
+///     if (result.IsEmpty()) {
+///       Napi::Error e = env.GetAndClearPendingException();
+///       cerr << "Caught JavaScript exception: " + e.Message();
+///     }
+///
+/// Since the exception was cleared here, it will not be propagated as a
+/// JavaScript exception after the native callback returns.
+class Error : public ObjectReference
+#ifdef NAPI_CPP_EXCEPTIONS
+    ,
+              public std::exception
+#endif  // NAPI_CPP_EXCEPTIONS
+{
+ public:
+  static Error New(napi_env env);
+  static Error New(napi_env env, const char* message);
+  static Error New(napi_env env, const std::string& message);
+
+  static NAPI_NO_RETURN void Fatal(const char* location, const char* message);
+
+  Error();
+  Error(napi_env env, napi_value value);
+
+  // An error can be moved or copied.
+  Error(Error&& other);
+  Error& operator=(Error&& other);
+  Error(const Error&);
+  Error& operator=(const Error&);
+
+  const std::string& Message() const NAPI_NOEXCEPT;
+  void ThrowAsJavaScriptException() const;
+
+  Object Value() const;
+
+#ifdef NAPI_CPP_EXCEPTIONS
+  const char* what() const NAPI_NOEXCEPT override;
+#endif  // NAPI_CPP_EXCEPTIONS
+
+ protected:
+  /// !cond INTERNAL
+  using create_error_fn = napi_status (*)(napi_env envb,
+                                          napi_value code,
+                                          napi_value msg,
+                                          napi_value* result);
+
+  template <typename TError>
+  static TError New(napi_env env,
+                    const char* message,
+                    size_t length,
+                    create_error_fn create_error);
+  /// !endcond
+
+ private:
+  static inline const char* ERROR_WRAP_VALUE() NAPI_NOEXCEPT;
+  mutable std::string _message;
+};
+
+class TypeError : public Error {
+ public:
+  static TypeError New(napi_env env, const char* message);
+  static TypeError New(napi_env env, const std::string& message);
+
+  TypeError();
+  TypeError(napi_env env, napi_value value);
+};
+
+class RangeError : public Error {
+ public:
+  static RangeError New(napi_env env, const char* message);
+  static RangeError New(napi_env env, const std::string& message);
+
+  RangeError();
+  RangeError(napi_env env, napi_value value);
+};
+
+class CallbackInfo {
+ public:
+  CallbackInfo(napi_env env, napi_callback_info info);
+  ~CallbackInfo();
+
+  // Disallow copying to prevent multiple free of _dynamicArgs
+  NAPI_DISALLOW_ASSIGN_COPY(CallbackInfo)
+
+  Napi::Env Env() const;
+  Value NewTarget() const;
+  bool IsConstructCall() const;
+  size_t Length() const;
+  const Value operator[](size_t index) const;
+  Value This() const;
+  void* Data() const;
+  void SetData(void* data);
+
+ private:
+  const size_t _staticArgCount = 6;
+  napi_env _env;
+  napi_callback_info _info;
+  napi_value _this;
+  size_t _argc;
+  napi_value* _argv;
+  napi_value _staticArgs[6];
+  napi_value* _dynamicArgs;
+  void* _data;
+};
+
+class PropertyDescriptor {
+ public:
+  using GetterCallback = Napi::Value (*)(const Napi::CallbackInfo& info);
+  using SetterCallback = void (*)(const Napi::CallbackInfo& info);
 
 #ifndef NODE_ADDON_API_DISABLE_DEPRECATED
-    template <typename Getter>
-    static PropertyDescriptor Accessor(const char* utf8name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter>
-    static PropertyDescriptor Accessor(const std::string& utf8name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter>
-    static PropertyDescriptor Accessor(napi_value name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter>
-    static PropertyDescriptor Accessor(Name name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(const char* utf8name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(const std::string& utf8name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(napi_value name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(Name name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(const char* utf8name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(const std::string& utf8name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(napi_value name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(Name name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-#endif // !NODE_ADDON_API_DISABLE_DEPRECATED
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      const char* utf8name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      const std::string& utf8name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      napi_value name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      Name name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      const char* utf8name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      const std::string& utf8name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      napi_value name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      Name name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      const char* utf8name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      const std::string& utf8name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      napi_value name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      Name name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+#endif  // !NODE_ADDON_API_DISABLE_DEPRECATED
 
-    template <GetterCallback Getter>
-    static PropertyDescriptor Accessor(const char* utf8name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter>
+  static PropertyDescriptor Accessor(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <GetterCallback Getter>
-    static PropertyDescriptor Accessor(const std::string& utf8name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter>
+  static PropertyDescriptor Accessor(
+      const std::string& utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <GetterCallback Getter>
-    static PropertyDescriptor Accessor(Name name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter>
+  static PropertyDescriptor Accessor(
+      Name name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <GetterCallback Getter, SetterCallback Setter>
-    static PropertyDescriptor Accessor(const char* utf8name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter, SetterCallback Setter>
+  static PropertyDescriptor Accessor(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <GetterCallback Getter, SetterCallback Setter>
-    static PropertyDescriptor Accessor(const std::string& utf8name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter, SetterCallback Setter>
+  static PropertyDescriptor Accessor(
+      const std::string& utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <GetterCallback Getter, SetterCallback Setter>
-    static PropertyDescriptor Accessor(Name name,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
+  template <GetterCallback Getter, SetterCallback Setter>
+  static PropertyDescriptor Accessor(
+      Name name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
 
-    template <typename Getter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       const char* utf8name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       const std::string& utf8name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       Name name,
-                                       Getter getter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       const char* utf8name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       const std::string& utf8name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Getter, typename Setter>
-    static PropertyDescriptor Accessor(Napi::Env env,
-                                       Napi::Object object,
-                                       Name name,
-                                       Getter getter,
-                                       Setter setter,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(Napi::Env env,
-                                       Napi::Object object,
-                                       const char* utf8name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(Napi::Env env,
-                                       Napi::Object object,
-                                       const std::string& utf8name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    template <typename Callable>
-    static PropertyDescriptor Function(Napi::Env env,
-                                       Napi::Object object,
-                                       Name name,
-                                       Callable cb,
-                                       napi_property_attributes attributes = napi_default,
-                                       void* data = nullptr);
-    static PropertyDescriptor Value(const char* utf8name,
-                                    napi_value value,
-                                    napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor Value(const std::string& utf8name,
-                                    napi_value value,
-                                    napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor Value(napi_value name,
-                                    napi_value value,
-                                    napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor Value(Name name,
-                                    Napi::Value value,
-                                    napi_property_attributes attributes = napi_default);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      const char* utf8name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      const std::string& utf8name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      Name name,
+      Getter getter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      const char* utf8name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      const std::string& utf8name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Getter, typename Setter>
+  static PropertyDescriptor Accessor(
+      Napi::Env env,
+      Napi::Object object,
+      Name name,
+      Getter getter,
+      Setter setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      Napi::Env env,
+      Napi::Object object,
+      const char* utf8name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      Napi::Env env,
+      Napi::Object object,
+      const std::string& utf8name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <typename Callable>
+  static PropertyDescriptor Function(
+      Napi::Env env,
+      Napi::Object object,
+      Name name,
+      Callable cb,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor Value(
+      const char* utf8name,
+      napi_value value,
+      napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor Value(
+      const std::string& utf8name,
+      napi_value value,
+      napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor Value(
+      napi_value name,
+      napi_value value,
+      napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor Value(
+      Name name,
+      Napi::Value value,
+      napi_property_attributes attributes = napi_default);
 
-    PropertyDescriptor(napi_property_descriptor desc);
+  PropertyDescriptor(napi_property_descriptor desc);
 
-    operator napi_property_descriptor&();
-    operator const napi_property_descriptor&() const;
+  operator napi_property_descriptor&();
+  operator const napi_property_descriptor&() const;
 
-  private:
-    napi_property_descriptor _desc;
-  };
+ private:
+  napi_property_descriptor _desc;
+};
 
-  /// Property descriptor for use with `ObjectWrap::DefineClass()`.
-  ///
-  /// This is different from the standalone `PropertyDescriptor` because it is specific to each
-  /// `ObjectWrap<T>` subclass. This prevents using descriptors from a different class when
-  /// defining a new class (preventing the callbacks from having incorrect `this` pointers).
-  template <typename T>
-  class ClassPropertyDescriptor {
-  public:
-    ClassPropertyDescriptor(napi_property_descriptor desc) : _desc(desc) {}
+/// Property descriptor for use with `ObjectWrap::DefineClass()`.
+///
+/// This is different from the standalone `PropertyDescriptor` because it is
+/// specific to each `ObjectWrap<T>` subclass. This prevents using descriptors
+/// from a different class when defining a new class (preventing the callbacks
+/// from having incorrect `this` pointers).
+template <typename T>
+class ClassPropertyDescriptor {
+ public:
+  ClassPropertyDescriptor(napi_property_descriptor desc) : _desc(desc) {}
 
-    operator napi_property_descriptor&() { return _desc; }
-    operator const napi_property_descriptor&() const { return _desc; }
+  operator napi_property_descriptor&() { return _desc; }
+  operator const napi_property_descriptor&() const { return _desc; }
 
-  private:
-    napi_property_descriptor _desc;
-  };
+ private:
+  napi_property_descriptor _desc;
+};
 
-  template <typename T, typename TCallback>
-  struct MethodCallbackData {
-    TCallback callback;
-    void* data;
-  };
+template <typename T, typename TCallback>
+struct MethodCallbackData {
+  TCallback callback;
+  void* data;
+};
 
-  template <typename T, typename TGetterCallback, typename TSetterCallback>
-  struct AccessorCallbackData {
-    TGetterCallback getterCallback;
-    TSetterCallback setterCallback;
-    void* data;
-  };
+template <typename T, typename TGetterCallback, typename TSetterCallback>
+struct AccessorCallbackData {
+  TGetterCallback getterCallback;
+  TSetterCallback setterCallback;
+  void* data;
+};
 
-  template <typename T>
-  class InstanceWrap {
-   public:
-    using InstanceVoidMethodCallback = void (T::*)(const CallbackInfo& info);
-    using InstanceMethodCallback = Napi::Value (T::*)(const CallbackInfo& info);
-    using InstanceGetterCallback = Napi::Value (T::*)(const CallbackInfo& info);
-    using InstanceSetterCallback = void (T::*)(const CallbackInfo& info,
-                                               const Napi::Value& value);
+template <typename T>
+class InstanceWrap {
+ public:
+  using InstanceVoidMethodCallback = void (T::*)(const CallbackInfo& info);
+  using InstanceMethodCallback = Napi::Value (T::*)(const CallbackInfo& info);
+  using InstanceGetterCallback = Napi::Value (T::*)(const CallbackInfo& info);
+  using InstanceSetterCallback = void (T::*)(const CallbackInfo& info,
+                                             const Napi::Value& value);
 
-    using PropertyDescriptor = ClassPropertyDescriptor<T>;
+  using PropertyDescriptor = ClassPropertyDescriptor<T>;
 
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             InstanceVoidMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             InstanceMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             InstanceVoidMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             InstanceMethodCallback method,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceVoidMethodCallback method>
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceMethodCallback method>
-    static PropertyDescriptor InstanceMethod(const char* utf8name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceVoidMethodCallback method>
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <InstanceMethodCallback method>
-    static PropertyDescriptor InstanceMethod(Symbol name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor InstanceAccessor(const char* utf8name,
-                                               InstanceGetterCallback getter,
-                                               InstanceSetterCallback setter,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    static PropertyDescriptor InstanceAccessor(Symbol name,
-                                               InstanceGetterCallback getter,
-                                               InstanceSetterCallback setter,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
-    static PropertyDescriptor InstanceAccessor(const char* utf8name,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    template <InstanceGetterCallback getter, InstanceSetterCallback setter=nullptr>
-    static PropertyDescriptor InstanceAccessor(Symbol name,
-                                               napi_property_attributes attributes = napi_default,
-                                               void* data = nullptr);
-    static PropertyDescriptor InstanceValue(const char* utf8name,
-                                            Napi::Value value,
-                                            napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor InstanceValue(Symbol name,
-                                            Napi::Value value,
-                                            napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor InstanceMethod(
+      const char* utf8name,
+      InstanceVoidMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceMethod(
+      const char* utf8name,
+      InstanceMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceMethod(
+      Symbol name,
+      InstanceVoidMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceMethod(
+      Symbol name,
+      InstanceMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceVoidMethodCallback method>
+  static PropertyDescriptor InstanceMethod(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceMethodCallback method>
+  static PropertyDescriptor InstanceMethod(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceVoidMethodCallback method>
+  static PropertyDescriptor InstanceMethod(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceMethodCallback method>
+  static PropertyDescriptor InstanceMethod(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceAccessor(
+      const char* utf8name,
+      InstanceGetterCallback getter,
+      InstanceSetterCallback setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceAccessor(
+      Symbol name,
+      InstanceGetterCallback getter,
+      InstanceSetterCallback setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceGetterCallback getter,
+            InstanceSetterCallback setter = nullptr>
+  static PropertyDescriptor InstanceAccessor(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <InstanceGetterCallback getter,
+            InstanceSetterCallback setter = nullptr>
+  static PropertyDescriptor InstanceAccessor(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor InstanceValue(
+      const char* utf8name,
+      Napi::Value value,
+      napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor InstanceValue(
+      Symbol name,
+      Napi::Value value,
+      napi_property_attributes attributes = napi_default);
 
-   protected:
-    static void AttachPropData(napi_env env, napi_value value, const napi_property_descriptor* prop);
+ protected:
+  static void AttachPropData(napi_env env,
+                             napi_value value,
+                             const napi_property_descriptor* prop);
 
-   private:
-    using This = InstanceWrap<T>;
+ private:
+  using This = InstanceWrap<T>;
 
-    using InstanceVoidMethodCallbackData =
-        MethodCallbackData<T, InstanceVoidMethodCallback>;
-    using InstanceMethodCallbackData =
-        MethodCallbackData<T, InstanceMethodCallback>;
-    using InstanceAccessorCallbackData =
-        AccessorCallbackData<T, InstanceGetterCallback, InstanceSetterCallback>;
+  using InstanceVoidMethodCallbackData =
+      MethodCallbackData<T, InstanceVoidMethodCallback>;
+  using InstanceMethodCallbackData =
+      MethodCallbackData<T, InstanceMethodCallback>;
+  using InstanceAccessorCallbackData =
+      AccessorCallbackData<T, InstanceGetterCallback, InstanceSetterCallback>;
 
-    static napi_value InstanceVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceGetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
+  static napi_value InstanceVoidMethodCallbackWrapper(napi_env env,
+                                                      napi_callback_info info);
+  static napi_value InstanceMethodCallbackWrapper(napi_env env,
+                                                  napi_callback_info info);
+  static napi_value InstanceGetterCallbackWrapper(napi_env env,
+                                                  napi_callback_info info);
+  static napi_value InstanceSetterCallbackWrapper(napi_env env,
+                                                  napi_callback_info info);
 
-    template <InstanceSetterCallback method>
-    static napi_value WrappedMethod(napi_env env,
-                                    napi_callback_info info) NAPI_NOEXCEPT;
+  template <InstanceSetterCallback method>
+  static napi_value WrappedMethod(napi_env env,
+                                  napi_callback_info info) NAPI_NOEXCEPT;
 
-    template <InstanceSetterCallback setter> struct SetterTag {};
+  template <InstanceSetterCallback setter>
+  struct SetterTag {};
 
-    template <InstanceSetterCallback setter>
-    static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT {
-      return &This::WrappedMethod<setter>;
-    }
-    static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT {
-      return nullptr;
-    }
-  };
+  template <InstanceSetterCallback setter>
+  static napi_callback WrapSetter(SetterTag<setter>) NAPI_NOEXCEPT {
+    return &This::WrappedMethod<setter>;
+  }
+  static napi_callback WrapSetter(SetterTag<nullptr>) NAPI_NOEXCEPT {
+    return nullptr;
+  }
+};
 
-  /// Base class to be extended by C++ classes exposed to JavaScript; each C++ class instance gets
-  /// "wrapped" by a JavaScript object that is managed by this class.
-  ///
-  /// At initialization time, the `DefineClass()` method must be used to
-  /// hook up the accessor and method callbacks. It takes a list of
-  /// property descriptors, which can be constructed via the various
-  /// static methods on the base class.
-  ///
-  /// #### Example:
-  ///
-  ///     class Example: public Napi::ObjectWrap<Example> {
-  ///       public:
-  ///         static void Initialize(Napi::Env& env, Napi::Object& target) {
-  ///           Napi::Function constructor = DefineClass(env, "Example", {
-  ///             InstanceAccessor<&Example::GetSomething, &Example::SetSomething>("value"),
-  ///             InstanceMethod<&Example::DoSomething>("doSomething"),
-  ///           });
-  ///           target.Set("Example", constructor);
-  ///         }
-  ///
-  ///         Example(const Napi::CallbackInfo& info); // Constructor
-  ///         Napi::Value GetSomething(const Napi::CallbackInfo& info);
-  ///         void SetSomething(const Napi::CallbackInfo& info, const Napi::Value& value);
-  ///         Napi::Value DoSomething(const Napi::CallbackInfo& info);
-  ///     }
-  template <typename T>
-  class ObjectWrap : public InstanceWrap<T>, public Reference<Object> {
-  public:
-    ObjectWrap(const CallbackInfo& callbackInfo);
-    virtual ~ObjectWrap();
+/// Base class to be extended by C++ classes exposed to JavaScript; each C++
+/// class instance gets "wrapped" by a JavaScript object that is managed by this
+/// class.
+///
+/// At initialization time, the `DefineClass()` method must be used to
+/// hook up the accessor and method callbacks. It takes a list of
+/// property descriptors, which can be constructed via the various
+/// static methods on the base class.
+///
+/// #### Example:
+///
+///     class Example: public Napi::ObjectWrap<Example> {
+///       public:
+///         static void Initialize(Napi::Env& env, Napi::Object& target) {
+///           Napi::Function constructor = DefineClass(env, "Example", {
+///             InstanceAccessor<&Example::GetSomething,
+///             &Example::SetSomething>("value"),
+///             InstanceMethod<&Example::DoSomething>("doSomething"),
+///           });
+///           target.Set("Example", constructor);
+///         }
+///
+///         Example(const Napi::CallbackInfo& info); // Constructor
+///         Napi::Value GetSomething(const Napi::CallbackInfo& info);
+///         void SetSomething(const Napi::CallbackInfo& info, const Napi::Value&
+///         value); Napi::Value DoSomething(const Napi::CallbackInfo& info);
+///     }
+template <typename T>
+class ObjectWrap : public InstanceWrap<T>, public Reference<Object> {
+ public:
+  ObjectWrap(const CallbackInfo& callbackInfo);
+  virtual ~ObjectWrap();
 
-    static T* Unwrap(Object wrapper);
+  static T* Unwrap(Object wrapper);
 
-    // Methods exposed to JavaScript must conform to one of these callback signatures.
-    using StaticVoidMethodCallback = void (*)(const CallbackInfo& info);
-    using StaticMethodCallback = Napi::Value (*)(const CallbackInfo& info);
-    using StaticGetterCallback = Napi::Value (*)(const CallbackInfo& info);
-    using StaticSetterCallback = void (*)(const CallbackInfo& info,
-                                          const Napi::Value& value);
+  // Methods exposed to JavaScript must conform to one of these callback
+  // signatures.
+  using StaticVoidMethodCallback = void (*)(const CallbackInfo& info);
+  using StaticMethodCallback = Napi::Value (*)(const CallbackInfo& info);
+  using StaticGetterCallback = Napi::Value (*)(const CallbackInfo& info);
+  using StaticSetterCallback = void (*)(const CallbackInfo& info,
+                                        const Napi::Value& value);
 
-    using PropertyDescriptor = ClassPropertyDescriptor<T>;
+  using PropertyDescriptor = ClassPropertyDescriptor<T>;
 
-    static Function DefineClass(Napi::Env env,
-                                const char* utf8name,
-                                const std::initializer_list<PropertyDescriptor>& properties,
-                                void* data = nullptr);
-    static Function DefineClass(Napi::Env env,
-                                const char* utf8name,
-                                const std::vector<PropertyDescriptor>& properties,
-                                void* data = nullptr);
-    static PropertyDescriptor StaticMethod(const char* utf8name,
-                                           StaticVoidMethodCallback method,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    static PropertyDescriptor StaticMethod(const char* utf8name,
-                                           StaticMethodCallback method,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    static PropertyDescriptor StaticMethod(Symbol name,
-                                           StaticVoidMethodCallback method,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    static PropertyDescriptor StaticMethod(Symbol name,
-                                           StaticMethodCallback method,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    template <StaticVoidMethodCallback method>
-    static PropertyDescriptor StaticMethod(const char* utf8name,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    template <StaticVoidMethodCallback method>
-    static PropertyDescriptor StaticMethod(Symbol name,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    template <StaticMethodCallback method>
-    static PropertyDescriptor StaticMethod(const char* utf8name,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    template <StaticMethodCallback method>
-    static PropertyDescriptor StaticMethod(Symbol name,
-                                           napi_property_attributes attributes = napi_default,
-                                           void* data = nullptr);
-    static PropertyDescriptor StaticAccessor(const char* utf8name,
-                                             StaticGetterCallback getter,
-                                             StaticSetterCallback setter,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor StaticAccessor(Symbol name,
-                                             StaticGetterCallback getter,
-                                             StaticSetterCallback setter,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <StaticGetterCallback getter, StaticSetterCallback setter=nullptr>
-    static PropertyDescriptor StaticAccessor(const char* utf8name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    template <StaticGetterCallback getter, StaticSetterCallback setter=nullptr>
-    static PropertyDescriptor StaticAccessor(Symbol name,
-                                             napi_property_attributes attributes = napi_default,
-                                             void* data = nullptr);
-    static PropertyDescriptor StaticValue(const char* utf8name,
-                                          Napi::Value value,
-                                          napi_property_attributes attributes = napi_default);
-    static PropertyDescriptor StaticValue(Symbol name,
-                                          Napi::Value value,
-                                          napi_property_attributes attributes = napi_default);
-    static Napi::Value OnCalledAsFunction(
-        const Napi::CallbackInfo& callbackInfo);
-    virtual void Finalize(Napi::Env env);
+  static Function DefineClass(
+      Napi::Env env,
+      const char* utf8name,
+      const std::initializer_list<PropertyDescriptor>& properties,
+      void* data = nullptr);
+  static Function DefineClass(Napi::Env env,
+                              const char* utf8name,
+                              const std::vector<PropertyDescriptor>& properties,
+                              void* data = nullptr);
+  static PropertyDescriptor StaticMethod(
+      const char* utf8name,
+      StaticVoidMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticMethod(
+      const char* utf8name,
+      StaticMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticMethod(
+      Symbol name,
+      StaticVoidMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticMethod(
+      Symbol name,
+      StaticMethodCallback method,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticVoidMethodCallback method>
+  static PropertyDescriptor StaticMethod(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticVoidMethodCallback method>
+  static PropertyDescriptor StaticMethod(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticMethodCallback method>
+  static PropertyDescriptor StaticMethod(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticMethodCallback method>
+  static PropertyDescriptor StaticMethod(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticAccessor(
+      const char* utf8name,
+      StaticGetterCallback getter,
+      StaticSetterCallback setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticAccessor(
+      Symbol name,
+      StaticGetterCallback getter,
+      StaticSetterCallback setter,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticGetterCallback getter, StaticSetterCallback setter = nullptr>
+  static PropertyDescriptor StaticAccessor(
+      const char* utf8name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  template <StaticGetterCallback getter, StaticSetterCallback setter = nullptr>
+  static PropertyDescriptor StaticAccessor(
+      Symbol name,
+      napi_property_attributes attributes = napi_default,
+      void* data = nullptr);
+  static PropertyDescriptor StaticValue(
+      const char* utf8name,
+      Napi::Value value,
+      napi_property_attributes attributes = napi_default);
+  static PropertyDescriptor StaticValue(
+      Symbol name,
+      Napi::Value value,
+      napi_property_attributes attributes = napi_default);
+  static Napi::Value OnCalledAsFunction(const Napi::CallbackInfo& callbackInfo);
+  virtual void Finalize(Napi::Env env);
 
-  private:
-    using This = ObjectWrap<T>;
+ private:
+  using This = ObjectWrap<T>;
 
-    static napi_value ConstructorCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value StaticVoidMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value StaticMethodCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value StaticGetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static napi_value StaticSetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static void FinalizeCallback(napi_env env, void* data, void* hint);
-    static Function DefineClass(Napi::Env env,
-                                const char* utf8name,
-                                const size_t props_count,
-                                const napi_property_descriptor* props,
-                                void* data = nullptr);
+  static napi_value ConstructorCallbackWrapper(napi_env env,
+                                               napi_callback_info info);
+  static napi_value StaticVoidMethodCallbackWrapper(napi_env env,
+                                                    napi_callback_info info);
+  static napi_value StaticMethodCallbackWrapper(napi_env env,
+                                                napi_callback_info info);
+  static napi_value StaticGetterCallbackWrapper(napi_env env,
+                                                napi_callback_info info);
+  static napi_value StaticSetterCallbackWrapper(napi_env env,
+                                                napi_callback_info info);
+  static void FinalizeCallback(napi_env env, void* data, void* hint);
+  static Function DefineClass(Napi::Env env,
+                              const char* utf8name,
+                              const size_t props_count,
+                              const napi_property_descriptor* props,
+                              void* data = nullptr);
 
-    using StaticVoidMethodCallbackData =
-        MethodCallbackData<T, StaticVoidMethodCallback>;
-    using StaticMethodCallbackData =
-        MethodCallbackData<T, StaticMethodCallback>;
+  using StaticVoidMethodCallbackData =
+      MethodCallbackData<T, StaticVoidMethodCallback>;
+  using StaticMethodCallbackData = MethodCallbackData<T, StaticMethodCallback>;
 
-    using StaticAccessorCallbackData =
-        AccessorCallbackData<T, StaticGetterCallback, StaticSetterCallback>;
+  using StaticAccessorCallbackData =
+      AccessorCallbackData<T, StaticGetterCallback, StaticSetterCallback>;
 
-    template <StaticSetterCallback method>
-    static napi_value WrappedMethod(napi_env env,
-                                    napi_callback_info info) NAPI_NOEXCEPT;
+  template <StaticSetterCallback method>
+  static napi_value WrappedMethod(napi_env env,
+                                  napi_callback_info info) NAPI_NOEXCEPT;
 
-    template <StaticSetterCallback setter> struct StaticSetterTag {};
+  template <StaticSetterCallback setter>
+  struct StaticSetterTag {};
 
-    template <StaticSetterCallback setter>
-    static napi_callback WrapStaticSetter(StaticSetterTag<setter>)
-        NAPI_NOEXCEPT {
-      return &This::WrappedMethod<setter>;
-    }
-    static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>)
-        NAPI_NOEXCEPT {
-      return nullptr;
-    }
+  template <StaticSetterCallback setter>
+  static napi_callback WrapStaticSetter(StaticSetterTag<setter>) NAPI_NOEXCEPT {
+    return &This::WrappedMethod<setter>;
+  }
+  static napi_callback WrapStaticSetter(StaticSetterTag<nullptr>)
+      NAPI_NOEXCEPT {
+    return nullptr;
+  }
 
-    bool _construction_failed = true;
-  };
+  bool _construction_failed = true;
+};
 
-  class HandleScope {
-  public:
-    HandleScope(napi_env env, napi_handle_scope scope);
-    explicit HandleScope(Napi::Env env);
-    ~HandleScope();
+class HandleScope {
+ public:
+  HandleScope(napi_env env, napi_handle_scope scope);
+  explicit HandleScope(Napi::Env env);
+  ~HandleScope();
 
-    // Disallow copying to prevent double close of napi_handle_scope
-    NAPI_DISALLOW_ASSIGN_COPY(HandleScope)
+  // Disallow copying to prevent double close of napi_handle_scope
+  NAPI_DISALLOW_ASSIGN_COPY(HandleScope)
 
-    operator napi_handle_scope() const;
+  operator napi_handle_scope() const;
 
-    Napi::Env Env() const;
+  Napi::Env Env() const;
 
-  private:
-    napi_env _env;
-    napi_handle_scope _scope;
-  };
+ private:
+  napi_env _env;
+  napi_handle_scope _scope;
+};
 
-  class EscapableHandleScope {
-  public:
-    EscapableHandleScope(napi_env env, napi_escapable_handle_scope scope);
-    explicit EscapableHandleScope(Napi::Env env);
-    ~EscapableHandleScope();
+class EscapableHandleScope {
+ public:
+  EscapableHandleScope(napi_env env, napi_escapable_handle_scope scope);
+  explicit EscapableHandleScope(Napi::Env env);
+  ~EscapableHandleScope();
 
-    // Disallow copying to prevent double close of napi_escapable_handle_scope
-    NAPI_DISALLOW_ASSIGN_COPY(EscapableHandleScope)
+  // Disallow copying to prevent double close of napi_escapable_handle_scope
+  NAPI_DISALLOW_ASSIGN_COPY(EscapableHandleScope)
 
-    operator napi_escapable_handle_scope() const;
+  operator napi_escapable_handle_scope() const;
 
-    Napi::Env Env() const;
-    Value Escape(napi_value escapee);
+  Napi::Env Env() const;
+  Value Escape(napi_value escapee);
 
-  private:
-    napi_env _env;
-    napi_escapable_handle_scope _scope;
-  };
+ private:
+  napi_env _env;
+  napi_escapable_handle_scope _scope;
+};
 
 #if (NAPI_VERSION > 2)
-  class CallbackScope {
-  public:
-    CallbackScope(napi_env env, napi_callback_scope scope);
-    CallbackScope(napi_env env, napi_async_context context);
-    virtual ~CallbackScope();
+class CallbackScope {
+ public:
+  CallbackScope(napi_env env, napi_callback_scope scope);
+  CallbackScope(napi_env env, napi_async_context context);
+  virtual ~CallbackScope();
 
-    // Disallow copying to prevent double close of napi_callback_scope
-    NAPI_DISALLOW_ASSIGN_COPY(CallbackScope)
+  // Disallow copying to prevent double close of napi_callback_scope
+  NAPI_DISALLOW_ASSIGN_COPY(CallbackScope)
 
-    operator napi_callback_scope() const;
+  operator napi_callback_scope() const;
 
-    Napi::Env Env() const;
+  Napi::Env Env() const;
 
-  private:
-    napi_env _env;
-    napi_callback_scope _scope;
-  };
+ private:
+  napi_env _env;
+  napi_callback_scope _scope;
+};
 #endif
 
-  class AsyncContext {
-  public:
-    explicit AsyncContext(napi_env env, const char* resource_name);
-    explicit AsyncContext(napi_env env, const char* resource_name, const Object& resource);
-    virtual ~AsyncContext();
+class AsyncContext {
+ public:
+  explicit AsyncContext(napi_env env, const char* resource_name);
+  explicit AsyncContext(napi_env env,
+                        const char* resource_name,
+                        const Object& resource);
+  virtual ~AsyncContext();
 
-    AsyncContext(AsyncContext&& other);
-    AsyncContext& operator =(AsyncContext&& other);
-    NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
+  AsyncContext(AsyncContext&& other);
+  AsyncContext& operator=(AsyncContext&& other);
+  NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
 
-    operator napi_async_context() const;
+  operator napi_async_context() const;
 
-    Napi::Env Env() const;
+  Napi::Env Env() const;
 
-  private:
-    napi_env _env;
-    napi_async_context _context;
+ private:
+  napi_env _env;
+  napi_async_context _context;
+};
+
+class AsyncWorker {
+ public:
+  virtual ~AsyncWorker();
+
+  // An async worker can be moved but cannot be copied.
+  AsyncWorker(AsyncWorker&& other);
+  AsyncWorker& operator=(AsyncWorker&& other);
+  NAPI_DISALLOW_ASSIGN_COPY(AsyncWorker)
+
+  operator napi_async_work() const;
+
+  Napi::Env Env() const;
+
+  void Queue();
+  void Cancel();
+  void SuppressDestruct();
+
+  ObjectReference& Receiver();
+  FunctionReference& Callback();
+
+  virtual void OnExecute(Napi::Env env);
+  virtual void OnWorkComplete(Napi::Env env, napi_status status);
+
+ protected:
+  explicit AsyncWorker(const Function& callback);
+  explicit AsyncWorker(const Function& callback, const char* resource_name);
+  explicit AsyncWorker(const Function& callback,
+                       const char* resource_name,
+                       const Object& resource);
+  explicit AsyncWorker(const Object& receiver, const Function& callback);
+  explicit AsyncWorker(const Object& receiver,
+                       const Function& callback,
+                       const char* resource_name);
+  explicit AsyncWorker(const Object& receiver,
+                       const Function& callback,
+                       const char* resource_name,
+                       const Object& resource);
+
+  explicit AsyncWorker(Napi::Env env);
+  explicit AsyncWorker(Napi::Env env, const char* resource_name);
+  explicit AsyncWorker(Napi::Env env,
+                       const char* resource_name,
+                       const Object& resource);
+
+  virtual void Execute() = 0;
+  virtual void OnOK();
+  virtual void OnError(const Error& e);
+  virtual void Destroy();
+  virtual std::vector<napi_value> GetResult(Napi::Env env);
+
+  void SetError(const std::string& error);
+
+ private:
+  static inline void OnAsyncWorkExecute(napi_env env, void* asyncworker);
+  static inline void OnAsyncWorkComplete(napi_env env,
+                                         napi_status status,
+                                         void* asyncworker);
+
+  napi_env _env;
+  napi_async_work _work;
+  ObjectReference _receiver;
+  FunctionReference _callback;
+  std::string _error;
+  bool _suppress_destruct;
+};
+
+#if (NAPI_VERSION > 3 && !defined(__wasm32__))
+class ThreadSafeFunction {
+ public:
+  // This API may only be called from the main thread.
+  template <typename ResourceString>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename ContextType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename Finalizer>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                Finalizer finalizeCallback);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                Finalizer finalizeCallback,
+                                FinalizerDataType* data);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename ContextType, typename Finalizer>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context,
+                                Finalizer finalizeCallback);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString,
+            typename ContextType,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context,
+                                Finalizer finalizeCallback,
+                                FinalizerDataType* data);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename ContextType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename Finalizer>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                Finalizer finalizeCallback);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                Finalizer finalizeCallback,
+                                FinalizerDataType* data);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString, typename ContextType, typename Finalizer>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context,
+                                Finalizer finalizeCallback);
+
+  // This API may only be called from the main thread.
+  template <typename ResourceString,
+            typename ContextType,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context,
+                                Finalizer finalizeCallback,
+                                FinalizerDataType* data);
+
+  ThreadSafeFunction();
+  ThreadSafeFunction(napi_threadsafe_function tsFunctionValue);
+
+  operator napi_threadsafe_function() const;
+
+  // This API may be called from any thread.
+  napi_status BlockingCall() const;
+
+  // This API may be called from any thread.
+  template <typename Callback>
+  napi_status BlockingCall(Callback callback) const;
+
+  // This API may be called from any thread.
+  template <typename DataType, typename Callback>
+  napi_status BlockingCall(DataType* data, Callback callback) const;
+
+  // This API may be called from any thread.
+  napi_status NonBlockingCall() const;
+
+  // This API may be called from any thread.
+  template <typename Callback>
+  napi_status NonBlockingCall(Callback callback) const;
+
+  // This API may be called from any thread.
+  template <typename DataType, typename Callback>
+  napi_status NonBlockingCall(DataType* data, Callback callback) const;
+
+  // This API may only be called from the main thread.
+  void Ref(napi_env env) const;
+
+  // This API may only be called from the main thread.
+  void Unref(napi_env env) const;
+
+  // This API may be called from any thread.
+  napi_status Acquire() const;
+
+  // This API may be called from any thread.
+  napi_status Release() const;
+
+  // This API may be called from any thread.
+  napi_status Abort() const;
+
+  struct ConvertibleContext {
+    template <class T>
+    operator T*() {
+      return static_cast<T*>(context);
+    }
+    void* context;
   };
 
-  class AsyncWorker {
-  public:
-    virtual ~AsyncWorker();
+  // This API may be called from any thread.
+  ConvertibleContext GetContext() const;
 
-    // An async worker can be moved but cannot be copied.
-    AsyncWorker(AsyncWorker&& other);
-    AsyncWorker& operator =(AsyncWorker&& other);
-    NAPI_DISALLOW_ASSIGN_COPY(AsyncWorker)
+ private:
+  using CallbackWrapper = std::function<void(Napi::Env, Napi::Function)>;
 
-    operator napi_async_work() const;
+  template <typename ResourceString,
+            typename ContextType,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static ThreadSafeFunction New(napi_env env,
+                                const Function& callback,
+                                const Object& resource,
+                                ResourceString resourceName,
+                                size_t maxQueueSize,
+                                size_t initialThreadCount,
+                                ContextType* context,
+                                Finalizer finalizeCallback,
+                                FinalizerDataType* data,
+                                napi_finalize wrapper);
 
-    Napi::Env Env() const;
+  napi_status CallInternal(CallbackWrapper* callbackWrapper,
+                           napi_threadsafe_function_call_mode mode) const;
 
-    void Queue();
-    void Cancel();
-    void SuppressDestruct();
+  static void CallJS(napi_env env,
+                     napi_value jsCallback,
+                     void* context,
+                     void* data);
 
-    ObjectReference& Receiver();
-    FunctionReference& Callback();
+  napi_threadsafe_function _tsfn;
+};
 
-    virtual void OnExecute(Napi::Env env);
-    virtual void OnWorkComplete(Napi::Env env,
-                                napi_status status);
-
-  protected:
-    explicit AsyncWorker(const Function& callback);
-    explicit AsyncWorker(const Function& callback,
-                         const char* resource_name);
-    explicit AsyncWorker(const Function& callback,
-                         const char* resource_name,
-                         const Object& resource);
-    explicit AsyncWorker(const Object& receiver,
-                         const Function& callback);
-    explicit AsyncWorker(const Object& receiver,
-                         const Function& callback,
-                         const char* resource_name);
-    explicit AsyncWorker(const Object& receiver,
-                         const Function& callback,
-                         const char* resource_name,
-                         const Object& resource);
-
-    explicit AsyncWorker(Napi::Env env);
-    explicit AsyncWorker(Napi::Env env,
-                         const char* resource_name);
-    explicit AsyncWorker(Napi::Env env,
-                         const char* resource_name,
-                         const Object& resource);
-
-    virtual void Execute() = 0;
-    virtual void OnOK();
-    virtual void OnError(const Error& e);
-    virtual void Destroy();
-    virtual std::vector<napi_value> GetResult(Napi::Env env);
-
-    void SetError(const std::string& error);
-
-  private:
-    static inline void OnAsyncWorkExecute(napi_env env, void* asyncworker);
-    static inline void OnAsyncWorkComplete(napi_env env,
-                                           napi_status status,
-                                           void* asyncworker);
-
-    napi_env _env;
-    napi_async_work _work;
-    ObjectReference _receiver;
-    FunctionReference _callback;
-    std::string _error;
-    bool _suppress_destruct;
-  };
-
-  #if (NAPI_VERSION > 3 && !defined(__wasm32__))
-  class ThreadSafeFunction {
-  public:
-    // This API may only be called from the main thread.
-    template <typename ResourceString>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename Finalizer>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType, typename Finalizer>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType,
-              typename Finalizer, typename FinalizerDataType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename Finalizer>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename Finalizer,
-              typename FinalizerDataType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType, typename Finalizer>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback);
-
-    // This API may only be called from the main thread.
-    template <typename ResourceString, typename ContextType,
-              typename Finalizer, typename FinalizerDataType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data);
-
-    ThreadSafeFunction();
-    ThreadSafeFunction(napi_threadsafe_function tsFunctionValue);
-
-    operator napi_threadsafe_function() const;
-
-    // This API may be called from any thread.
-    napi_status BlockingCall() const;
-
-    // This API may be called from any thread.
-    template <typename Callback>
-    napi_status BlockingCall(Callback callback) const;
-
-    // This API may be called from any thread.
-    template <typename DataType, typename Callback>
-    napi_status BlockingCall(DataType* data, Callback callback) const;
-
-    // This API may be called from any thread.
-    napi_status NonBlockingCall() const;
-
-    // This API may be called from any thread.
-    template <typename Callback>
-    napi_status NonBlockingCall(Callback callback) const;
-
-    // This API may be called from any thread.
-    template <typename DataType, typename Callback>
-    napi_status NonBlockingCall(DataType* data, Callback callback) const;
-
-    // This API may only be called from the main thread.
-    void Ref(napi_env env) const;
-
-    // This API may only be called from the main thread.
-    void Unref(napi_env env) const;
-
-    // This API may be called from any thread.
-    napi_status Acquire() const;
-
-    // This API may be called from any thread.
-    napi_status Release() const;
-
-    // This API may be called from any thread.
-    napi_status Abort() const;
-
-    struct ConvertibleContext
-    {
-      template <class T>
-      operator T*() { return static_cast<T*>(context); }
-      void* context;
-    };
-
-    // This API may be called from any thread.
-    ConvertibleContext GetContext() const;
-
-  private:
-    using CallbackWrapper = std::function<void(Napi::Env, Napi::Function)>;
-
-    template <typename ResourceString, typename ContextType,
-              typename Finalizer, typename FinalizerDataType>
-    static ThreadSafeFunction New(napi_env env,
-                                  const Function& callback,
-                                  const Object& resource,
-                                  ResourceString resourceName,
-                                  size_t maxQueueSize,
-                                  size_t initialThreadCount,
-                                  ContextType* context,
-                                  Finalizer finalizeCallback,
-                                  FinalizerDataType* data,
-                                  napi_finalize wrapper);
-
-    napi_status CallInternal(CallbackWrapper* callbackWrapper,
-                        napi_threadsafe_function_call_mode mode) const;
-
-    static void CallJS(napi_env env,
-                       napi_value jsCallback,
-                       void* context,
-                       void* data);
-
-    napi_threadsafe_function _tsfn;
-  };
-
-  // A TypedThreadSafeFunction by default has no context (nullptr) and can
-  // accept any type (void) to its CallJs.
-  template <typename ContextType = std::nullptr_t,
-            typename DataType = void,
-            void (*CallJs)(Napi::Env, Napi::Function, ContextType*, DataType*) =
-                nullptr>
-  class TypedThreadSafeFunction {
-   public:
-    // This API may only be called from the main thread.
-    // Helper function that returns nullptr if running Node-API 5+, otherwise a
-    // non-empty, no-op Function. This provides the ability to specify at
-    // compile-time a callback parameter to `New` that safely does no action
-    // when targeting _any_ Node-API version.
+// A TypedThreadSafeFunction by default has no context (nullptr) and can
+// accept any type (void) to its CallJs.
+template <typename ContextType = std::nullptr_t,
+          typename DataType = void,
+          void (*CallJs)(Napi::Env, Napi::Function, ContextType*, DataType*) =
+              nullptr>
+class TypedThreadSafeFunction {
+ public:
+  // This API may only be called from the main thread.
+  // Helper function that returns nullptr if running Node-API 5+, otherwise a
+  // non-empty, no-op Function. This provides the ability to specify at
+  // compile-time a callback parameter to `New` that safely does no action
+  // when targeting _any_ Node-API version.
 #if NAPI_VERSION > 4
-    static std::nullptr_t EmptyFunctionFactory(Napi::Env env);
+  static std::nullptr_t EmptyFunctionFactory(Napi::Env env);
 #else
-    static Napi::Function EmptyFunctionFactory(Napi::Env env);
+  static Napi::Function EmptyFunctionFactory(Napi::Env env);
 #endif
-    static Napi::Function FunctionOrEmpty(Napi::Env env,
-                                          Napi::Function& callback);
+  static Napi::Function FunctionOrEmpty(Napi::Env env,
+                                        Napi::Function& callback);
 
 #if NAPI_VERSION > 4
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [missing] Finalizer [missing]
-    template <typename ResourceString>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [missing] Resource [missing] Finalizer [missing]
+  template <typename ResourceString>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [passed] Finalizer [missing]
-    template <typename ResourceString>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Object& resource,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [missing] Resource [passed] Finalizer [missing]
+  template <typename ResourceString>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Object& resource,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [missing] Finalizer [passed]
-    template <typename ResourceString,
-              typename Finalizer,
-              typename FinalizerDataType = void>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context,
-        Finalizer finalizeCallback,
-        FinalizerDataType* data = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [missing] Resource [missing] Finalizer [passed]
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType = void>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context,
+      Finalizer finalizeCallback,
+      FinalizerDataType* data = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [missing] Resource [passed] Finalizer [passed]
-    template <typename ResourceString,
-              typename Finalizer,
-              typename FinalizerDataType = void>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Object& resource,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context,
-        Finalizer finalizeCallback,
-        FinalizerDataType* data = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [missing] Resource [passed] Finalizer [passed]
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType = void>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Object& resource,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context,
+      Finalizer finalizeCallback,
+      FinalizerDataType* data = nullptr);
 #endif
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [missing] Finalizer [missing]
-    template <typename ResourceString>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Function& callback,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [passed] Resource [missing] Finalizer [missing]
+  template <typename ResourceString>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Function& callback,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [passed] Finalizer [missing]
-    template <typename ResourceString>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Function& callback,
-        const Object& resource,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [passed] Resource [passed] Finalizer [missing]
+  template <typename ResourceString>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Function& callback,
+      const Object& resource,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [missing] Finalizer [passed]
-    template <typename ResourceString,
-              typename Finalizer,
-              typename FinalizerDataType = void>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Function& callback,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context,
-        Finalizer finalizeCallback,
-        FinalizerDataType* data = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [passed] Resource [missing] Finalizer [passed]
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType = void>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Function& callback,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context,
+      Finalizer finalizeCallback,
+      FinalizerDataType* data = nullptr);
 
-    // This API may only be called from the main thread.
-    // Creates a new threadsafe function with:
-    //   Callback [passed] Resource [passed] Finalizer [passed]
-    template <typename CallbackType,
-              typename ResourceString,
-              typename Finalizer,
-              typename FinalizerDataType>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        CallbackType callback,
-        const Object& resource,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context,
-        Finalizer finalizeCallback,
-        FinalizerDataType* data = nullptr);
+  // This API may only be called from the main thread.
+  // Creates a new threadsafe function with:
+  //   Callback [passed] Resource [passed] Finalizer [passed]
+  template <typename CallbackType,
+            typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      CallbackType callback,
+      const Object& resource,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context,
+      Finalizer finalizeCallback,
+      FinalizerDataType* data = nullptr);
 
-    TypedThreadSafeFunction();
-    TypedThreadSafeFunction(napi_threadsafe_function tsFunctionValue);
+  TypedThreadSafeFunction();
+  TypedThreadSafeFunction(napi_threadsafe_function tsFunctionValue);
 
-    operator napi_threadsafe_function() const;
+  operator napi_threadsafe_function() const;
 
-    // This API may be called from any thread.
-    napi_status BlockingCall(DataType* data = nullptr) const;
+  // This API may be called from any thread.
+  napi_status BlockingCall(DataType* data = nullptr) const;
 
-    // This API may be called from any thread.
-    napi_status NonBlockingCall(DataType* data = nullptr) const;
+  // This API may be called from any thread.
+  napi_status NonBlockingCall(DataType* data = nullptr) const;
 
-    // This API may only be called from the main thread.
-    void Ref(napi_env env) const;
+  // This API may only be called from the main thread.
+  void Ref(napi_env env) const;
 
-    // This API may only be called from the main thread.
-    void Unref(napi_env env) const;
+  // This API may only be called from the main thread.
+  void Unref(napi_env env) const;
 
-    // This API may be called from any thread.
-    napi_status Acquire() const;
+  // This API may be called from any thread.
+  napi_status Acquire() const;
 
-    // This API may be called from any thread.
-    napi_status Release() const;
+  // This API may be called from any thread.
+  napi_status Release() const;
 
-    // This API may be called from any thread.
-    napi_status Abort() const;
+  // This API may be called from any thread.
+  napi_status Abort() const;
 
-    // This API may be called from any thread.
-    ContextType* GetContext() const;
+  // This API may be called from any thread.
+  ContextType* GetContext() const;
+
+ private:
+  template <typename ResourceString,
+            typename Finalizer,
+            typename FinalizerDataType>
+  static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
+      napi_env env,
+      const Function& callback,
+      const Object& resource,
+      ResourceString resourceName,
+      size_t maxQueueSize,
+      size_t initialThreadCount,
+      ContextType* context,
+      Finalizer finalizeCallback,
+      FinalizerDataType* data,
+      napi_finalize wrapper);
+
+  static void CallJsInternal(napi_env env,
+                             napi_value jsCallback,
+                             void* context,
+                             void* data);
+
+ protected:
+  napi_threadsafe_function _tsfn;
+};
+template <typename DataType>
+class AsyncProgressWorkerBase : public AsyncWorker {
+ public:
+  virtual void OnWorkProgress(DataType* data) = 0;
+  class ThreadSafeData {
+   public:
+    ThreadSafeData(AsyncProgressWorkerBase* asyncprogressworker, DataType* data)
+        : _asyncprogressworker(asyncprogressworker), _data(data) {}
+
+    AsyncProgressWorkerBase* asyncprogressworker() {
+      return _asyncprogressworker;
+    };
+    DataType* data() { return _data; };
 
    private:
-    template <typename ResourceString,
-              typename Finalizer,
-              typename FinalizerDataType>
-    static TypedThreadSafeFunction<ContextType, DataType, CallJs> New(
-        napi_env env,
-        const Function& callback,
-        const Object& resource,
-        ResourceString resourceName,
-        size_t maxQueueSize,
-        size_t initialThreadCount,
-        ContextType* context,
-        Finalizer finalizeCallback,
-        FinalizerDataType* data,
-        napi_finalize wrapper);
-
-    static void CallJsInternal(napi_env env,
-                               napi_value jsCallback,
-                               void* context,
-                               void* data);
-
-   protected:
-    napi_threadsafe_function _tsfn;
+    AsyncProgressWorkerBase* _asyncprogressworker;
+    DataType* _data;
   };
-  template <typename DataType>
-  class AsyncProgressWorkerBase : public AsyncWorker {
-    public:
-     virtual void OnWorkProgress(DataType* data) = 0;
-     class ThreadSafeData {
-       public:
-        ThreadSafeData(AsyncProgressWorkerBase* asyncprogressworker, DataType* data)
-          : _asyncprogressworker(asyncprogressworker), _data(data) {}
+  void OnWorkComplete(Napi::Env env, napi_status status) override;
 
-        AsyncProgressWorkerBase* asyncprogressworker() { return _asyncprogressworker; };
-        DataType* data() { return _data; };
+ protected:
+  explicit AsyncProgressWorkerBase(const Object& receiver,
+                                   const Function& callback,
+                                   const char* resource_name,
+                                   const Object& resource,
+                                   size_t queue_size = 1);
+  virtual ~AsyncProgressWorkerBase();
 
-       private:
-        AsyncProgressWorkerBase* _asyncprogressworker;
-        DataType* _data;
-     };
-     void OnWorkComplete(Napi::Env env, napi_status status) override;
-    protected:
-     explicit AsyncProgressWorkerBase(const Object& receiver,
-                                      const Function& callback,
-                                      const char* resource_name,
-                                      const Object& resource,
-                                      size_t queue_size = 1);
-    virtual ~AsyncProgressWorkerBase();
-
-// Optional callback of Napi::ThreadSafeFunction only available after NAPI_VERSION 4.
-// Refs: https://github.com/nodejs/node/pull/27791
+// Optional callback of Napi::ThreadSafeFunction only available after
+// NAPI_VERSION 4. Refs: https://github.com/nodejs/node/pull/27791
 #if NAPI_VERSION > 4
-     explicit AsyncProgressWorkerBase(Napi::Env env,
-                                      const char* resource_name,
-                                      const Object& resource,
-                                      size_t queue_size = 1);
+  explicit AsyncProgressWorkerBase(Napi::Env env,
+                                   const char* resource_name,
+                                   const Object& resource,
+                                   size_t queue_size = 1);
 #endif
 
-     static inline void OnAsyncWorkProgress(Napi::Env env,
-                                            Napi::Function jsCallback,
-                                            void* data);
+  static inline void OnAsyncWorkProgress(Napi::Env env,
+                                         Napi::Function jsCallback,
+                                         void* data);
 
-     napi_status NonBlockingCall(DataType* data);
+  napi_status NonBlockingCall(DataType* data);
 
-    private:
-     ThreadSafeFunction _tsfn;
-     bool _work_completed = false;
-     napi_status _complete_status;
-     static inline void OnThreadSafeFunctionFinalize(Napi::Env env, void* data, AsyncProgressWorkerBase* context);
+ private:
+  ThreadSafeFunction _tsfn;
+  bool _work_completed = false;
+  napi_status _complete_status;
+  static inline void OnThreadSafeFunctionFinalize(
+      Napi::Env env, void* data, AsyncProgressWorkerBase* context);
+};
+
+template <class T>
+class AsyncProgressWorker : public AsyncProgressWorkerBase<void> {
+ public:
+  virtual ~AsyncProgressWorker();
+
+  class ExecutionProgress {
+    friend class AsyncProgressWorker;
+
+   public:
+    void Signal() const;
+    void Send(const T* data, size_t count) const;
+
+   private:
+    explicit ExecutionProgress(AsyncProgressWorker* worker) : _worker(worker) {}
+    AsyncProgressWorker* const _worker;
   };
 
-  template<class T>
-  class AsyncProgressWorker : public AsyncProgressWorkerBase<void> {
-    public:
-     virtual ~AsyncProgressWorker();
+  void OnWorkProgress(void*) override;
 
-     class ExecutionProgress {
-        friend class AsyncProgressWorker;
-       public:
-        void Signal() const;
-        void Send(const T* data, size_t count) const;
-       private:
-        explicit ExecutionProgress(AsyncProgressWorker* worker) : _worker(worker) {}
-        AsyncProgressWorker* const _worker;
-     };
+ protected:
+  explicit AsyncProgressWorker(const Function& callback);
+  explicit AsyncProgressWorker(const Function& callback,
+                               const char* resource_name);
+  explicit AsyncProgressWorker(const Function& callback,
+                               const char* resource_name,
+                               const Object& resource);
+  explicit AsyncProgressWorker(const Object& receiver,
+                               const Function& callback);
+  explicit AsyncProgressWorker(const Object& receiver,
+                               const Function& callback,
+                               const char* resource_name);
+  explicit AsyncProgressWorker(const Object& receiver,
+                               const Function& callback,
+                               const char* resource_name,
+                               const Object& resource);
 
-     void OnWorkProgress(void*) override;
-
-    protected:
-     explicit AsyncProgressWorker(const Function& callback);
-     explicit AsyncProgressWorker(const Function& callback,
-                                  const char* resource_name);
-     explicit AsyncProgressWorker(const Function& callback,
-                                  const char* resource_name,
-                                  const Object& resource);
-     explicit AsyncProgressWorker(const Object& receiver,
-                                  const Function& callback);
-     explicit AsyncProgressWorker(const Object& receiver,
-                                  const Function& callback,
-                                  const char* resource_name);
-     explicit AsyncProgressWorker(const Object& receiver,
-                                  const Function& callback,
-                                  const char* resource_name,
-                                  const Object& resource);
-
-// Optional callback of Napi::ThreadSafeFunction only available after NAPI_VERSION 4.
-// Refs: https://github.com/nodejs/node/pull/27791
+// Optional callback of Napi::ThreadSafeFunction only available after
+// NAPI_VERSION 4. Refs: https://github.com/nodejs/node/pull/27791
 #if NAPI_VERSION > 4
-     explicit AsyncProgressWorker(Napi::Env env);
-     explicit AsyncProgressWorker(Napi::Env env,
-                                  const char* resource_name);
-     explicit AsyncProgressWorker(Napi::Env env,
-                                  const char* resource_name,
-                                  const Object& resource);
+  explicit AsyncProgressWorker(Napi::Env env);
+  explicit AsyncProgressWorker(Napi::Env env, const char* resource_name);
+  explicit AsyncProgressWorker(Napi::Env env,
+                               const char* resource_name,
+                               const Object& resource);
 #endif
-     virtual void Execute(const ExecutionProgress& progress) = 0;
-     virtual void OnProgress(const T* data, size_t count) = 0;
+  virtual void Execute(const ExecutionProgress& progress) = 0;
+  virtual void OnProgress(const T* data, size_t count) = 0;
 
-    private:
-     void Execute() override;
-     void Signal() const;
-     void SendProgress_(const T* data, size_t count);
+ private:
+  void Execute() override;
+  void Signal() const;
+  void SendProgress_(const T* data, size_t count);
 
-     std::mutex _mutex;
-     T* _asyncdata;
-     size_t _asyncsize;
+  std::mutex _mutex;
+  T* _asyncdata;
+  size_t _asyncsize;
+};
+
+template <class T>
+class AsyncProgressQueueWorker
+    : public AsyncProgressWorkerBase<std::pair<T*, size_t>> {
+ public:
+  virtual ~AsyncProgressQueueWorker(){};
+
+  class ExecutionProgress {
+    friend class AsyncProgressQueueWorker;
+
+   public:
+    void Signal() const;
+    void Send(const T* data, size_t count) const;
+
+   private:
+    explicit ExecutionProgress(AsyncProgressQueueWorker* worker)
+        : _worker(worker) {}
+    AsyncProgressQueueWorker* const _worker;
   };
 
-  template<class T>
-  class AsyncProgressQueueWorker : public AsyncProgressWorkerBase<std::pair<T*, size_t>> {
-    public:
-     virtual ~AsyncProgressQueueWorker() {};
+  void OnWorkComplete(Napi::Env env, napi_status status) override;
+  void OnWorkProgress(std::pair<T*, size_t>*) override;
 
-     class ExecutionProgress {
-        friend class AsyncProgressQueueWorker;
-       public:
-        void Signal() const;
-        void Send(const T* data, size_t count) const;
-       private:
-        explicit ExecutionProgress(AsyncProgressQueueWorker* worker) : _worker(worker) {}
-        AsyncProgressQueueWorker* const _worker;
-     };
+ protected:
+  explicit AsyncProgressQueueWorker(const Function& callback);
+  explicit AsyncProgressQueueWorker(const Function& callback,
+                                    const char* resource_name);
+  explicit AsyncProgressQueueWorker(const Function& callback,
+                                    const char* resource_name,
+                                    const Object& resource);
+  explicit AsyncProgressQueueWorker(const Object& receiver,
+                                    const Function& callback);
+  explicit AsyncProgressQueueWorker(const Object& receiver,
+                                    const Function& callback,
+                                    const char* resource_name);
+  explicit AsyncProgressQueueWorker(const Object& receiver,
+                                    const Function& callback,
+                                    const char* resource_name,
+                                    const Object& resource);
 
-     void OnWorkComplete(Napi::Env env, napi_status status) override;
-     void OnWorkProgress(std::pair<T*, size_t>*) override;
-
-    protected:
-     explicit AsyncProgressQueueWorker(const Function& callback);
-     explicit AsyncProgressQueueWorker(const Function& callback,
-                                       const char* resource_name);
-     explicit AsyncProgressQueueWorker(const Function& callback,
-                                       const char* resource_name,
-                                       const Object& resource);
-     explicit AsyncProgressQueueWorker(const Object& receiver,
-                                       const Function& callback);
-     explicit AsyncProgressQueueWorker(const Object& receiver,
-                                       const Function& callback,
-                                       const char* resource_name);
-     explicit AsyncProgressQueueWorker(const Object& receiver,
-                                       const Function& callback,
-                                       const char* resource_name,
-                                       const Object& resource);
-
-// Optional callback of Napi::ThreadSafeFunction only available after NAPI_VERSION 4.
-// Refs: https://github.com/nodejs/node/pull/27791
+// Optional callback of Napi::ThreadSafeFunction only available after
+// NAPI_VERSION 4. Refs: https://github.com/nodejs/node/pull/27791
 #if NAPI_VERSION > 4
-     explicit AsyncProgressQueueWorker(Napi::Env env);
-     explicit AsyncProgressQueueWorker(Napi::Env env,
-                                       const char* resource_name);
-     explicit AsyncProgressQueueWorker(Napi::Env env,
-                                       const char* resource_name,
-                                       const Object& resource);
+  explicit AsyncProgressQueueWorker(Napi::Env env);
+  explicit AsyncProgressQueueWorker(Napi::Env env, const char* resource_name);
+  explicit AsyncProgressQueueWorker(Napi::Env env,
+                                    const char* resource_name,
+                                    const Object& resource);
 #endif
-     virtual void Execute(const ExecutionProgress& progress) = 0;
-     virtual void OnProgress(const T* data, size_t count) = 0;
+  virtual void Execute(const ExecutionProgress& progress) = 0;
+  virtual void OnProgress(const T* data, size_t count) = 0;
 
-    private:
-     void Execute() override;
-     void Signal() const;
-     void SendProgress_(const T* data, size_t count);
-  };
-  #endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
+ private:
+  void Execute() override;
+  void Signal() const;
+  void SendProgress_(const T* data, size_t count);
+};
+#endif  // NAPI_VERSION > 3 && !defined(__wasm32__)
 
-  // Memory management.
-  class MemoryManagement {
-    public:
-      static int64_t AdjustExternalMemory(Env env, int64_t change_in_bytes);
-  };
+// Memory management.
+class MemoryManagement {
+ public:
+  static int64_t AdjustExternalMemory(Env env, int64_t change_in_bytes);
+};
 
-  // Version management
-  class VersionManagement {
-    public:
-      static uint32_t GetNapiVersion(Env env);
-      static const napi_node_version* GetNodeVersion(Env env);
-  };
+// Version management
+class VersionManagement {
+ public:
+  static uint32_t GetNapiVersion(Env env);
+  static const napi_node_version* GetNodeVersion(Env env);
+};
 
 #if NAPI_VERSION > 5
-  template <typename T>
-  class Addon : public InstanceWrap<T> {
-   public:
-    static inline Object Init(Env env, Object exports);
-    static T* Unwrap(Object wrapper);
+template <typename T>
+class Addon : public InstanceWrap<T> {
+ public:
+  static inline Object Init(Env env, Object exports);
+  static T* Unwrap(Object wrapper);
 
-   protected:
-    using AddonProp = ClassPropertyDescriptor<T>;
-    void DefineAddon(Object exports,
-                     const std::initializer_list<AddonProp>& props);
-    Napi::Object DefineProperties(Object object,
-                                 const std::initializer_list<AddonProp>& props);
+ protected:
+  using AddonProp = ClassPropertyDescriptor<T>;
+  void DefineAddon(Object exports,
+                   const std::initializer_list<AddonProp>& props);
+  Napi::Object DefineProperties(Object object,
+                                const std::initializer_list<AddonProp>& props);
 
-   private:
-    Object entry_point_;
-  };
+ private:
+  Object entry_point_;
+};
 #endif  // NAPI_VERSION > 5
 
 #ifdef NAPI_CPP_CUSTOM_NAMESPACE
-  }  // namespace NAPI_CPP_CUSTOM_NAMESPACE
+}  // namespace NAPI_CPP_CUSTOM_NAMESPACE
 #endif
 
-} // namespace Napi
+}  // namespace Napi
 
 // Inline implementations of all the above class methods are included here.
 #include "napi-inl.h"
 
-#endif // SRC_NAPI_H_
+#endif  // SRC_NAPI_H_

--- a/test/addon.cc
+++ b/test/addon.cc
@@ -7,12 +7,14 @@ namespace {
 class TestAddon : public Napi::Addon<TestAddon> {
  public:
   inline TestAddon(Napi::Env env, Napi::Object exports) {
-    DefineAddon(exports, {
-      InstanceMethod("increment", &TestAddon::Increment),
-      InstanceValue("subObject", DefineProperties(Napi::Object::New(env), {
-        InstanceMethod("decrement", &TestAddon::Decrement)
-      }))
-    });
+    DefineAddon(
+        exports,
+        {InstanceMethod("increment", &TestAddon::Increment),
+         InstanceValue(
+             "subObject",
+             DefineProperties(
+                 Napi::Object::New(env),
+                 {InstanceMethod("decrement", &TestAddon::Decrement)}))});
   }
 
  private:

--- a/test/addon_build/index.js
+++ b/test/addon_build/index.js
@@ -23,7 +23,7 @@ async function beforeAll (addons) {
 
 async function test (addon) {
   console.log(`   >Building addon: '${addon}'`);
-  const { stderr, stdout } = await exec('npm install', {
+  await exec('npm install', {
     cwd: path.join(ADDONS_FOLDER, addon)
   });
   console.log(`   >Running test for: '${addon}'`);

--- a/test/addon_build/index.js
+++ b/test/addon_build/index.js
@@ -4,28 +4,28 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const { copy, remove } = require('fs-extra');
 const path = require('path');
-const assert = require('assert')
+const assert = require('assert');
 
 const ADDONS_FOLDER = path.join(__dirname, 'addons');
 
 const addons = [
   'echo addon',
   'echo-addon'
-]
+];
 
-async function beforeAll(addons) {
-  console.log('   >Preparing native addons to build')
+async function beforeAll (addons) {
+  console.log('   >Preparing native addons to build');
   for (const addon of addons) {
     await remove(path.join(ADDONS_FOLDER, addon));
     await copy(path.join(__dirname, 'tpl'), path.join(ADDONS_FOLDER, addon));
   }
 }
 
-async function test(addon) {
+async function test (addon) {
   console.log(`   >Building addon: '${addon}'`);
   const { stderr, stdout } = await exec('npm install', {
     cwd: path.join(ADDONS_FOLDER, addon)
-  })
+  });
   console.log(`   >Running test for: '${addon}'`);
   // Disabled the checks on stderr and stdout because of this issue on npm:
   // Stop using process.umask(): https://github.com/npm/cli/issues/1103
@@ -41,9 +41,9 @@ async function test(addon) {
   assert.strictEqual(binding.noexcept.echo(103), 103);
 }
 
-module.exports = (async function() {
+module.exports = (async function () {
   await beforeAll(addons);
   for (const addon of addons) {
     await test(addon);
   }
-})()
+})();

--- a/test/addon_build/tpl/addon.cc
+++ b/test/addon_build/tpl/addon.cc
@@ -3,7 +3,8 @@
 Napi::Value Echo(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() != 1) {
-    Napi::TypeError::New(env, "Wrong number of arguments. One argument expected.")
+    Napi::TypeError::New(env,
+                         "Wrong number of arguments. One argument expected.")
         .ThrowAsJavaScriptException();
   }
   return info[0].As<Napi::Value>();

--- a/test/addon_build/tpl/index.js
+++ b/test/addon_build/tpl/index.js
@@ -1,9 +1,9 @@
-'use strict'
+'use strict';
 
-const except = require('bindings')('addon')
-const noexcept = require('bindings')('addon_noexcept')
+const except = require('bindings')('addon');
+const noexcept = require('bindings')('addon_noexcept');
 
 module.exports = {
   except,
   noexcept
-}
+};

--- a/test/addon_data.cc
+++ b/test/addon_data.cc
@@ -17,11 +17,10 @@ class Addon {
  public:
   class VerboseIndicator : public Napi::ObjectWrap<VerboseIndicator> {
    public:
-    VerboseIndicator(const Napi::CallbackInfo& info):
-        Napi::ObjectWrap<VerboseIndicator>(info) {
-      info.This().As<Napi::Object>()["verbose"] =
-          Napi::Boolean::New(info.Env(),
-                             info.Env().GetInstanceData<Addon>()->verbose);
+    VerboseIndicator(const Napi::CallbackInfo& info)
+        : Napi::ObjectWrap<VerboseIndicator>(info) {
+      info.This().As<Napi::Object>()["verbose"] = Napi::Boolean::New(
+          info.Env(), info.Env().GetInstanceData<Addon>()->verbose);
     }
 
     Napi::Value Getter(const Napi::CallbackInfo& info) {
@@ -34,11 +33,11 @@ class Addon {
     }
 
     static Napi::FunctionReference Init(Napi::Env env) {
-      return Napi::Persistent(DefineClass(env, "VerboseIndicator", {
-        InstanceAccessor<
-                         &VerboseIndicator::Getter,
-                         &VerboseIndicator::Setter>("verbose")
-      }));
+      return Napi::Persistent(DefineClass(
+          env,
+          "VerboseIndicator",
+          {InstanceAccessor<&VerboseIndicator::Getter,
+                            &VerboseIndicator::Setter>("verbose")}));
     }
   };
 
@@ -51,7 +50,7 @@ class Addon {
     info.Env().GetInstanceData<Addon>()->verbose = info[0].As<Napi::Boolean>();
   }
 
-  Addon(Napi::Env env): VerboseIndicator(VerboseIndicator::Init(env)) {}
+  Addon(Napi::Env env) : VerboseIndicator(VerboseIndicator::Init(env)) {}
   ~Addon() {
     if (verbose) {
       fprintf(stderr, "addon_data: Addon::~Addon\n");
@@ -76,7 +75,7 @@ class Addon {
                                                         new uint32_t(hint));
     Napi::Object result = Napi::Object::New(env);
     result.DefineProperties({
-      Napi::PropertyDescriptor::Accessor<Getter, Setter>("verbose"),
+        Napi::PropertyDescriptor::Accessor<Getter, Setter>("verbose"),
     });
 
     return result;

--- a/test/array_buffer.js
+++ b/test/array_buffer.js
@@ -5,7 +5,7 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   return testUtil.runGCTests([
     'Internal ArrayBuffer',
     () => {
@@ -64,6 +64,6 @@ function test(binding) {
       // Let C++ detach the ArrayBuffer.
       const extBuffer = binding.arraybuffer.createExternalBuffer();
       binding.arraybuffer.checkDetachUpdatesData(extBuffer);
-    },
+    }
   ]);
 }

--- a/test/array_buffer.js
+++ b/test/array_buffer.js
@@ -58,6 +58,7 @@ function test (binding) {
     'ArrayBuffer updates data pointer and length when detached',
     () => {
       // Detach the ArrayBuffer in JavaScript.
+      // eslint-disable-next-line no-undef
       const mem = new WebAssembly.Memory({ initial: 1 });
       binding.arraybuffer.checkDetachUpdatesData(mem.buffer, () => mem.grow(1));
 

--- a/test/async_progress_queue_worker.js
+++ b/test/async_progress_queue_worker.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const common = require('./common')
+const common = require('./common');
 const assert = require('assert');
 
 module.exports = common.runTest(test);
 
-async function test({ asyncprogressqueueworker }) {
+async function test ({ asyncprogressqueueworker }) {
   await success(asyncprogressqueueworker);
   await fail(asyncprogressqueueworker);
 }
 
-function success(binding) {
+function success (binding) {
   return new Promise((resolve, reject) => {
     const expected = [0, 1, 2, 3];
     const actual = [];
@@ -32,11 +32,11 @@ function success(binding) {
   });
 }
 
-function fail(binding) {
+function fail (binding) {
   return new Promise((resolve, reject) => {
     const worker = binding.createWork(-1,
       common.mustCall((err) => {
-        assert.throws(() => { throw err }, /test error/);
+        assert.throws(() => { throw err; }, /test error/);
         resolve();
       }),
       common.mustNotCall()

--- a/test/async_progress_worker.js
+++ b/test/async_progress_worker.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const common = require('./common')
+const common = require('./common');
 const assert = require('assert');
 
 module.exports = common.runTest(test);
 
-async function test({ asyncprogressworker }) {
+async function test ({ asyncprogressworker }) {
   await success(asyncprogressworker);
   await fail(asyncprogressworker);
   await malignTest(asyncprogressworker);
 }
 
-function success(binding) {
+function success (binding) {
   return new Promise((resolve, reject) => {
     const expected = [0, 1, 2, 3];
     const actual = [];
@@ -32,11 +32,11 @@ function success(binding) {
   });
 }
 
-function fail(binding) {
+function fail (binding) {
   return new Promise((resolve) => {
     binding.doWork(-1,
       common.mustCall((err) => {
-        assert.throws(() => { throw err }, /test error/)
+        assert.throws(() => { throw err; }, /test error/);
         resolve();
       }),
       common.mustNotCall()
@@ -44,7 +44,7 @@ function fail(binding) {
   });
 }
 
-function malignTest(binding) {
+function malignTest (binding) {
   return new Promise((resolve, reject) => {
     binding.doMalignTest(
       common.mustCall((err) => {

--- a/test/async_worker.js
+++ b/test/async_worker.js
@@ -5,11 +5,11 @@ const common = require('./common');
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
 const nodeVersion = process.versions.node.split('.')[0];
-let async_hooks;
+let asyncHooks;
 function checkAsyncHooks () {
   if (nodeVersion >= 8) {
-    if (async_hooks == undefined) {
-      async_hooks = require('async_hooks');
+    if (asyncHooks === undefined) {
+      asyncHooks = require('async_hooks');
     }
     return true;
   }
@@ -26,7 +26,6 @@ function installAsyncHooksForTest () {
      * TODO(legendecas): investigate why resolving & disabling hooks in
      * destroy callback causing crash with case 'callbackscope.js'.
      */
-    let hook;
     let destroyed = false;
     const interval = setInterval(() => {
       if (destroyed) {
@@ -36,7 +35,7 @@ function installAsyncHooksForTest () {
       }
     }, 10);
 
-    hook = async_hooks.createHook({
+    const hook = asyncHooks.createHook({
       init (asyncId, type, triggerAsyncId, resource) {
         if (id === undefined && type === 'TestResource') {
           id = asyncId;
@@ -86,9 +85,9 @@ async function test (binding) {
 
     await new Promise((resolve) => {
       binding.asyncworker.doWorkWithResult(true, {}, function (succeed, succeedString) {
-        assert(arguments.length == 2);
+        assert(arguments.length === 2);
         assert(succeed);
-        assert(succeedString == 'ok');
+        assert(succeedString === 'ok');
         assert.strictEqual(typeof this, 'object');
         assert.strictEqual(this.data, 'test data');
         resolve();
@@ -100,7 +99,7 @@ async function test (binding) {
 
   {
     const hooks = installAsyncHooksForTest();
-    const triggerAsyncId = async_hooks.executionAsyncId();
+    const triggerAsyncId = asyncHooks.executionAsyncId();
     await new Promise((resolve) => {
       binding.asyncworker.doWork(true, { foo: 'foo' }, function (e) {
         assert.strictEqual(typeof e, 'undefined');
@@ -127,13 +126,13 @@ async function test (binding) {
 
   {
     const hooks = installAsyncHooksForTest();
-    const triggerAsyncId = async_hooks.executionAsyncId();
+    const triggerAsyncId = asyncHooks.executionAsyncId();
     await new Promise((resolve) => {
       binding.asyncworker.doWorkWithResult(true, { foo: 'foo' },
         function (succeed, succeedString) {
-          assert(arguments.length == 2);
+          assert(arguments.length === 2);
           assert(succeed);
-          assert(succeedString == 'ok');
+          assert(succeedString === 'ok');
           assert.strictEqual(typeof this, 'object');
           assert.strictEqual(this.data, 'test data');
           resolve();
@@ -157,7 +156,7 @@ async function test (binding) {
 
   {
     const hooks = installAsyncHooksForTest();
-    const triggerAsyncId = async_hooks.executionAsyncId();
+    const triggerAsyncId = asyncHooks.executionAsyncId();
     await new Promise((resolve) => {
       binding.asyncworker.doWork(false, { foo: 'foo' }, function (e) {
         assert.ok(e instanceof Error);

--- a/test/async_worker.js
+++ b/test/async_worker.js
@@ -4,10 +4,10 @@ const common = require('./common');
 
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
-const nodeVersion = process.versions.node.split('.')[0]
-let async_hooks = undefined;
-function checkAsyncHooks() {
-  if (nodeVersion >=8) {
+const nodeVersion = process.versions.node.split('.')[0];
+let async_hooks;
+function checkAsyncHooks () {
+  if (nodeVersion >= 8) {
     if (async_hooks == undefined) {
       async_hooks = require('async_hooks');
     }
@@ -18,7 +18,7 @@ function checkAsyncHooks() {
 
 module.exports = common.runTest(test);
 
-function installAsyncHooksForTest() {
+function installAsyncHooksForTest () {
   return new Promise((resolve, reject) => {
     let id;
     const events = [];
@@ -26,34 +26,34 @@ function installAsyncHooksForTest() {
      * TODO(legendecas): investigate why resolving & disabling hooks in
      * destroy callback causing crash with case 'callbackscope.js'.
      */
-     let hook;
-     let destroyed = false;
-     const interval = setInterval(() => {
-       if (destroyed) {
-         hook.disable();
-         clearInterval(interval);
-         resolve(events);
-       }
-     }, 10);
+    let hook;
+    let destroyed = false;
+    const interval = setInterval(() => {
+      if (destroyed) {
+        hook.disable();
+        clearInterval(interval);
+        resolve(events);
+      }
+    }, 10);
 
     hook = async_hooks.createHook({
-      init(asyncId, type, triggerAsyncId, resource) {
+      init (asyncId, type, triggerAsyncId, resource) {
         if (id === undefined && type === 'TestResource') {
           id = asyncId;
           events.push({ eventName: 'init', type, triggerAsyncId, resource });
         }
       },
-      before(asyncId) {
+      before (asyncId) {
         if (asyncId === id) {
           events.push({ eventName: 'before' });
         }
       },
-      after(asyncId) {
+      after (asyncId) {
         if (asyncId === id) {
           events.push({ eventName: 'after' });
         }
       },
-      destroy(asyncId) {
+      destroy (asyncId) {
         if (asyncId === id) {
           events.push({ eventName: 'destroy' });
           destroyed = true;
@@ -63,7 +63,7 @@ function installAsyncHooksForTest() {
   });
 }
 
-async function test(binding) {
+async function test (binding) {
   if (!checkAsyncHooks()) {
     await new Promise((resolve) => {
       binding.asyncworker.doWork(true, {}, function (e) {
@@ -88,7 +88,7 @@ async function test(binding) {
       binding.asyncworker.doWorkWithResult(true, {}, function (succeed, succeedString) {
         assert(arguments.length == 2);
         assert(succeed);
-        assert(succeedString == "ok");
+        assert(succeedString == 'ok');
         assert.strictEqual(typeof this, 'object');
         assert.strictEqual(this.data, 'test data');
         resolve();
@@ -112,10 +112,12 @@ async function test(binding) {
 
     await hooks.then(actual => {
       assert.deepStrictEqual(actual, [
-        { eventName: 'init',
+        {
+          eventName: 'init',
           type: 'TestResource',
           triggerAsyncId: triggerAsyncId,
-          resource: { foo: 'foo' } },
+          resource: { foo: 'foo' }
+        },
         { eventName: 'before' },
         { eventName: 'after' },
         { eventName: 'destroy' }
@@ -131,7 +133,7 @@ async function test(binding) {
         function (succeed, succeedString) {
           assert(arguments.length == 2);
           assert(succeed);
-          assert(succeedString == "ok");
+          assert(succeedString == 'ok');
           assert.strictEqual(typeof this, 'object');
           assert.strictEqual(this.data, 'test data');
           resolve();
@@ -140,10 +142,12 @@ async function test(binding) {
 
     await hooks.then(actual => {
       assert.deepStrictEqual(actual, [
-        { eventName: 'init',
+        {
+          eventName: 'init',
           type: 'TestResource',
           triggerAsyncId: triggerAsyncId,
-          resource: { foo: 'foo' } },
+          resource: { foo: 'foo' }
+        },
         { eventName: 'before' },
         { eventName: 'after' },
         { eventName: 'destroy' }
@@ -166,10 +170,12 @@ async function test(binding) {
 
     await hooks.then(actual => {
       assert.deepStrictEqual(actual, [
-        { eventName: 'init',
+        {
+          eventName: 'init',
           type: 'TestResource',
           triggerAsyncId: triggerAsyncId,
-          resource: { foo: 'foo' } },
+          resource: { foo: 'foo' }
+        },
         { eventName: 'before' },
         { eventName: 'after' },
         { eventName: 'destroy' }

--- a/test/async_worker_nocallback.js
+++ b/test/async_worker_nocallback.js
@@ -4,7 +4,7 @@ const common = require('./common');
 
 module.exports = common.runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   await binding.asyncworker.doWorkNoCallback(true, {})
     .then(common.mustCall()).catch(common.mustNotCall());
 

--- a/test/async_worker_persistent.js
+++ b/test/async_worker_persistent.js
@@ -2,11 +2,11 @@
 
 const assert = require('assert');
 
-function test(binding, succeed) {
+function test (binding, succeed) {
   return new Promise((resolve) =>
     // Can't pass an arrow function to doWork because that results in an
     // undefined context inside its body when the function gets called.
-    binding.doWork(succeed, function(e) {
+    binding.doWork(succeed, function (e) {
       setImmediate(() => {
         // If the work is supposed to fail, make sure there's an error.
         assert.strictEqual(succeed || e.message === 'test error', true);

--- a/test/basic_types/array.js
+++ b/test/basic_types/array.js
@@ -3,8 +3,7 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-
+function test (binding) {
   // create empty array
   const array = binding.basic_types_array.createArray();
   assert.strictEqual(binding.basic_types_array.getLength(array), 0);
@@ -15,7 +14,7 @@ function test(binding) {
 
   // set function test
   binding.basic_types_array.set(array, 0, 10);
-  binding.basic_types_array.set(array, 1, "test");
+  binding.basic_types_array.set(array, 1, 'test');
   binding.basic_types_array.set(array, 2, 3.0);
 
   // check length after set data
@@ -23,7 +22,7 @@ function test(binding) {
 
   // get function test
   assert.strictEqual(binding.basic_types_array.get(array, 0), 10);
-  assert.strictEqual(binding.basic_types_array.get(array, 1), "test");
+  assert.strictEqual(binding.basic_types_array.get(array, 1), 'test');
   assert.strictEqual(binding.basic_types_array.get(array, 2), 3.0);
 
   // overwrite test

--- a/test/basic_types/boolean.cc
+++ b/test/basic_types/boolean.cc
@@ -31,8 +31,10 @@ Object InitBasicTypesBoolean(Env env) {
 
   exports["createBoolean"] = Function::New(env, CreateBoolean);
   exports["createEmptyBoolean"] = Function::New(env, CreateEmptyBoolean);
-  exports["createBooleanFromExistingValue"] = Function::New(env, CreateBooleanFromExistingValue);
-  exports["createBooleanFromPrimitive"] = Function::New(env, CreateBooleanFromPrimitive);
+  exports["createBooleanFromExistingValue"] =
+      Function::New(env, CreateBooleanFromExistingValue);
+  exports["createBooleanFromPrimitive"] =
+      Function::New(env, CreateBooleanFromPrimitive);
   exports["operatorBool"] = Function::New(env, OperatorBool);
   return exports;
 }

--- a/test/basic_types/boolean.js
+++ b/test/basic_types/boolean.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const bool1 = binding.basic_types_boolean.createBoolean(true);
   assert.strictEqual(bool1, true);
 
@@ -31,5 +31,4 @@ function test(binding) {
 
   const bool8 = binding.basic_types_boolean.operatorBool(false);
   assert.strictEqual(bool8, false);
-
 }

--- a/test/basic_types/number.cc
+++ b/test/basic_types/number.cc
@@ -43,27 +43,32 @@ Value MaxDouble(const CallbackInfo& info) {
 
 Value OperatorInt32(const CallbackInfo& info) {
   Number number = info[0].As<Number>();
-  return Boolean::New(info.Env(), number.Int32Value() == static_cast<int32_t>(number));
+  return Boolean::New(info.Env(),
+                      number.Int32Value() == static_cast<int32_t>(number));
 }
 
 Value OperatorUint32(const CallbackInfo& info) {
   Number number = info[0].As<Number>();
-  return Boolean::New(info.Env(), number.Uint32Value() == static_cast<uint32_t>(number));
+  return Boolean::New(info.Env(),
+                      number.Uint32Value() == static_cast<uint32_t>(number));
 }
 
 Value OperatorInt64(const CallbackInfo& info) {
   Number number = info[0].As<Number>();
-  return Boolean::New(info.Env(), number.Int64Value() == static_cast<int64_t>(number));
+  return Boolean::New(info.Env(),
+                      number.Int64Value() == static_cast<int64_t>(number));
 }
 
 Value OperatorFloat(const CallbackInfo& info) {
   Number number = info[0].As<Number>();
-  return Boolean::New(info.Env(), number.FloatValue() == static_cast<float>(number));
+  return Boolean::New(info.Env(),
+                      number.FloatValue() == static_cast<float>(number));
 }
 
 Value OperatorDouble(const CallbackInfo& info) {
   Number number = info[0].As<Number>();
-  return Boolean::New(info.Env(), number.DoubleValue() == static_cast<double>(number));
+  return Boolean::New(info.Env(),
+                      number.DoubleValue() == static_cast<double>(number));
 }
 
 Value CreateEmptyNumber(const CallbackInfo& info) {
@@ -93,7 +98,8 @@ Object InitBasicTypesNumber(Env env) {
   exports["operatorFloat"] = Function::New(env, OperatorFloat);
   exports["operatorDouble"] = Function::New(env, OperatorDouble);
   exports["createEmptyNumber"] = Function::New(env, CreateEmptyNumber);
-  exports["createNumberFromExistingValue"] = Function::New(env, CreateNumberFromExistingValue);
+  exports["createNumberFromExistingValue"] =
+      Function::New(env, CreateNumberFromExistingValue);
 
   return exports;
 }

--- a/test/basic_types/number.js
+++ b/test/basic_types/number.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-lone-blocks */
 'use strict';
 
 const assert = require('assert');

--- a/test/basic_types/number.js
+++ b/test/basic_types/number.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const MIN_INT32 = -2147483648;
   const MAX_INT32 = 2147483647;
   const MIN_UINT32 = 0;
@@ -16,9 +16,9 @@ function test(binding) {
   const MIN_DOUBLE = binding.basic_types_number.minDouble();
   const MAX_DOUBLE = binding.basic_types_number.maxDouble();
 
-  function randomRangeTestForInteger(min, max, converter) {
-    for (let i = min; i < max; i+= Math.floor(Math.random() * max / 100)) {
-        assert.strictEqual(i, converter(i));
+  function randomRangeTestForInteger (min, max, converter) {
+    for (let i = min; i < max; i += Math.floor(Math.random() * max / 100)) {
+      assert.strictEqual(i, converter(i));
     }
   }
 
@@ -96,19 +96,19 @@ function test(binding) {
 
   // Construction test
   {
-    assert.strictEqual(binding.basic_types_number.createEmptyNumber(), true);
-    randomRangeTestForInteger(MIN_INT32, MAX_INT32, binding.basic_types_number.createNumberFromExistingValue);
-    assert.strictEqual(MIN_INT32, binding.basic_types_number.createNumberFromExistingValue(MIN_INT32));
-    assert.strictEqual(MAX_INT32, binding.basic_types_number.createNumberFromExistingValue(MAX_INT32));
-    randomRangeTestForInteger(MIN_UINT32, MAX_UINT32, binding.basic_types_number.createNumberFromExistingValue);
-    assert.strictEqual(MIN_UINT32, binding.basic_types_number.createNumberFromExistingValue(MIN_UINT32));
-    assert.strictEqual(MAX_UINT32, binding.basic_types_number.createNumberFromExistingValue(MAX_UINT32));
-    randomRangeTestForInteger(MIN_INT64, MAX_INT64, binding.basic_types_number.createNumberFromExistingValue);
-    assert.strictEqual(MIN_INT64, binding.basic_types_number.createNumberFromExistingValue(MIN_INT64));
-    assert.strictEqual(MAX_INT64, binding.basic_types_number.createNumberFromExistingValue(MAX_INT64));
-    assert.strictEqual(MIN_FLOAT, binding.basic_types_number.createNumberFromExistingValue(MIN_FLOAT));
-    assert.strictEqual(MAX_FLOAT, binding.basic_types_number.createNumberFromExistingValue(MAX_FLOAT));
-    assert.strictEqual(MIN_DOUBLE, binding.basic_types_number.createNumberFromExistingValue(MIN_DOUBLE));
-    assert.strictEqual(MAX_DOUBLE, binding.basic_types_number.createNumberFromExistingValue(MAX_DOUBLE));
+    assert.strictEqual(binding.basic_types_number.createEmptyNumber(), true);
+    randomRangeTestForInteger(MIN_INT32, MAX_INT32, binding.basic_types_number.createNumberFromExistingValue);
+    assert.strictEqual(MIN_INT32, binding.basic_types_number.createNumberFromExistingValue(MIN_INT32));
+    assert.strictEqual(MAX_INT32, binding.basic_types_number.createNumberFromExistingValue(MAX_INT32));
+    randomRangeTestForInteger(MIN_UINT32, MAX_UINT32, binding.basic_types_number.createNumberFromExistingValue);
+    assert.strictEqual(MIN_UINT32, binding.basic_types_number.createNumberFromExistingValue(MIN_UINT32));
+    assert.strictEqual(MAX_UINT32, binding.basic_types_number.createNumberFromExistingValue(MAX_UINT32));
+    randomRangeTestForInteger(MIN_INT64, MAX_INT64, binding.basic_types_number.createNumberFromExistingValue);
+    assert.strictEqual(MIN_INT64, binding.basic_types_number.createNumberFromExistingValue(MIN_INT64));
+    assert.strictEqual(MAX_INT64, binding.basic_types_number.createNumberFromExistingValue(MAX_INT64));
+    assert.strictEqual(MIN_FLOAT, binding.basic_types_number.createNumberFromExistingValue(MIN_FLOAT));
+    assert.strictEqual(MAX_FLOAT, binding.basic_types_number.createNumberFromExistingValue(MAX_FLOAT));
+    assert.strictEqual(MIN_DOUBLE, binding.basic_types_number.createNumberFromExistingValue(MIN_DOUBLE));
+    assert.strictEqual(MAX_DOUBLE, binding.basic_types_number.createNumberFromExistingValue(MAX_DOUBLE));
   }
 }

--- a/test/basic_types/value.cc
+++ b/test/basic_types/value.cc
@@ -12,7 +12,7 @@ Value CreateExternal(const CallbackInfo& info) {
   return External<int>::New(info.Env(), &testData);
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 static Value StrictlyEquals(const CallbackInfo& info) {
   bool strictlyEquals = info[0].StrictEquals(info[1]);

--- a/test/bigint.cc
+++ b/test/bigint.cc
@@ -59,7 +59,8 @@ Value TestWords(const CallbackInfo& info) {
   big.ToWords(&sign_bit, &word_count, words);
 
   if (word_count != expected_word_count) {
-    Error::New(info.Env(), "word count did not match").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "word count did not match")
+        .ThrowAsJavaScriptException();
     return BigInt();
   }
 

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -43,7 +43,7 @@ Object InitName(Env env);
 Object InitObject(Env env);
 #ifndef NODE_ADDON_API_DISABLE_DEPRECATED
 Object InitObjectDeprecated(Env env);
-#endif // !NODE_ADDON_API_DISABLE_DEPRECATED
+#endif  // !NODE_ADDON_API_DISABLE_DEPRECATED
 Object InitPromise(Env env);
 Object InitRunScript(Env env);
 #if (NAPI_VERSION > 3)
@@ -126,13 +126,14 @@ Object Init(Env env, Object exports) {
   exports.Set("object", InitObject(env));
 #ifndef NODE_ADDON_API_DISABLE_DEPRECATED
   exports.Set("object_deprecated", InitObjectDeprecated(env));
-#endif // !NODE_ADDON_API_DISABLE_DEPRECATED
+#endif  // !NODE_ADDON_API_DISABLE_DEPRECATED
   exports.Set("promise", InitPromise(env));
   exports.Set("run_script", InitRunScript(env));
   exports.Set("symbol", InitSymbol(env));
 #if (NAPI_VERSION > 3)
   exports.Set("threadsafe_function_ctx", InitThreadSafeFunctionCtx(env));
-  exports.Set("threadsafe_function_existing_tsfn", InitThreadSafeFunctionExistingTsfn(env));
+  exports.Set("threadsafe_function_existing_tsfn",
+              InitThreadSafeFunctionExistingTsfn(env));
   exports.Set("threadsafe_function_ptr", InitThreadSafeFunctionPtr(env));
   exports.Set("threadsafe_function_sum", InitThreadSafeFunctionSum(env));
   exports.Set("threadsafe_function_unref", InitThreadSafeFunctionUnref(env));
@@ -152,10 +153,11 @@ Object Init(Env env, Object exports) {
   exports.Set("typedarray", InitTypedArray(env));
   exports.Set("objectwrap", InitObjectWrap(env));
   exports.Set("objectwrapConstructorException",
-      InitObjectWrapConstructorException(env));
+              InitObjectWrapConstructorException(env));
   exports.Set("objectwrap_function", InitObjectWrapFunction(env));
   exports.Set("objectwrap_removewrap", InitObjectWrapRemoveWrap(env));
-  exports.Set("objectwrap_multiple_inheritance", InitObjectWrapMultipleInheritance(env));
+  exports.Set("objectwrap_multiple_inheritance",
+              InitObjectWrapMultipleInheritance(env));
   exports.Set("objectreference", InitObjectReference(env));
   exports.Set("reference", InitReference(env));
   exports.Set("version_management", InitVersionManagement(env));

--- a/test/buffer.cc
+++ b/test/buffer.cc
@@ -29,7 +29,8 @@ Value CreateBuffer(const CallbackInfo& info) {
   Buffer<uint16_t> buffer = Buffer<uint16_t>::New(info.Env(), testLength);
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
@@ -40,18 +41,18 @@ Value CreateBuffer(const CallbackInfo& info) {
 Value CreateExternalBuffer(const CallbackInfo& info) {
   finalizeCount = 0;
 
-  Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
-    info.Env(),
-    testData,
-    testLength);
+  Buffer<uint16_t> buffer =
+      Buffer<uint16_t>::New(info.Env(), testData, testLength);
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
   if (buffer.Data() != testData) {
-    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer data.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
@@ -65,21 +66,20 @@ Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
   uint16_t* data = new uint16_t[testLength];
 
   Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
-    info.Env(),
-    data,
-    testLength,
-    [](Env /*env*/, uint16_t* finalizeData) {
-      delete[] finalizeData;
-      finalizeCount++;
-    });
+      info.Env(), data, testLength, [](Env /*env*/, uint16_t* finalizeData) {
+        delete[] finalizeData;
+        finalizeCount++;
+      });
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
   if (buffer.Data() != data) {
-    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer data.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
@@ -94,22 +94,24 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
 
   char* hint = nullptr;
   Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
-    info.Env(),
-    data,
-    testLength,
-    [](Env /*env*/, uint16_t* finalizeData, char* /*finalizeHint*/) {
-      delete[] finalizeData;
-      finalizeCount++;
-    },
-    hint);
+      info.Env(),
+      data,
+      testLength,
+      [](Env /*env*/, uint16_t* finalizeData, char* /*finalizeHint*/) {
+        delete[] finalizeData;
+        finalizeCount++;
+      },
+      hint);
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
   if (buffer.Data() != data) {
-    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer data.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
@@ -120,21 +122,24 @@ Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
 Value CreateBufferCopy(const CallbackInfo& info) {
   InitData(testData, testLength);
 
-  Buffer<uint16_t> buffer = Buffer<uint16_t>::Copy(
-    info.Env(), testData, testLength);
+  Buffer<uint16_t> buffer =
+      Buffer<uint16_t>::Copy(info.Env(), testData, testLength);
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
   if (buffer.Data() == testData) {
-    Error::New(info.Env(), "Copy should have different memory.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Copy should have different memory.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
   if (!VerifyData(buffer.Data(), buffer.Length())) {
-    Error::New(info.Env(), "Copy data is incorrect.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Copy data is incorrect.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 
@@ -143,28 +148,31 @@ Value CreateBufferCopy(const CallbackInfo& info) {
 
 void CheckBuffer(const CallbackInfo& info) {
   if (!info[0].IsBuffer()) {
-    Error::New(info.Env(), "A buffer was expected.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "A buffer was expected.")
+        .ThrowAsJavaScriptException();
     return;
   }
 
   Buffer<uint16_t> buffer = info[0].As<Buffer<uint16_t>>();
 
   if (buffer.Length() != testLength) {
-    Error::New(info.Env(), "Incorrect buffer length.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer length.")
+        .ThrowAsJavaScriptException();
     return;
   }
 
   if (!VerifyData(buffer.Data(), testLength)) {
-    Error::New(info.Env(), "Incorrect buffer data.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Incorrect buffer data.")
+        .ThrowAsJavaScriptException();
     return;
   }
 }
 
 Value GetFinalizeCount(const CallbackInfo& info) {
-   return Number::New(info.Env(), finalizeCount);
+  return Number::New(info.Env(), finalizeCount);
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitBuffer(Env env) {
   Object exports = Object::New(env);
@@ -172,9 +180,9 @@ Object InitBuffer(Env env) {
   exports["createBuffer"] = Function::New(env, CreateBuffer);
   exports["createExternalBuffer"] = Function::New(env, CreateExternalBuffer);
   exports["createExternalBufferWithFinalize"] =
-    Function::New(env, CreateExternalBufferWithFinalize);
+      Function::New(env, CreateExternalBufferWithFinalize);
   exports["createExternalBufferWithFinalizeHint"] =
-    Function::New(env, CreateExternalBufferWithFinalizeHint);
+      Function::New(env, CreateExternalBufferWithFinalizeHint);
   exports["createBufferCopy"] = Function::New(env, CreateBufferCopy);
   exports["checkBuffer"] = Function::New(env, CheckBuffer);
   exports["getFinalizeCount"] = Function::New(env, GetFinalizeCount);

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -6,7 +6,7 @@ const safeBuffer = require('safe-buffer');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   return testUtil.runGCTests([
     'Internal Buffer',
     () => {
@@ -34,8 +34,8 @@ function test(binding) {
       assert.strictEqual(0, binding.buffer.getFinalizeCount());
     },
     () => {
-        global.gc();
-        assert.strictEqual(0, binding.buffer.getFinalizeCount());
+      global.gc();
+      assert.strictEqual(0, binding.buffer.getFinalizeCount());
     },
 
     'External Buffer with finalizer',
@@ -46,24 +46,24 @@ function test(binding) {
       assert.strictEqual(0, binding.buffer.getFinalizeCount());
     },
     () => {
-        global.gc();
+      global.gc();
     },
     () => {
-        assert.strictEqual(1, binding.buffer.getFinalizeCount());
+      assert.strictEqual(1, binding.buffer.getFinalizeCount());
     },
 
     'External Buffer with finalizer hint',
     () => {
-        const test = binding.buffer.createExternalBufferWithFinalizeHint();
-        binding.buffer.checkBuffer(test);
-        assert.ok(test instanceof Buffer);
-        assert.strictEqual(0, binding.buffer.getFinalizeCount());
+      const test = binding.buffer.createExternalBufferWithFinalizeHint();
+      binding.buffer.checkBuffer(test);
+      assert.ok(test instanceof Buffer);
+      assert.strictEqual(0, binding.buffer.getFinalizeCount());
     },
     () => {
-        global.gc();
+      global.gc();
     },
     () => {
-        assert.strictEqual(1, binding.buffer.getFinalizeCount());
-    },
+      assert.strictEqual(1, binding.buffer.getFinalizeCount());
+    }
   ]);
 }

--- a/test/callbackscope.cc
+++ b/test/callbackscope.cc
@@ -12,7 +12,7 @@ static void RunInCallbackScope(const CallbackInfo& info) {
   callback.Call({});
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitCallbackScope(Env env) {
   Object exports = Object::New(env);

--- a/test/callbackscope.js
+++ b/test/callbackscope.js
@@ -3,9 +3,9 @@ const assert = require('assert');
 
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
-const nodeVersion = process.versions.node.split('.')[0]
-let async_hooks = undefined;
-function checkAsyncHooks() {
+const nodeVersion = process.versions.node.split('.')[0];
+let async_hooks;
+function checkAsyncHooks () {
   if (nodeVersion >= 8) {
     if (async_hooks == undefined) {
       async_hooks = require('async_hooks');
@@ -17,30 +17,27 @@ function checkAsyncHooks() {
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
-  if (!checkAsyncHooks())
-    return;
+function test (binding) {
+  if (!checkAsyncHooks()) { return; }
 
   let id;
   let insideHook = false;
   const hook = async_hooks.createHook({
-    init(asyncId, type, triggerAsyncId, resource) {
+    init (asyncId, type, triggerAsyncId, resource) {
       if (id === undefined && type === 'callback_scope_test') {
         id = asyncId;
       }
     },
-    before(asyncId) {
-      if (asyncId === id)
-        insideHook = true;
+    before (asyncId) {
+      if (asyncId === id) { insideHook = true; }
     },
-    after(asyncId) {
-      if (asyncId === id)
-        insideHook = false;
+    after (asyncId) {
+      if (asyncId === id) { insideHook = false; }
     }
   }).enable();
 
   return new Promise(resolve => {
-    binding.callbackscope.runInCallbackScope(function() {
+    binding.callbackscope.runInCallbackScope(function () {
       assert(insideHook);
       hook.disable();
       resolve();

--- a/test/callbackscope.js
+++ b/test/callbackscope.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
 const nodeVersion = process.versions.node.split('.')[0];
-let async_hooks;
+let asyncHooks;
 function checkAsyncHooks () {
   if (nodeVersion >= 8) {
-    if (async_hooks == undefined) {
-      async_hooks = require('async_hooks');
+    if (asyncHooks === undefined) {
+      asyncHooks = require('async_hooks');
     }
     return true;
   }
@@ -22,7 +22,7 @@ function test (binding) {
 
   let id;
   let insideHook = false;
-  const hook = async_hooks.createHook({
+  const hook = asyncHooks.createHook({
     init (asyncId, type, triggerAsyncId, resource) {
       if (id === undefined && type === 'callback_scope_test') {
         id = asyncId;

--- a/test/dataview/dataview.js
+++ b/test/dataview/dataview.js
@@ -3,18 +3,18 @@
 const assert = require('assert');
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testDataViewCreation(factory, arrayBuffer, offset, length) {
+function test (binding) {
+  function testDataViewCreation (factory, arrayBuffer, offset, length) {
     const view = factory(arrayBuffer, offset, length);
-    offset = offset ? offset : 0;
+    offset = offset || 0;
     assert.ok(dataview.getArrayBuffer(view) instanceof ArrayBuffer);
     assert.strictEqual(dataview.getArrayBuffer(view), arrayBuffer);
     assert.strictEqual(dataview.getByteOffset(view), offset);
     assert.strictEqual(dataview.getByteLength(view),
-        length ? length : arrayBuffer.byteLength - offset);
+      length || arrayBuffer.byteLength - offset);
   }
 
-  function testInvalidRange(factory, arrayBuffer, offset, length) {
+  function testInvalidRange (factory, arrayBuffer, offset, length) {
     assert.throws(() => {
       factory(arrayBuffer, offset, length);
     }, RangeError);

--- a/test/dataview/dataview_read_write.js
+++ b/test/dataview/dataview_read_write.js
@@ -4,52 +4,52 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function expected(type, value) {
+function test (binding) {
+  function expected (type, value) {
     return eval(`(new ${type}Array([${value}]))[0]`);
   }
 
-  function nativeReadDataView(dataview, type, offset, value) {
+  function nativeReadDataView (dataview, type, offset, value) {
     return eval(`binding.dataview_read_write.get${type}(dataview, offset)`);
   }
 
-  function nativeWriteDataView(dataview, type, offset, value) {
+  function nativeWriteDataView (dataview, type, offset, value) {
     eval(`binding.dataview_read_write.set${type}(dataview, offset, value)`);
   }
 
-  function isLittleEndian() {
+  function isLittleEndian () {
     const buffer = new ArrayBuffer(2);
     new DataView(buffer).setInt16(0, 256, true /* littleEndian */);
     return new Int16Array(buffer)[0] === 256;
   }
 
-  function jsReadDataView(dataview, type, offset, value) {
+  function jsReadDataView (dataview, type, offset, value) {
     return eval(`dataview.get${type}(offset, isLittleEndian())`);
   }
 
-  function jsWriteDataView(dataview, type, offset, value) {
+  function jsWriteDataView (dataview, type, offset, value) {
     eval(`dataview.set${type}(offset, value, isLittleEndian())`);
   }
 
-  function testReadData(dataview, type, offset, value) {
+  function testReadData (dataview, type, offset, value) {
     jsWriteDataView(dataview, type, offset, 0);
     assert.strictEqual(jsReadDataView(dataview, type, offset), 0);
 
     jsWriteDataView(dataview, type, offset, value);
     assert.strictEqual(
-        nativeReadDataView(dataview, type, offset), expected(type, value));
+      nativeReadDataView(dataview, type, offset), expected(type, value));
   }
 
-  function testWriteData(dataview, type, offset, value) {
+  function testWriteData (dataview, type, offset, value) {
     jsWriteDataView(dataview, type, offset, 0);
     assert.strictEqual(jsReadDataView(dataview, type, offset), 0);
 
     nativeWriteDataView(dataview, type, offset, value);
     assert.strictEqual(
-        jsReadDataView(dataview, type, offset), expected(type, value));
+      jsReadDataView(dataview, type, offset), expected(type, value));
   }
 
-  function testInvalidOffset(dataview, type, offset, value) {
+  function testInvalidOffset (dataview, type, offset, value) {
     assert.throws(() => {
       nativeReadDataView(dataview, type, offset);
     }, RangeError);

--- a/test/dataview/dataview_read_write.js
+++ b/test/dataview/dataview_read_write.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-eval */
 'use strict';
 
 const assert = require('assert');
@@ -17,6 +18,7 @@ function test (binding) {
     eval(`binding.dataview_read_write.set${type}(dataview, offset, value)`);
   }
 
+  // eslint-disable-next-line no-unused-vars
   function isLittleEndian () {
     const buffer = new ArrayBuffer(2);
     new DataView(buffer).setInt16(0, 256, true /* littleEndian */);

--- a/test/date.cc
+++ b/test/date.cc
@@ -26,7 +26,8 @@ Value ValueOf(const CallbackInfo& info) {
 Value OperatorValue(const CallbackInfo& info) {
   Date input = info[0].As<Date>();
 
-  return Boolean::New(info.Env(), input.ValueOf() == static_cast<double>(input));
+  return Boolean::New(info.Env(),
+                      input.ValueOf() == static_cast<double>(input));
 }
 
 }  // anonymous namespace

--- a/test/date.js
+++ b/test/date.js
@@ -4,12 +4,12 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const {
     CreateDate,
     IsDate,
     ValueOf,
-    OperatorValue,
+    OperatorValue
   } = binding.date;
   assert.deepStrictEqual(CreateDate(0), new Date(0));
   assert.strictEqual(IsDate(new Date(0)), true);

--- a/test/env_cleanup.js
+++ b/test/env_cleanup.js
@@ -3,54 +3,53 @@
 const assert = require('assert');
 
 if (process.argv[2] === 'runInChildProcess') {
-    const binding_path = process.argv[3];
-    const remove_hooks = process.argv[4] === 'true';
+  const binding_path = process.argv[3];
+  const remove_hooks = process.argv[4] === 'true';
 
-    const binding = require(binding_path);
-    const actualAdded = binding.env_cleanup.addHooks(remove_hooks);
-    const expectedAdded = remove_hooks === true ? 0 : 8;
-    assert(actualAdded === expectedAdded, 'Incorrect number of hooks added');
+  const binding = require(binding_path);
+  const actualAdded = binding.env_cleanup.addHooks(remove_hooks);
+  const expectedAdded = remove_hooks === true ? 0 : 8;
+  assert(actualAdded === expectedAdded, 'Incorrect number of hooks added');
+} else {
+  module.exports = require('./common').runTestWithBindingPath(test);
 }
-else {
-    module.exports = require('./common').runTestWithBindingPath(test);
-}
 
-function test(bindingPath) {
-    for (const remove_hooks of [false, true]) {
-        const { status, output } = require('./napi_child').spawnSync(
-            process.execPath,
-            [
-                __filename,
-                'runInChildProcess',
-                bindingPath,
-                remove_hooks,
-            ],
-            { encoding: 'utf8' }
-        );
+function test (bindingPath) {
+  for (const remove_hooks of [false, true]) {
+    const { status, output } = require('./napi_child').spawnSync(
+      process.execPath,
+      [
+        __filename,
+        'runInChildProcess',
+        bindingPath,
+        remove_hooks
+      ],
+      { encoding: 'utf8' }
+    );
 
-        const stdout = output[1].trim();
-        /**
+    const stdout = output[1].trim();
+    /**
          * There is no need to sort the lines, as per Node-API documentation:
          *  > The hooks will be called in reverse order, i.e. the most recently
          *  > added one will be called first.
         */
-        const lines = stdout.split(/[\r\n]+/);
+    const lines = stdout.split(/[\r\n]+/);
 
-        assert(status === 0, `Process aborted with status ${status}`);
+    assert(status === 0, `Process aborted with status ${status}`);
 
-        if (remove_hooks) {
-            assert.deepStrictEqual(lines, [''], 'Child process had console output when none expected')
-        } else {
-            assert.deepStrictEqual(lines, [
-                'lambda cleanup()',
-                'lambda cleanup(void)',
-                'lambda cleanup(42)',
-                'static cleanup()',
-                'static cleanup()',
-                'static cleanup(43)',
-                'static cleanup(42)',
-                'static cleanup(42)'
-            ],  'Child process console output mismisatch')
-        }
+    if (remove_hooks) {
+      assert.deepStrictEqual(lines, [''], 'Child process had console output when none expected');
+    } else {
+      assert.deepStrictEqual(lines, [
+        'lambda cleanup()',
+        'lambda cleanup(void)',
+        'lambda cleanup(42)',
+        'static cleanup()',
+        'static cleanup()',
+        'static cleanup(43)',
+        'static cleanup(42)',
+        'static cleanup(42)'
+      ], 'Child process console output mismisatch');
     }
+  }
 }

--- a/test/env_cleanup.js
+++ b/test/env_cleanup.js
@@ -3,26 +3,26 @@
 const assert = require('assert');
 
 if (process.argv[2] === 'runInChildProcess') {
-  const binding_path = process.argv[3];
-  const remove_hooks = process.argv[4] === 'true';
+  const bindingPath = process.argv[3];
+  const removeHooks = process.argv[4] === 'true';
 
-  const binding = require(binding_path);
-  const actualAdded = binding.env_cleanup.addHooks(remove_hooks);
-  const expectedAdded = remove_hooks === true ? 0 : 8;
+  const binding = require(bindingPath);
+  const actualAdded = binding.env_cleanup.addHooks(removeHooks);
+  const expectedAdded = removeHooks === true ? 0 : 8;
   assert(actualAdded === expectedAdded, 'Incorrect number of hooks added');
 } else {
   module.exports = require('./common').runTestWithBindingPath(test);
 }
 
 function test (bindingPath) {
-  for (const remove_hooks of [false, true]) {
+  for (const removeHooks of [false, true]) {
     const { status, output } = require('./napi_child').spawnSync(
       process.execPath,
       [
         __filename,
         'runInChildProcess',
         bindingPath,
-        remove_hooks
+        removeHooks
       ],
       { encoding: 'utf8' }
     );
@@ -37,7 +37,7 @@ function test (bindingPath) {
 
     assert(status === 0, `Process aborted with status ${status}`);
 
-    if (remove_hooks) {
+    if (removeHooks) {
       assert.deepStrictEqual(lines, [''], 'Child process had console output when none expected');
     } else {
       assert.deepStrictEqual(lines, [

--- a/test/error.cc
+++ b/test/error.cc
@@ -140,7 +140,7 @@ void CatchAndRethrowErrorThatEscapesScope(const CallbackInfo& info) {
   }
 }
 
-#else // NAPI_CPP_EXCEPTIONS
+#else  // NAPI_CPP_EXCEPTIONS
 
 void ThrowJSError(const CallbackInfo& info) {
   std::string message = info[0].As<String>().Utf8Value();
@@ -219,7 +219,7 @@ void CatchAndRethrowErrorThatEscapesScope(const CallbackInfo& info) {
   }
 }
 
-#endif // NAPI_CPP_EXCEPTIONS
+#endif  // NAPI_CPP_EXCEPTIONS
 
 void ThrowFatalError(const CallbackInfo& /*info*/) {
   Error::Fatal("Error::ThrowFatalError", "This is a fatal error");
@@ -261,7 +261,7 @@ void ThrowDefaultError(const CallbackInfo& info) {
   NAPI_THROW_IF_FAILED_VOID(env, status);
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitError(Env env) {
   Object exports = Object::New(env);
@@ -275,9 +275,10 @@ Object InitError(Env env) {
   exports["catchErrorMessage"] = Function::New(env, CatchErrorMessage);
   exports["doNotCatch"] = Function::New(env, DoNotCatch);
   exports["catchAndRethrowError"] = Function::New(env, CatchAndRethrowError);
-  exports["throwErrorThatEscapesScope"] = Function::New(env, ThrowErrorThatEscapesScope);
+  exports["throwErrorThatEscapesScope"] =
+      Function::New(env, ThrowErrorThatEscapesScope);
   exports["catchAndRethrowErrorThatEscapesScope"] =
-    Function::New(env, CatchAndRethrowErrorThatEscapesScope);
+      Function::New(env, CatchAndRethrowErrorThatEscapesScope);
   exports["throwFatalError"] = Function::New(env, ThrowFatalError);
   exports["throwDefaultError"] = Function::New(env, ThrowDefaultError);
   exports["resetPromises"] = Function::New(env, ResetPromises);

--- a/test/error_terminating_environment.js
+++ b/test/error_terminating_environment.js
@@ -6,10 +6,10 @@ const assert = require('assert');
 // environment without triggering any fatal errors.
 
 if (process.argv[2] === 'runInChildProcess') {
-  const binding_path = process.argv[3];
-  const index_for_test_case = Number(process.argv[4]);
+  const bindingPath = process.argv[3];
+  const indexForTestCase = Number(process.argv[4]);
 
-  const binding = require(binding_path);
+  const binding = require(bindingPath);
 
   // Use C++ promises to ensure the worker thread is terminated right
   // before running the testable code in the binding.
@@ -23,8 +23,8 @@ if (process.argv[2] === 'runInChildProcess') {
     {
       argv: [
         'runInWorkerThread',
-        binding_path,
-        index_for_test_case
+        bindingPath,
+        indexForTestCase
       ]
     }
   );
@@ -34,62 +34,60 @@ if (process.argv[2] === 'runInChildProcess') {
   worker.terminate();
 
   binding.error.releaseWorkerThread();
+} else {
+  if (process.argv[2] === 'runInWorkerThread') {
+    const bindingPath = process.argv[3];
+    const indexForTestCase = Number(process.argv[4]);
 
-  return;
-}
+    const binding = require(bindingPath);
 
-if (process.argv[2] === 'runInWorkerThread') {
-  const binding_path = process.argv[3];
-  const index_for_test_case = Number(process.argv[4]);
+    switch (indexForTestCase) {
+      case 0:
+        binding.error.throwJSError('test', true);
+        break;
+      case 1:
+        binding.error.throwTypeError('test', true);
+        break;
+      case 2:
+        binding.error.throwRangeError('test', true);
+        break;
+      case 3:
+        binding.error.throwDefaultError(false, true);
+        break;
+      case 4:
+        binding.error.throwDefaultError(true, true);
+        break;
+      default: assert.fail('Invalid index');
+    }
 
-  const binding = require(binding_path);
-
-  switch (index_for_test_case) {
-    case 0:
-      binding.error.throwJSError('test', true);
-      break;
-    case 1:
-      binding.error.throwTypeError('test', true);
-      break;
-    case 2:
-      binding.error.throwRangeError('test', true);
-      break;
-    case 3:
-      binding.error.throwDefaultError(false, true);
-      break;
-    case 4:
-      binding.error.throwDefaultError(true, true);
-      break;
-    default: assert.fail('Invalid index');
+    assert.fail('This should not be reachable');
   }
 
-  assert.fail('This should not be reachable');
-}
+  test(`./build/${buildType}/binding.node`, true);
+  test(`./build/${buildType}/binding_noexcept.node`, true);
+  test(`./build/${buildType}/binding_swallowexcept.node`, false);
+  test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
+  test(`./build/${buildType}/binding_custom_namespace.node`, true);
 
-test(`./build/${buildType}/binding.node`, true);
-test(`./build/${buildType}/binding_noexcept.node`, true);
-test(`./build/${buildType}/binding_swallowexcept.node`, false);
-test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
-test(`./build/${buildType}/binding_custom_namespace.node`, true);
+  function test (bindingPath, processShouldAbort) {
+    const numberOfTestCases = 5;
 
-function test (bindingPath, process_should_abort) {
-  const number_of_test_cases = 5;
+    for (let i = 0; i < numberOfTestCases; ++i) {
+      const childProcess = require('./napi_child').spawnSync(
+        process.execPath,
+        [
+          __filename,
+          'runInChildProcess',
+          bindingPath,
+          i
+        ]
+      );
 
-  for (let i = 0; i < number_of_test_cases; ++i) {
-    const child_process = require('./napi_child').spawnSync(
-      process.execPath,
-      [
-        __filename,
-        'runInChildProcess',
-        bindingPath,
-        i
-      ]
-    );
-
-    if (process_should_abort) {
-      assert(child_process.status !== 0, `Test case ${bindingPath} ${i} failed: Process exited with status code 0.`);
-    } else {
-      assert(child_process.status === 0, `Test case ${bindingPath} ${i} failed: Process status ${child_process.status} is non-zero`);
+      if (processShouldAbort) {
+        assert(childProcess.status !== 0, `Test case ${bindingPath} ${i} failed: Process exited with status code 0.`);
+      } else {
+        assert(childProcess.status === 0, `Test case ${bindingPath} ${i} failed: Process status ${childProcess.status} is non-zero`);
+      }
     }
   }
 }

--- a/test/error_terminating_environment.js
+++ b/test/error_terminating_environment.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'runInChildProcess') {
   // Use C++ promises to ensure the worker thread is terminated right
   // before running the testable code in the binding.
 
-  binding.error.resetPromises()
+  binding.error.resetPromises();
 
   const { Worker } = require('worker_threads');
 
@@ -24,16 +24,16 @@ if (process.argv[2] === 'runInChildProcess') {
       argv: [
         'runInWorkerThread',
         binding_path,
-        index_for_test_case,
+        index_for_test_case
       ]
     }
   );
 
-  binding.error.waitForWorkerThread()
+  binding.error.waitForWorkerThread();
 
   worker.terminate();
 
-  binding.error.releaseWorkerThread()
+  binding.error.releaseWorkerThread();
 
   return;
 }
@@ -72,7 +72,7 @@ test(`./build/${buildType}/binding_swallowexcept.node`, false);
 test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
 test(`./build/${buildType}/binding_custom_namespace.node`, true);
 
-function test(bindingPath, process_should_abort) {
+function test (bindingPath, process_should_abort) {
   const number_of_test_cases = 5;
 
   for (let i = 0; i < number_of_test_cases; ++i) {
@@ -82,7 +82,7 @@ function test(bindingPath, process_should_abort) {
         __filename,
         'runInChildProcess',
         bindingPath,
-        i,
+        i
       ]
     );
 

--- a/test/external.cc
+++ b/test/external.cc
@@ -14,66 +14,70 @@ Value CreateExternal(const CallbackInfo& info) {
 
 Value CreateExternalWithFinalize(const CallbackInfo& info) {
   finalizeCount = 0;
-  return External<int>::New(info.Env(), new int(1),
-    [](Env /*env*/, int* data) {
-      delete data;
-      finalizeCount++;
-    });
+  return External<int>::New(info.Env(), new int(1), [](Env /*env*/, int* data) {
+    delete data;
+    finalizeCount++;
+  });
 }
 
 Value CreateExternalWithFinalizeHint(const CallbackInfo& info) {
   finalizeCount = 0;
   char* hint = nullptr;
-  return External<int>::New(info.Env(), new int(1),
-    [](Env /*env*/, int* data, char* /*hint*/) {
-      delete data;
-      finalizeCount++;
-    },
-    hint);
+  return External<int>::New(
+      info.Env(),
+      new int(1),
+      [](Env /*env*/, int* data, char* /*hint*/) {
+        delete data;
+        finalizeCount++;
+      },
+      hint);
 }
 
 void CheckExternal(const CallbackInfo& info) {
-   Value arg = info[0];
-   if (arg.Type() != napi_external) {
-      Error::New(info.Env(), "An external argument was expected.").ThrowAsJavaScriptException();
-      return;
-   }
+  Value arg = info[0];
+  if (arg.Type() != napi_external) {
+    Error::New(info.Env(), "An external argument was expected.")
+        .ThrowAsJavaScriptException();
+    return;
+  }
 
-   External<int> external = arg.As<External<int>>();
-   int* externalData = external.Data();
-   if (externalData == nullptr || *externalData != 1) {
-      Error::New(info.Env(), "An external value of 1 was expected.").ThrowAsJavaScriptException();
-      return;
-   }
+  External<int> external = arg.As<External<int>>();
+  int* externalData = external.Data();
+  if (externalData == nullptr || *externalData != 1) {
+    Error::New(info.Env(), "An external value of 1 was expected.")
+        .ThrowAsJavaScriptException();
+    return;
+  }
 }
 
 Value GetFinalizeCount(const CallbackInfo& info) {
-   return Number::New(info.Env(), finalizeCount);
+  return Number::New(info.Env(), finalizeCount);
 }
 
 Value CreateExternalWithFinalizeException(const CallbackInfo& info) {
-  return External<int>::New(info.Env(), new int(1),
-    [](Env env, int* data) {
-      Error error = Error::New(env, "Finalizer exception");
-      delete data;
+  return External<int>::New(info.Env(), new int(1), [](Env env, int* data) {
+    Error error = Error::New(env, "Finalizer exception");
+    delete data;
 #ifdef NAPI_CPP_EXCEPTIONS
-      throw error;
+    throw error;
 #else
       error.ThrowAsJavaScriptException();
 #endif
-    });
+  });
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitExternal(Env env) {
   Object exports = Object::New(env);
 
   exports["createExternal"] = Function::New(env, CreateExternal);
-  exports["createExternalWithFinalize"] = Function::New(env, CreateExternalWithFinalize);
+  exports["createExternalWithFinalize"] =
+      Function::New(env, CreateExternalWithFinalize);
   exports["createExternalWithFinalizeException"] =
       Function::New(env, CreateExternalWithFinalizeException);
-  exports["createExternalWithFinalizeHint"] = Function::New(env, CreateExternalWithFinalizeHint);
+  exports["createExternalWithFinalizeHint"] =
+      Function::New(env, CreateExternalWithFinalizeHint);
   exports["checkExternal"] = Function::New(env, CheckExternal);
   exports["getFinalizeCount"] = Function::New(env, GetFinalizeCount);
 

--- a/test/external.js
+++ b/test/external.js
@@ -27,7 +27,7 @@ if (process.argv.length === 3) {
   // exception is thrown from a native `SetImmediate()` we cannot catch it
   // anywhere except in the process' `uncaughtException` handler.
   let maxGCTries = 10;
-  (function gcInterval() {
+  (function gcInterval () {
     global.gc();
     if (!interval) {
       interval = setInterval(gcInterval, 100);
@@ -42,7 +42,7 @@ if (process.argv.length === 3) {
 
 module.exports = require('./common').runTestWithBindingPath(test);
 
-function test(bindingPath) {
+function test (bindingPath) {
   const binding = require(bindingPath);
 
   const child = spawnSync(process.execPath, [
@@ -83,6 +83,6 @@ function test(bindingPath) {
     },
     () => {
       assert.strictEqual(1, binding.external.getFinalizeCount());
-    },
+    }
   ]);
 }

--- a/test/function.cc
+++ b/test/function.cc
@@ -60,13 +60,13 @@ Value CallWithArgs(const CallbackInfo& info) {
 }
 
 Value CallWithVector(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   std::vector<napi_value> args;
-   args.reserve(3);
-   args.push_back(info[1]);
-   args.push_back(info[2]);
-   args.push_back(info[3]);
-   return MaybeUnwrap(func.Call(args));
+  Function func = info[0].As<Function>();
+  std::vector<napi_value> args;
+  args.reserve(3);
+  args.push_back(info[1]);
+  args.push_back(info[2]);
+  args.push_back(info[3]);
+  return MaybeUnwrap(func.Call(args));
 }
 
 Value CallWithVectorUsingCppWrapper(const CallbackInfo& info) {
@@ -101,21 +101,21 @@ Value CallWithReceiverAndCStyleArray(const CallbackInfo& info) {
 }
 
 Value CallWithReceiverAndArgs(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   Value receiver = info[1];
-   return MaybeUnwrap(func.Call(
-       receiver, std::initializer_list<napi_value>{info[2], info[3], info[4]}));
+  Function func = info[0].As<Function>();
+  Value receiver = info[1];
+  return MaybeUnwrap(func.Call(
+      receiver, std::initializer_list<napi_value>{info[2], info[3], info[4]}));
 }
 
 Value CallWithReceiverAndVector(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   Value receiver = info[1];
-   std::vector<napi_value> args;
-   args.reserve(3);
-   args.push_back(info[2]);
-   args.push_back(info[3]);
-   args.push_back(info[4]);
-   return MaybeUnwrap(func.Call(receiver, args));
+  Function func = info[0].As<Function>();
+  Value receiver = info[1];
+  std::vector<napi_value> args;
+  args.reserve(3);
+  args.push_back(info[2]);
+  args.push_back(info[3]);
+  args.push_back(info[4]);
+  return MaybeUnwrap(func.Call(receiver, args));
 }
 
 Value CallWithReceiverAndVectorUsingCppWrapper(const CallbackInfo& info) {
@@ -130,25 +130,25 @@ Value CallWithReceiverAndVectorUsingCppWrapper(const CallbackInfo& info) {
 }
 
 Value CallWithInvalidReceiver(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   return MaybeUnwrapOr(func.Call(Value(), std::initializer_list<napi_value>{}),
-                        Value());
+  Function func = info[0].As<Function>();
+  return MaybeUnwrapOr(func.Call(Value(), std::initializer_list<napi_value>{}),
+                       Value());
 }
 
 Value CallConstructorWithArgs(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   return MaybeUnwrap(
-       func.New(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
+  Function func = info[0].As<Function>();
+  return MaybeUnwrap(
+      func.New(std::initializer_list<napi_value>{info[1], info[2], info[3]}));
 }
 
 Value CallConstructorWithVector(const CallbackInfo& info) {
-   Function func = info[0].As<Function>();
-   std::vector<napi_value> args;
-   args.reserve(3);
-   args.push_back(info[1]);
-   args.push_back(info[2]);
-   args.push_back(info[3]);
-   return MaybeUnwrap(func.New(args));
+  Function func = info[0].As<Function>();
+  std::vector<napi_value> args;
+  args.reserve(3);
+  args.push_back(info[1]);
+  args.push_back(info[2]);
+  args.push_back(info[3]);
+  return MaybeUnwrap(func.New(args));
 }
 
 Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
@@ -162,9 +162,9 @@ Value CallConstructorWithCStyleArray(const CallbackInfo& info) {
 }
 
 void IsConstructCall(const CallbackInfo& info) {
-   Function callback = info[0].As<Function>();
-   bool isConstructCall = info.IsConstructCall();
-   callback({Napi::Boolean::New(info.Env(), isConstructCall)});
+  Function callback = info[0].As<Function>();
+  bool isConstructCall = info.IsConstructCall();
+  callback({Napi::Boolean::New(info.Env(), isConstructCall)});
 }
 
 void MakeCallbackWithArgs(const CallbackInfo& info) {
@@ -220,18 +220,19 @@ Value CallWithFunctionOperator(const CallbackInfo& info) {
   return MaybeUnwrap(func({info[1], info[2], info[3]}));
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitFunction(Env env) {
   Object result = Object::New(env);
   Object exports = Object::New(env);
   exports["emptyConstructor"] = Function::New(env, EmptyConstructor);
   exports["voidCallback"] = Function::New(env, VoidCallback, "voidCallback");
-  exports["valueCallback"] = Function::New(env, ValueCallback, std::string("valueCallback"));
+  exports["valueCallback"] =
+      Function::New(env, ValueCallback, std::string("valueCallback"));
   exports["voidCallbackWithData"] =
-    Function::New(env, VoidCallbackWithData, nullptr, &testData);
+      Function::New(env, VoidCallbackWithData, nullptr, &testData);
   exports["valueCallbackWithData"] =
-    Function::New(env, ValueCallbackWithData, nullptr, &testData);
+      Function::New(env, ValueCallbackWithData, nullptr, &testData);
   exports["callWithArgs"] = Function::New(env, CallWithArgs);
   exports["callWithVector"] = Function::New(env, CallWithVector);
   exports["callWithVectorUsingCppWrapper"] =
@@ -239,13 +240,18 @@ Object InitFunction(Env env) {
   exports["callWithCStyleArray"] = Function::New(env, CallWithCStyleArray);
   exports["callWithReceiverAndCStyleArray"] =
       Function::New(env, CallWithReceiverAndCStyleArray);
-  exports["callWithReceiverAndArgs"] = Function::New(env, CallWithReceiverAndArgs);
-  exports["callWithReceiverAndVector"] = Function::New(env, CallWithReceiverAndVector);
+  exports["callWithReceiverAndArgs"] =
+      Function::New(env, CallWithReceiverAndArgs);
+  exports["callWithReceiverAndVector"] =
+      Function::New(env, CallWithReceiverAndVector);
   exports["callWithReceiverAndVectorUsingCppWrapper"] =
       Function::New(env, CallWithReceiverAndVectorUsingCppWrapper);
-  exports["callWithInvalidReceiver"] = Function::New(env, CallWithInvalidReceiver);
-  exports["callConstructorWithArgs"] = Function::New(env, CallConstructorWithArgs);
-  exports["callConstructorWithVector"] = Function::New(env, CallConstructorWithVector);
+  exports["callWithInvalidReceiver"] =
+      Function::New(env, CallWithInvalidReceiver);
+  exports["callConstructorWithArgs"] =
+      Function::New(env, CallConstructorWithArgs);
+  exports["callConstructorWithVector"] =
+      Function::New(env, CallConstructorWithVector);
   exports["callConstructorWithCStyleArray"] =
       Function::New(env, CallConstructorWithCStyleArray);
   exports["isConstructCall"] = Function::New(env, IsConstructCall);

--- a/test/globalObject/global_object_delete_property.js
+++ b/test/globalObject/global_object_delete_property.js
@@ -4,58 +4,55 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-    const KEY_TYPE = {
-        C_STR: 'KEY_AS_C_STRING',
-        CPP_STR: 'KEY_AS_CPP_STRING',
-        NAPI:  'KEY_AS_NAPI_VALUES',
-        INT_32: 'KEY_AS_INT_32_NUM'
-    };
+function test (binding) {
+  const KEY_TYPE = {
+    C_STR: 'KEY_AS_C_STRING',
+    CPP_STR: 'KEY_AS_CPP_STRING',
+    NAPI: 'KEY_AS_NAPI_VALUES',
+    INT_32: 'KEY_AS_INT_32_NUM'
+  };
 
-    function assertNotGlobalObjectHasNoProperty(key, keyType)
-    {
-        switch(keyType)
-        {
-            case KEY_TYPE.NAPI:
-                assert.notStrictEqual(binding.globalObject.hasPropertyWithNapiValue(key), true);
-                break;
+  function assertNotGlobalObjectHasNoProperty (key, keyType) {
+    switch (keyType) {
+      case KEY_TYPE.NAPI:
+        assert.notStrictEqual(binding.globalObject.hasPropertyWithNapiValue(key), true);
+        break;
 
-              case KEY_TYPE.C_STR:
-                assert.notStrictEqual(binding.globalObject.hasPropertyWithCStyleString(key), true);
-                break;
+      case KEY_TYPE.C_STR:
+        assert.notStrictEqual(binding.globalObject.hasPropertyWithCStyleString(key), true);
+        break;
 
-              case KEY_TYPE.CPP_STR:
-                assert.notStrictEqual(binding.globalObject.hasPropertyWithCppStyleString(key), true);
-                break;
+      case KEY_TYPE.CPP_STR:
+        assert.notStrictEqual(binding.globalObject.hasPropertyWithCppStyleString(key), true);
+        break;
 
-              case KEY_TYPE.INT_32:
-                assert.notStrictEqual(binding.globalObject.hasPropertyWithInt32(key), true);
-                break;
-        }
+      case KEY_TYPE.INT_32:
+        assert.notStrictEqual(binding.globalObject.hasPropertyWithInt32(key), true);
+        break;
     }
+  }
 
-    function assertErrMessageIsThrown(propertyCheckExistenceFunction, errMsg) {
-        assert.throws(() => {
-          propertyCheckExistenceFunction(undefined);
-        }, errMsg);
-    }
+  function assertErrMessageIsThrown (propertyCheckExistenceFunction, errMsg) {
+    assert.throws(() => {
+      propertyCheckExistenceFunction(undefined);
+    }, errMsg);
+  }
 
-    binding.globalObject.createMockTestObject();
+  binding.globalObject.createMockTestObject();
 
-    binding.globalObject.deletePropertyWithCStyleString('c_str_key');
-    binding.globalObject.deletePropertyWithCppStyleString('cpp_string_key');
-    binding.globalObject.deletePropertyWithCppStyleString('circular');
-    binding.globalObject.deletePropertyWithInt32(15);
-    binding.globalObject.deletePropertyWithNapiValue('2');
+  binding.globalObject.deletePropertyWithCStyleString('c_str_key');
+  binding.globalObject.deletePropertyWithCppStyleString('cpp_string_key');
+  binding.globalObject.deletePropertyWithCppStyleString('circular');
+  binding.globalObject.deletePropertyWithInt32(15);
+  binding.globalObject.deletePropertyWithNapiValue('2');
 
+  assertNotGlobalObjectHasNoProperty('c_str_key', KEY_TYPE.C_STR);
+  assertNotGlobalObjectHasNoProperty('cpp_string_key', KEY_TYPE.CPP_STR);
+  assertNotGlobalObjectHasNoProperty('circular', KEY_TYPE.CPP_STR);
+  assertNotGlobalObjectHasNoProperty(15, true);
+  assertNotGlobalObjectHasNoProperty('2', KEY_TYPE.NAPI);
 
-    assertNotGlobalObjectHasNoProperty('c_str_key',KEY_TYPE.C_STR);
-    assertNotGlobalObjectHasNoProperty('cpp_string_key',KEY_TYPE.CPP_STR);
-    assertNotGlobalObjectHasNoProperty('circular',KEY_TYPE.CPP_STR);
-    assertNotGlobalObjectHasNoProperty(15,true);
-    assertNotGlobalObjectHasNoProperty('2', KEY_TYPE.NAPI);
-
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCppStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithInt32, 'Error: A number was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCppStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithInt32, 'Error: A number was expected');
 }

--- a/test/globalObject/global_object_get_property.js
+++ b/test/globalObject/global_object_get_property.js
@@ -4,51 +4,50 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const KEY_TYPE = {
-        C_STR: 'KEY_AS_C_STRING',
-        CPP_STR: 'KEY_AS_CPP_STRING',
-        NAPI:  'KEY_AS_NAPI_VALUES',
-        INT_32: 'KEY_AS_INT_32_NUM'
-    };
+    C_STR: 'KEY_AS_C_STRING',
+    CPP_STR: 'KEY_AS_CPP_STRING',
+    NAPI: 'KEY_AS_NAPI_VALUES',
+    INT_32: 'KEY_AS_INT_32_NUM'
+  };
 
   binding.globalObject.createMockTestObject();
-  function assertGlobalObjectPropertyIs(key, attribute, keyType) {
+  function assertGlobalObjectPropertyIs (key, attribute, keyType) {
     let napiObjectAttr;
-    switch(keyType)
-      {
-        case KEY_TYPE.NAPI:
-          napiObjectAttr = binding.globalObject.getPropertyWithNapiValue(key);
-          assert.deepStrictEqual(attribute, napiObjectAttr);
-          break;
+    switch (keyType) {
+      case KEY_TYPE.NAPI:
+        napiObjectAttr = binding.globalObject.getPropertyWithNapiValue(key);
+        assert.deepStrictEqual(attribute, napiObjectAttr);
+        break;
 
-        case KEY_TYPE.C_STR:
-          napiObjectAttr = binding.globalObject.getPropertyWithCString(key);
-          assert.deepStrictEqual(attribute, napiObjectAttr);
-          break;
+      case KEY_TYPE.C_STR:
+        napiObjectAttr = binding.globalObject.getPropertyWithCString(key);
+        assert.deepStrictEqual(attribute, napiObjectAttr);
+        break;
 
-        case KEY_TYPE.CPP_STR:
-          napiObjectAttr = binding.globalObject.getPropertyWithCppString(key);
-          assert.deepStrictEqual(attribute, napiObjectAttr);
-          break;
+      case KEY_TYPE.CPP_STR:
+        napiObjectAttr = binding.globalObject.getPropertyWithCppString(key);
+        assert.deepStrictEqual(attribute, napiObjectAttr);
+        break;
 
-        case KEY_TYPE.INT_32:
-          napiObjectAttr = binding.globalObject.getPropertyWithInt32(key);
-          assert.deepStrictEqual(attribute, napiObjectAttr);
-          break;
-      }
+      case KEY_TYPE.INT_32:
+        napiObjectAttr = binding.globalObject.getPropertyWithInt32(key);
+        assert.deepStrictEqual(attribute, napiObjectAttr);
+        break;
+    }
   }
 
-  function assertErrMessageIsThrown(propertyFetchFunction, errMsg) {
+  function assertErrMessageIsThrown (propertyFetchFunction, errMsg) {
     assert.throws(() => {
       propertyFetchFunction(undefined);
     }, errMsg);
   }
 
-  assertGlobalObjectPropertyIs('2',global['2'], KEY_TYPE.NAPI);
-  assertGlobalObjectPropertyIs('c_str_key',global['c_str_key'],KEY_TYPE.C_STR);
-  assertGlobalObjectPropertyIs('cpp_string_key',global['cpp_string_key'],KEY_TYPE.CPP_STR);
-  assertGlobalObjectPropertyIs('circular',global['circular'],KEY_TYPE.CPP_STR);
+  assertGlobalObjectPropertyIs('2', global['2'], KEY_TYPE.NAPI);
+  assertGlobalObjectPropertyIs('c_str_key', global.c_str_key, KEY_TYPE.C_STR);
+  assertGlobalObjectPropertyIs('cpp_string_key', global.cpp_string_key, KEY_TYPE.CPP_STR);
+  assertGlobalObjectPropertyIs('circular', global.circular, KEY_TYPE.CPP_STR);
   assertGlobalObjectPropertyIs(15, global['15'], KEY_TYPE.INT_32);
 
   assertErrMessageIsThrown(binding.globalObject.getPropertyWithCString, 'Error: A string was expected');

--- a/test/globalObject/global_object_has_own_property.js
+++ b/test/globalObject/global_object_has_own_property.js
@@ -4,45 +4,43 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-    const KEY_TYPE = {
-        C_STR: 'KEY_AS_C_STRING',
-        CPP_STR: 'KEY_AS_CPP_STRING',
-        NAPI:  'KEY_AS_NAPI_VALUES',
-        INT_32: 'KEY_AS_INT_32_NUM'
-    };
+function test (binding) {
+  const KEY_TYPE = {
+    C_STR: 'KEY_AS_C_STRING',
+    CPP_STR: 'KEY_AS_CPP_STRING',
+    NAPI: 'KEY_AS_NAPI_VALUES',
+    INT_32: 'KEY_AS_INT_32_NUM'
+  };
 
-    function assertGlobalObjectHasProperty(key, keyType)
-    {
-        switch(keyType)
-        {
-            case KEY_TYPE.NAPI:
-                assert.strictEqual(binding.globalObject.hasPropertyWithNapiValue(key), true);
-                break;
+  function assertGlobalObjectHasProperty (key, keyType) {
+    switch (keyType) {
+      case KEY_TYPE.NAPI:
+        assert.strictEqual(binding.globalObject.hasPropertyWithNapiValue(key), true);
+        break;
 
-              case KEY_TYPE.C_STR:
-                assert.strictEqual(binding.globalObject.hasPropertyWithCStyleString(key), true);
-                break;
+      case KEY_TYPE.C_STR:
+        assert.strictEqual(binding.globalObject.hasPropertyWithCStyleString(key), true);
+        break;
 
-              case KEY_TYPE.CPP_STR:
-                assert.strictEqual(binding.globalObject.hasPropertyWithCppStyleString(key), true);
-                break;
-        }
+      case KEY_TYPE.CPP_STR:
+        assert.strictEqual(binding.globalObject.hasPropertyWithCppStyleString(key), true);
+        break;
     }
+  }
 
-    function assertErrMessageIsThrown(propertyCheckExistenceFunction, errMsg) {
-        assert.throws(() => {
-          propertyCheckExistenceFunction(undefined);
-        }, errMsg);
-    }
+  function assertErrMessageIsThrown (propertyCheckExistenceFunction, errMsg) {
+    assert.throws(() => {
+      propertyCheckExistenceFunction(undefined);
+    }, errMsg);
+  }
 
-    binding.globalObject.createMockTestObject();
-    assertGlobalObjectHasProperty('c_str_key',KEY_TYPE.C_STR);
-    assertGlobalObjectHasProperty('cpp_string_key',KEY_TYPE.CPP_STR);
-    assertGlobalObjectHasProperty('circular',KEY_TYPE.CPP_STR);
-    assertGlobalObjectHasProperty('2', KEY_TYPE.NAPI);
+  binding.globalObject.createMockTestObject();
+  assertGlobalObjectHasProperty('c_str_key', KEY_TYPE.C_STR);
+  assertGlobalObjectHasProperty('cpp_string_key', KEY_TYPE.CPP_STR);
+  assertGlobalObjectHasProperty('circular', KEY_TYPE.CPP_STR);
+  assertGlobalObjectHasProperty('2', KEY_TYPE.NAPI);
 
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCppStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.hasPropertyWithInt32, 'Error: A number was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCppStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithCStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.hasPropertyWithInt32, 'Error: A number was expected');
 }

--- a/test/globalObject/global_object_set_property.js
+++ b/test/globalObject/global_object_set_property.js
@@ -4,55 +4,53 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const KEY_TYPE = {
-        C_STR: 'KEY_AS_C_STRING',
-        CPP_STR: 'KEY_AS_CPP_STRING',
-        NAPI:  'KEY_AS_NAPI_VALUES',
-        INT_32: 'KEY_AS_INT_32_NUM'
-    };
+    C_STR: 'KEY_AS_C_STRING',
+    CPP_STR: 'KEY_AS_CPP_STRING',
+    NAPI: 'KEY_AS_NAPI_VALUES',
+    INT_32: 'KEY_AS_INT_32_NUM'
+  };
 
-    function setGlobalObjectKeyValue(key, value, keyType) {
-        switch(keyType)
-        {
-            case KEY_TYPE.CPP_STR:
-            binding.globalObject.setPropertyWithCppStyleString(key,value);
-            break;
+  function setGlobalObjectKeyValue (key, value, keyType) {
+    switch (keyType) {
+      case KEY_TYPE.CPP_STR:
+        binding.globalObject.setPropertyWithCppStyleString(key, value);
+        break;
 
-            case KEY_TYPE.C_STR:
-            binding.globalObject.setPropertyWithCStyleString(key,value);
-            break;
+      case KEY_TYPE.C_STR:
+        binding.globalObject.setPropertyWithCStyleString(key, value);
+        break;
 
-            case KEY_TYPE.INT_32:
-            binding.globalObject.setPropertyWithInt32(key,value);
-            break;
+      case KEY_TYPE.INT_32:
+        binding.globalObject.setPropertyWithInt32(key, value);
+        break;
 
-            case KEY_TYPE.NAPI:
-            binding.globalObject.setPropertyWithNapiValue(key,value);
-            break;
-        }
+      case KEY_TYPE.NAPI:
+        binding.globalObject.setPropertyWithNapiValue(key, value);
+        break;
     }
+  }
 
-    function assertErrMessageIsThrown(nativeObjectSetFunction, errMsg) {
-        assert.throws(() => {
-          nativeObjectSetFunction(undefined, 1);
-        }, errMsg);
-      }
+  function assertErrMessageIsThrown (nativeObjectSetFunction, errMsg) {
+    assert.throws(() => {
+      nativeObjectSetFunction(undefined, 1);
+    }, errMsg);
+  }
 
+  setGlobalObjectKeyValue('cKey', 'cValue', KEY_TYPE.CPP_STR);
+  setGlobalObjectKeyValue(1, 10, KEY_TYPE.INT_32);
+  setGlobalObjectKeyValue('napi_key', 'napi_value', KEY_TYPE.NAPI);
+  setGlobalObjectKeyValue('cppKey', 'cppValue', KEY_TYPE.CPP_STR);
+  setGlobalObjectKeyValue('circular', global, KEY_TYPE.NAPI);
 
-    setGlobalObjectKeyValue("cKey","cValue",KEY_TYPE.CPP_STR);
-    setGlobalObjectKeyValue(1,10,KEY_TYPE.INT_32);
-    setGlobalObjectKeyValue("napi_key","napi_value",KEY_TYPE.NAPI);
-    setGlobalObjectKeyValue("cppKey","cppValue",KEY_TYPE.CPP_STR);
-    setGlobalObjectKeyValue("circular",global,KEY_TYPE.NAPI);
+  assert.deepStrictEqual(global.circular, global);
+  assert.deepStrictEqual(global.cppKey, 'cppValue');
+  assert.deepStrictEqual(global.napi_key, 'napi_value');
+  assert.deepStrictEqual(global[1], 10);
+  assert.deepStrictEqual(global.cKey, 'cValue');
 
-    assert.deepStrictEqual(global["circular"], global);
-    assert.deepStrictEqual(global["cppKey"],"cppValue");
-    assert.deepStrictEqual(global["napi_key"],"napi_value");
-    assert.deepStrictEqual(global[1],10);
-    assert.deepStrictEqual(global["cKey"],"cValue");
-
-    assertErrMessageIsThrown(binding.globalObject.setPropertyWithCppStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.setPropertyWithCStyleString, 'Error: A string was expected');
-    assertErrMessageIsThrown(binding.globalObject.setPropertyWithInt32, 'Error: A number was expected');
+  assertErrMessageIsThrown(binding.globalObject.setPropertyWithCppStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.setPropertyWithCStyleString, 'Error: A string was expected');
+  assertErrMessageIsThrown(binding.globalObject.setPropertyWithInt32, 'Error: A number was expected');
 }

--- a/test/handlescope.cc
+++ b/test/handlescope.cc
@@ -1,7 +1,7 @@
-#include "napi.h"
-#include "string.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "napi.h"
+#include "string.h"
 
 using namespace Napi;
 
@@ -31,7 +31,7 @@ Value stressEscapeFromScope(const CallbackInfo& info) {
     snprintf(buffer, 128, "%d", i);
     std::string name = std::string("inner-scope") + std::string(buffer);
     Value newValue = String::New(info.Env(), name.c_str());
-    if (i == (LOOP_MAX -1)) {
+    if (i == (LOOP_MAX - 1)) {
       result = scope.Escape(newValue);
     }
   }

--- a/test/handlescope.js
+++ b/test/handlescope.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   assert.strictEqual(binding.handlescope.createScope(), 'scope');
   assert.strictEqual(binding.handlescope.escapeFromScope(), 'inner-scope');
   assert.strictEqual(binding.handlescope.stressEscapeFromScope(), 'inner-scope999999');
   assert.throws(() => binding.handlescope.doubleEscapeFromScope(),
-                Error,
-                ' napi_escape_handle already called on scope');
+    Error,
+    ' napi_escape_handle already called on scope');
 }

--- a/test/maybe/index.js
+++ b/test/maybe/index.js
@@ -2,7 +2,6 @@
 
 const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
-const os = require('os');
 
 const napiChild = require('../napi_child');
 

--- a/test/maybe/index.js
+++ b/test/maybe/index.js
@@ -8,13 +8,13 @@ const napiChild = require('../napi_child');
 
 module.exports = test(require(`../build/${buildType}/binding_noexcept_maybe.node`).maybe_check);
 
-function test(binding) {
+function test (binding) {
   if (process.argv.includes('child')) {
     child(binding);
     return;
   }
   const cp = napiChild.spawn(process.execPath, [__filename, 'child'], {
-    stdio: ['ignore', 'inherit', 'pipe'],
+    stdio: ['ignore', 'inherit', 'pipe']
   });
   cp.stderr.setEncoding('utf8');
   let stderr = '';
@@ -31,8 +31,8 @@ function test(binding) {
   });
 }
 
-function child(binding) {
+function child (binding) {
   binding.voidCallback(() => {
     throw new Error('foobar');
-  })
+  });
 }

--- a/test/memory_management.cc
+++ b/test/memory_management.cc
@@ -3,15 +3,16 @@
 using namespace Napi;
 
 Value externalAllocatedMemory(const CallbackInfo& info) {
-    int64_t kSize = 1024 * 1024;
-    int64_t baseline = MemoryManagement::AdjustExternalMemory(info.Env(), 0);
-    int64_t tmp = MemoryManagement::AdjustExternalMemory(info.Env(), kSize);
-    tmp = MemoryManagement::AdjustExternalMemory(info.Env(), -kSize);
-    return Boolean::New(info.Env(), tmp == baseline);
+  int64_t kSize = 1024 * 1024;
+  int64_t baseline = MemoryManagement::AdjustExternalMemory(info.Env(), 0);
+  int64_t tmp = MemoryManagement::AdjustExternalMemory(info.Env(), kSize);
+  tmp = MemoryManagement::AdjustExternalMemory(info.Env(), -kSize);
+  return Boolean::New(info.Env(), tmp == baseline);
 }
 
 Object InitMemoryManagement(Env env) {
-    Object exports = Object::New(env);
-    exports["externalAllocatedMemory"] = Function::New(env, externalAllocatedMemory);
-    return exports;
+  Object exports = Object::New(env);
+  exports["externalAllocatedMemory"] =
+      Function::New(env, externalAllocatedMemory);
+  return exports;
 }

--- a/test/memory_management.js
+++ b/test/memory_management.js
@@ -4,6 +4,6 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
-    assert.strictEqual(binding.memory_management.externalAllocatedMemory(), true)
+function test (binding) {
+  assert.strictEqual(binding.memory_management.externalAllocatedMemory(), true);
 }

--- a/test/movable_callbacks.js
+++ b/test/movable_callbacks.js
@@ -5,7 +5,7 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTest(binding => test(binding.movable_callbacks));
 
-async function test(binding) {
+async function test (binding) {
   await testUtil.runGCTests([
     'External',
     () => {

--- a/test/movable_callbacks.js
+++ b/test/movable_callbacks.js
@@ -12,7 +12,7 @@ async function test (binding) {
       const fn = common.mustCall(() => {
         // noop
       }, 1);
-      const external = binding.createExternal(fn);
+      binding.createExternal(fn);
     },
     () => {
       // noop, wait for gc

--- a/test/name.js
+++ b/test/name.js
@@ -4,13 +4,12 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const expected = '123456789';
-
 
   assert.throws(binding.name.nullStringShouldThrow, {
     name: 'Error',
-    message: 'Error in native callback',
+    message: 'Error in native callback'
   });
   assert.ok(binding.name.checkString(expected, 'utf8'));
   assert.ok(binding.name.checkString(expected, 'utf16'));

--- a/test/name.js
+++ b/test/name.js
@@ -36,6 +36,7 @@ function test (binding) {
   assert.ok(binding.name.checkString(substr2, 'utf8', 3));
   assert.ok(binding.name.checkString(substr2, 'utf16', 3));
 
+  // eslint-disable-next-line symbol-description
   assert.ok(binding.name.checkSymbol(Symbol()));
   assert.ok(binding.name.checkSymbol(Symbol('test')));
 

--- a/test/napi_child.js
+++ b/test/napi_child.js
@@ -1,12 +1,12 @@
 // Makes sure that child processes are spawned appropriately.
-exports.spawnSync = function(command, args, options) {
+exports.spawnSync = function (command, args, options) {
   if (require('../index').needsFlag) {
     args.splice(0, 0, '--napi-modules');
   }
   return require('child_process').spawnSync(command, args, options);
 };
 
-exports.spawn = function(command, args, options) {
+exports.spawn = function (command, args, options) {
   if (require('../index').needsFlag) {
     args.splice(0, 0, '--napi-modules');
   }

--- a/test/object/delete_property.js
+++ b/test/object/delete_property.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testDeleteProperty(nativeDeleteProperty) {
+function test (binding) {
+  function testDeleteProperty (nativeDeleteProperty) {
     const obj = { one: 1, two: 2 };
-    Object.defineProperty(obj, "three", {configurable: false, value: 3});
+    Object.defineProperty(obj, 'three', { configurable: false, value: 3 });
     assert.strictEqual(nativeDeleteProperty(obj, 'one'), true);
     assert.strictEqual(nativeDeleteProperty(obj, 'missing'), true);
 
@@ -17,17 +17,17 @@ function test(binding) {
     assert.deepStrictEqual(obj, { two: 2 });
   }
 
-  function testShouldThrowErrorIfKeyIsInvalid(nativeDeleteProperty) {
+  function testShouldThrowErrorIfKeyIsInvalid (nativeDeleteProperty) {
     assert.throws(() => {
       nativeDeleteProperty(undefined, 'test');
     }, /Cannot convert undefined or null to object/);
   }
 
-  const testObj = { 15 : 42 , three: 3};
+  const testObj = { 15: 42, three: 3 };
 
-  binding.object.deletePropertyWithUint32(testObj,15);
+  binding.object.deletePropertyWithUint32(testObj, 15);
 
-  assert.strictEqual(testObj.hasOwnProperty(15),false);
+  assert.strictEqual(testObj.hasOwnProperty(15), false);
 
   testDeleteProperty(binding.object.deletePropertyWithNapiValue);
   testDeleteProperty(binding.object.deletePropertyWithNapiWrapperValue);

--- a/test/object/delete_property.js
+++ b/test/object/delete_property.js
@@ -27,7 +27,7 @@ function test (binding) {
 
   binding.object.deletePropertyWithUint32(testObj, 15);
 
-  assert.strictEqual(testObj.hasOwnProperty(15), false);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(testObj, 15), false);
 
   testDeleteProperty(binding.object.deletePropertyWithNapiValue);
   testDeleteProperty(binding.object.deletePropertyWithNapiWrapperValue);

--- a/test/object/finalizer.cc
+++ b/test/object/finalizer.cc
@@ -7,23 +7,24 @@ static int dummy;
 Value AddFinalizer(const CallbackInfo& info) {
   ObjectReference* ref = new ObjectReference;
   *ref = Persistent(Object::New(info.Env()));
-  info[0]
-    .As<Object>()
-    .AddFinalizer([](Napi::Env /*env*/, ObjectReference* ref) {
-      ref->Set("finalizerCalled", true);
-      delete ref;
-    }, ref);
+  info[0].As<Object>().AddFinalizer(
+      [](Napi::Env /*env*/, ObjectReference* ref) {
+        ref->Set("finalizerCalled", true);
+        delete ref;
+      },
+      ref);
   return ref->Value();
 }
 
 Value AddFinalizerWithHint(const CallbackInfo& info) {
   ObjectReference* ref = new ObjectReference;
   *ref = Persistent(Object::New(info.Env()));
-  info[0]
-    .As<Object>()
-    .AddFinalizer([](Napi::Env /*env*/, ObjectReference* ref, int* dummy_p) {
-      ref->Set("finalizerCalledWithCorrectHint", dummy_p == &dummy);
-      delete ref;
-    }, ref, &dummy);
+  info[0].As<Object>().AddFinalizer(
+      [](Napi::Env /*env*/, ObjectReference* ref, int* dummy_p) {
+        ref->Set("finalizerCalledWithCorrectHint", dummy_p == &dummy);
+        delete ref;
+      },
+      ref,
+      &dummy);
   return ref->Value();
 }

--- a/test/object/finalizer.js
+++ b/test/object/finalizer.js
@@ -5,11 +5,11 @@ const testUtil = require('../testUtil');
 
 module.exports = require('../common').runTest(test);
 
-function createWeakRef(binding, bindingToTest) {
+function createWeakRef (binding, bindingToTest) {
   return binding.object[bindingToTest]({});
 }
 
-function test(binding) {
+function test (binding) {
   let obj1;
   let obj2;
   return testUtil.runGCTests([

--- a/test/object/get_property.js
+++ b/test/object/get_property.js
@@ -4,26 +4,26 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testGetProperty(nativeGetProperty) {
+function test (binding) {
+  function testGetProperty (nativeGetProperty) {
     const obj = { test: 1 };
     assert.strictEqual(nativeGetProperty(obj, 'test'), 1);
   }
 
-  function testShouldReturnUndefinedIfKeyIsNotPresent(nativeGetProperty) {
+  function testShouldReturnUndefinedIfKeyIsNotPresent (nativeGetProperty) {
     const obj = { };
     assert.strictEqual(nativeGetProperty(obj, 'test'), undefined);
   }
 
-  function testShouldThrowErrorIfKeyIsInvalid(nativeGetProperty) {
+  function testShouldThrowErrorIfKeyIsInvalid (nativeGetProperty) {
     assert.throws(() => {
       nativeGetProperty(undefined, 'test');
     }, /Cannot convert undefined or null to object/);
   }
 
   const testObject = { 42: 100 };
-  const property =  binding.object.getPropertyWithUint32(testObject, 42);
-  assert.strictEqual(property,100)
+  const property = binding.object.getPropertyWithUint32(testObject, 42);
+  assert.strictEqual(property, 100);
 
   const nativeFunctions = [
     binding.object.getPropertyWithNapiValue,

--- a/test/object/has_own_property.js
+++ b/test/object/has_own_property.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testHasOwnProperty(nativeHasOwnProperty) {
+function test (binding) {
+  function testHasOwnProperty (nativeHasOwnProperty) {
     const obj = { one: 1 };
 
     Object.defineProperty(obj, 'two', { value: 2 });
@@ -16,7 +16,7 @@ function test(binding) {
     assert.strictEqual(nativeHasOwnProperty(obj, 'toString'), false);
   }
 
-  function testShouldThrowErrorIfKeyIsInvalid(nativeHasOwnProperty) {
+  function testShouldThrowErrorIfKeyIsInvalid (nativeHasOwnProperty) {
     assert.throws(() => {
       nativeHasOwnProperty(undefined, 'test');
     }, /Cannot convert undefined or null to object/);

--- a/test/object/has_property.js
+++ b/test/object/has_property.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testHasProperty(nativeHasProperty) {
+function test (binding) {
+  function testHasProperty (nativeHasProperty) {
     const obj = { one: 1 };
 
     Object.defineProperty(obj, 'two', { value: 2 });
@@ -16,14 +16,14 @@ function test(binding) {
     assert.strictEqual(nativeHasProperty(obj, 'toString'), true);
   }
 
-  function testShouldThrowErrorIfKeyIsInvalid(nativeHasProperty) {
+  function testShouldThrowErrorIfKeyIsInvalid (nativeHasProperty) {
     assert.throws(() => {
       nativeHasProperty(undefined, 'test');
     }, /Cannot convert undefined or null to object/);
   }
 
   const objectWithInt32Key = { 12: 101 };
-  assert.strictEqual(binding.object.hasPropertyWithUint32(objectWithInt32Key,12),true);
+  assert.strictEqual(binding.object.hasPropertyWithUint32(objectWithInt32Key, 12), true);
 
   testHasProperty(binding.object.hasPropertyWithNapiValue);
   testHasProperty(binding.object.hasPropertyWithNapiWrapperValue);

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -56,11 +56,11 @@ struct UserDataHolder {
 };
 
 Value TestGetter(const CallbackInfo& info) {
-   return Boolean::New(info.Env(), testValue);
+  return Boolean::New(info.Env(), testValue);
 }
 
 void TestSetter(const CallbackInfo& info) {
-   testValue = info[0].As<Boolean>();
+  testValue = info[0].As<Boolean>();
 }
 
 Value TestGetterWithUserData(const CallbackInfo& info) {
@@ -74,7 +74,7 @@ void TestSetterWithUserData(const CallbackInfo& info) {
 }
 
 Value TestFunction(const CallbackInfo& info) {
-   return Boolean::New(info.Env(), true);
+  return Boolean::New(info.Env(), true);
 }
 
 Value TestFunctionWithUserData(const CallbackInfo& info) {
@@ -112,36 +112,56 @@ void DefineProperties(const CallbackInfo& info) {
 
   if (nameType.Utf8Value() == "literal") {
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(env, obj, "readonlyAccessor", TestGetter),
-      PropertyDescriptor::Accessor(env, obj, "readwriteAccessor", TestGetter, TestSetter),
-      PropertyDescriptor::Accessor(env, obj, "readonlyAccessorWithUserData", TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor(env, obj, "readwriteAccessorWithUserData", TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(env, obj, "readonlyAccessor", TestGetter),
+        PropertyDescriptor::Accessor(
+            env, obj, "readwriteAccessor", TestGetter, TestSetter),
+        PropertyDescriptor::Accessor(env,
+                                     obj,
+                                     "readonlyAccessorWithUserData",
+                                     TestGetterWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(env,
+                                     obj,
+                                     "readwriteAccessorWithUserData",
+                                     TestGetterWithUserData,
+                                     TestSetterWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Accessor<TestGetter>("readonlyAccessorT"),
-      PropertyDescriptor::Accessor<TestGetter, TestSetter>(
-          "readwriteAccessorT"),
-      PropertyDescriptor::Accessor<TestGetterWithUserData>(
-          "readonlyAccessorWithUserDataT",
-          napi_property_attributes::napi_default,
-          reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor<
-          TestGetterWithUserData,
-          TestSetterWithUserData>("readwriteAccessorWithUserDataT",
-                                  napi_property_attributes::napi_default,
-                                  reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetter>("readonlyAccessorT"),
+        PropertyDescriptor::Accessor<TestGetter, TestSetter>(
+            "readwriteAccessorT"),
+        PropertyDescriptor::Accessor<TestGetterWithUserData>(
+            "readonlyAccessorWithUserDataT",
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetterWithUserData,
+                                     TestSetterWithUserData>(
+            "readwriteAccessorWithUserDataT",
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Value("readonlyValue", trueValue),
-      PropertyDescriptor::Value("readwriteValue", trueValue, napi_writable),
-      PropertyDescriptor::Value("enumerableValue", trueValue, napi_enumerable),
-      PropertyDescriptor::Value("configurableValue", trueValue, napi_configurable),
-      PropertyDescriptor::Function(env, obj, "function", TestFunction),
-      PropertyDescriptor::Function(env, obj, "functionWithUserData", TestFunctionWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Value("readonlyValue", trueValue),
+        PropertyDescriptor::Value("readwriteValue", trueValue, napi_writable),
+        PropertyDescriptor::Value(
+            "enumerableValue", trueValue, napi_enumerable),
+        PropertyDescriptor::Value(
+            "configurableValue", trueValue, napi_configurable),
+        PropertyDescriptor::Function(env, obj, "function", TestFunction),
+        PropertyDescriptor::Function(env,
+                                     obj,
+                                     "functionWithUserData",
+                                     TestFunctionWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
     });
   } else if (nameType.Utf8Value() == "string") {
-    // VS2013 has lifetime issues when passing temporary objects into the constructor of another
-    // object. It generates code to destruct the object as soon as the constructor call returns.
-    // Since this isn't a common case for using std::string objects, I'm refactoring the test to
-    // work around the issue.
+    // VS2013 has lifetime issues when passing temporary objects into the
+    // constructor of another object. It generates code to destruct the object
+    // as soon as the constructor call returns. Since this isn't a common case
+    // for using std::string objects, I'm refactoring the test to work around
+    // the issue.
     std::string str1("readonlyAccessor");
     std::string str2("readwriteAccessor");
     std::string str1a("readonlyAccessorWithUserData");
@@ -160,66 +180,105 @@ void DefineProperties(const CallbackInfo& info) {
     std::string str8("functionWithUserData");
 
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(env, obj, str1, TestGetter),
-      PropertyDescriptor::Accessor(env, obj, str2, TestGetter, TestSetter),
-      PropertyDescriptor::Accessor(env, obj, str1a, TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor(env, obj, str2a, TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(env, obj, str1, TestGetter),
+        PropertyDescriptor::Accessor(env, obj, str2, TestGetter, TestSetter),
+        PropertyDescriptor::Accessor(env,
+                                     obj,
+                                     str1a,
+                                     TestGetterWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(env,
+                                     obj,
+                                     str2a,
+                                     TestGetterWithUserData,
+                                     TestSetterWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Accessor<TestGetter>(str1t),
-      PropertyDescriptor::Accessor<TestGetter, TestSetter>(str2t),
-      PropertyDescriptor::Accessor<TestGetterWithUserData>(str1at,
-                                         napi_property_attributes::napi_default,
-                                         reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor<
-          TestGetterWithUserData,
-          TestSetterWithUserData>(str2at,
-                                  napi_property_attributes::napi_default,
-                                  reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetter>(str1t),
+        PropertyDescriptor::Accessor<TestGetter, TestSetter>(str2t),
+        PropertyDescriptor::Accessor<TestGetterWithUserData>(
+            str1at,
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetterWithUserData,
+                                     TestSetterWithUserData>(
+            str2at,
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Value(str3, trueValue),
-      PropertyDescriptor::Value(str4, trueValue, napi_writable),
-      PropertyDescriptor::Value(str5, trueValue, napi_enumerable),
-      PropertyDescriptor::Value(str6, trueValue, napi_configurable),
-      PropertyDescriptor::Function(env, obj, str7, TestFunction),
-      PropertyDescriptor::Function(env, obj, str8, TestFunctionWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Value(str3, trueValue),
+        PropertyDescriptor::Value(str4, trueValue, napi_writable),
+        PropertyDescriptor::Value(str5, trueValue, napi_enumerable),
+        PropertyDescriptor::Value(str6, trueValue, napi_configurable),
+        PropertyDescriptor::Function(env, obj, str7, TestFunction),
+        PropertyDescriptor::Function(env,
+                                     obj,
+                                     str8,
+                                     TestFunctionWithUserData,
+                                     napi_property_attributes::napi_default,
+                                     reinterpret_cast<void*>(holder)),
     });
   } else if (nameType.Utf8Value() == "value") {
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readonlyAccessor"), TestGetter),
-      PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readwriteAccessor"), TestGetter, TestSetter),
-      PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readonlyAccessorWithUserData"), TestGetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor(env, obj,
-        Napi::String::New(env, "readwriteAccessorWithUserData"), TestGetterWithUserData, TestSetterWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(
+            env, obj, Napi::String::New(env, "readonlyAccessor"), TestGetter),
+        PropertyDescriptor::Accessor(
+            env,
+            obj,
+            Napi::String::New(env, "readwriteAccessor"),
+            TestGetter,
+            TestSetter),
+        PropertyDescriptor::Accessor(
+            env,
+            obj,
+            Napi::String::New(env, "readonlyAccessorWithUserData"),
+            TestGetterWithUserData,
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor(
+            env,
+            obj,
+            Napi::String::New(env, "readwriteAccessorWithUserData"),
+            TestGetterWithUserData,
+            TestSetterWithUserData,
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Accessor<TestGetter>(
-                                   Napi::String::New(env, "readonlyAccessorT")),
-      PropertyDescriptor::Accessor<TestGetter, TestSetter>(
-                                  Napi::String::New(env, "readwriteAccessorT")),
-      PropertyDescriptor::Accessor<TestGetterWithUserData>(
-                        Napi::String::New(env, "readonlyAccessorWithUserDataT"),
-                        napi_property_attributes::napi_default,
-                        reinterpret_cast<void*>(holder)),
-      PropertyDescriptor::Accessor<
-          TestGetterWithUserData, TestSetterWithUserData>(
-                       Napi::String::New(env, "readwriteAccessorWithUserDataT"),
-                       napi_property_attributes::napi_default,
-                       reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetter>(
+            Napi::String::New(env, "readonlyAccessorT")),
+        PropertyDescriptor::Accessor<TestGetter, TestSetter>(
+            Napi::String::New(env, "readwriteAccessorT")),
+        PropertyDescriptor::Accessor<TestGetterWithUserData>(
+            Napi::String::New(env, "readonlyAccessorWithUserDataT"),
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Accessor<TestGetterWithUserData,
+                                     TestSetterWithUserData>(
+            Napi::String::New(env, "readwriteAccessorWithUserDataT"),
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
 
-      PropertyDescriptor::Value(
-        Napi::String::New(env, "readonlyValue"), trueValue),
-      PropertyDescriptor::Value(
-        Napi::String::New(env, "readwriteValue"), trueValue, napi_writable),
-      PropertyDescriptor::Value(
-        Napi::String::New(env, "enumerableValue"), trueValue, napi_enumerable),
-      PropertyDescriptor::Value(
-        Napi::String::New(env, "configurableValue"), trueValue, napi_configurable),
-      PropertyDescriptor::Function(env, obj,
-        Napi::String::New(env, "function"), TestFunction),
-      PropertyDescriptor::Function(env, obj,
-        Napi::String::New(env, "functionWithUserData"), TestFunctionWithUserData, napi_property_attributes::napi_default, reinterpret_cast<void*>(holder)),
+        PropertyDescriptor::Value(Napi::String::New(env, "readonlyValue"),
+                                  trueValue),
+        PropertyDescriptor::Value(
+            Napi::String::New(env, "readwriteValue"), trueValue, napi_writable),
+        PropertyDescriptor::Value(Napi::String::New(env, "enumerableValue"),
+                                  trueValue,
+                                  napi_enumerable),
+        PropertyDescriptor::Value(Napi::String::New(env, "configurableValue"),
+                                  trueValue,
+                                  napi_configurable),
+        PropertyDescriptor::Function(
+            env, obj, Napi::String::New(env, "function"), TestFunction),
+        PropertyDescriptor::Function(
+            env,
+            obj,
+            Napi::String::New(env, "functionWithUserData"),
+            TestFunctionWithUserData,
+            napi_property_attributes::napi_default,
+            reinterpret_cast<void*>(holder)),
     });
   }
 }
@@ -295,36 +354,57 @@ Object InitObject(Env env) {
   exports["defineValueProperty"] = Function::New(env, DefineValueProperty);
 
   exports["getPropertyWithUint32"] = Function::New(env, GetPropertyWithUint32);
-  exports["getPropertyWithNapiValue"] = Function::New(env, GetPropertyWithNapiValue);
-  exports["getPropertyWithNapiWrapperValue"] = Function::New(env, GetPropertyWithNapiWrapperValue);
-  exports["getPropertyWithCStyleString"] = Function::New(env, GetPropertyWithCStyleString);
-  exports["getPropertyWithCppStyleString"] = Function::New(env, GetPropertyWithCppStyleString);
+  exports["getPropertyWithNapiValue"] =
+      Function::New(env, GetPropertyWithNapiValue);
+  exports["getPropertyWithNapiWrapperValue"] =
+      Function::New(env, GetPropertyWithNapiWrapperValue);
+  exports["getPropertyWithCStyleString"] =
+      Function::New(env, GetPropertyWithCStyleString);
+  exports["getPropertyWithCppStyleString"] =
+      Function::New(env, GetPropertyWithCppStyleString);
 
   exports["setPropertyWithUint32"] = Function::New(env, SetPropertyWithUint32);
-  exports["setPropertyWithNapiValue"] = Function::New(env, SetPropertyWithNapiValue);
-  exports["setPropertyWithNapiWrapperValue"] = Function::New(env, SetPropertyWithNapiWrapperValue);
-  exports["setPropertyWithCStyleString"] = Function::New(env, SetPropertyWithCStyleString);
-  exports["setPropertyWithCppStyleString"] = Function::New(env, SetPropertyWithCppStyleString);
+  exports["setPropertyWithNapiValue"] =
+      Function::New(env, SetPropertyWithNapiValue);
+  exports["setPropertyWithNapiWrapperValue"] =
+      Function::New(env, SetPropertyWithNapiWrapperValue);
+  exports["setPropertyWithCStyleString"] =
+      Function::New(env, SetPropertyWithCStyleString);
+  exports["setPropertyWithCppStyleString"] =
+      Function::New(env, SetPropertyWithCppStyleString);
 
   exports["deletePropertyWithUint32"] =
       Function::New(env, DeletePropertyWithUint32);
-  exports["deletePropertyWithNapiValue"] = Function::New(env, DeletePropertyWithNapiValue);
-  exports["deletePropertyWithNapiWrapperValue"] = Function::New(env, DeletePropertyWithNapiWrapperValue);
-  exports["deletePropertyWithCStyleString"] = Function::New(env, DeletePropertyWithCStyleString);
-  exports["deletePropertyWithCppStyleString"] = Function::New(env, DeletePropertyWithCppStyleString);
+  exports["deletePropertyWithNapiValue"] =
+      Function::New(env, DeletePropertyWithNapiValue);
+  exports["deletePropertyWithNapiWrapperValue"] =
+      Function::New(env, DeletePropertyWithNapiWrapperValue);
+  exports["deletePropertyWithCStyleString"] =
+      Function::New(env, DeletePropertyWithCStyleString);
+  exports["deletePropertyWithCppStyleString"] =
+      Function::New(env, DeletePropertyWithCppStyleString);
 
-  exports["hasOwnPropertyWithNapiValue"] = Function::New(env, HasOwnPropertyWithNapiValue);
-  exports["hasOwnPropertyWithNapiWrapperValue"] = Function::New(env, HasOwnPropertyWithNapiWrapperValue);
-  exports["hasOwnPropertyWithCStyleString"] = Function::New(env, HasOwnPropertyWithCStyleString);
-  exports["hasOwnPropertyWithCppStyleString"] = Function::New(env, HasOwnPropertyWithCppStyleString);
+  exports["hasOwnPropertyWithNapiValue"] =
+      Function::New(env, HasOwnPropertyWithNapiValue);
+  exports["hasOwnPropertyWithNapiWrapperValue"] =
+      Function::New(env, HasOwnPropertyWithNapiWrapperValue);
+  exports["hasOwnPropertyWithCStyleString"] =
+      Function::New(env, HasOwnPropertyWithCStyleString);
+  exports["hasOwnPropertyWithCppStyleString"] =
+      Function::New(env, HasOwnPropertyWithCppStyleString);
 
   exports["hasPropertyWithUint32"] = Function::New(env, HasPropertyWithUint32);
-  exports["hasPropertyWithNapiValue"] = Function::New(env, HasPropertyWithNapiValue);
-  exports["hasPropertyWithNapiWrapperValue"] = Function::New(env, HasPropertyWithNapiWrapperValue);
-  exports["hasPropertyWithCStyleString"] = Function::New(env, HasPropertyWithCStyleString);
-  exports["hasPropertyWithCppStyleString"] = Function::New(env, HasPropertyWithCppStyleString);
+  exports["hasPropertyWithNapiValue"] =
+      Function::New(env, HasPropertyWithNapiValue);
+  exports["hasPropertyWithNapiWrapperValue"] =
+      Function::New(env, HasPropertyWithNapiWrapperValue);
+  exports["hasPropertyWithCStyleString"] =
+      Function::New(env, HasPropertyWithCStyleString);
+  exports["hasPropertyWithCppStyleString"] =
+      Function::New(env, HasPropertyWithCppStyleString);
 
-  exports["createObjectUsingMagic"] = Function::New(env, CreateObjectUsingMagic);
+  exports["createObjectUsingMagic"] =
+      Function::New(env, CreateObjectUsingMagic);
 #ifdef NAPI_CPP_EXCEPTIONS
   exports["sum"] = Function::New(env, Sum);
   exports["increment"] = Function::New(env, Increment);

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -4,20 +4,20 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function assertPropertyIs(obj, key, attribute) {
+function test (binding) {
+  function assertPropertyIs (obj, key, attribute) {
     const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(propDesc[attribute]);
   }
 
-  function assertPropertyIsNot(obj, key, attribute) {
+  function assertPropertyIsNot (obj, key, attribute) {
     const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(!propDesc[attribute]);
   }
 
-  function testDefineProperties(nameType) {
+  function testDefineProperties (nameType) {
     const obj = {};
     binding.object.defineProperties(obj, nameType);
 
@@ -107,7 +107,7 @@ function test(binding) {
   }
 
   {
-    const expected = { 'one': 1, 'two': 2, 'three': 3 };
+    const expected = { one: 1, two: 2, three: 3 };
     const actual = binding.object.constructorFromObject(expected);
     assert.deepStrictEqual(actual, expected);
   }
@@ -121,8 +121,8 @@ function test(binding) {
 
   {
     const testSym = Symbol();
-    const obj = { 'one': 1, 'two': 2, 'three': 3, [testSym]: 4 };
-    var arr = binding.object.GetPropertyNames(obj);
+    const obj = { one: 1, two: 2, three: 3, [testSym]: 4 };
+    const arr = binding.object.GetPropertyNames(obj);
     assert.deepStrictEqual(arr, ['one', 'two', 'three']);
   }
 
@@ -149,7 +149,7 @@ function test(binding) {
   }
 
   {
-    function Ctor() {};
+    function Ctor () {}
 
     assert.strictEqual(binding.object.instanceOf(new Ctor(), Ctor), true);
     assert.strictEqual(binding.object.instanceOf(new Ctor(), Object), true);
@@ -158,60 +158,60 @@ function test(binding) {
   }
 
   if ('sum' in binding.object) {
-      {
-        const obj = {
-          '-forbid': -0x4B1D,
-          '-feedcode': -0xFEEDC0DE,
-          '+office': +0x0FF1CE,
-          '+forbid': +0x4B1D,
-          '+deadbeef': +0xDEADBEEF,
-          '+feedcode': +0xFEEDC0DE,
-        };
+    {
+      const obj = {
+        '-forbid': -0x4B1D,
+        '-feedcode': -0xFEEDC0DE,
+        '+office': +0x0FF1CE,
+        '+forbid': +0x4B1D,
+        '+deadbeef': +0xDEADBEEF,
+        '+feedcode': +0xFEEDC0DE
+      };
 
-        let sum = 0;
-        for (const key in obj) {
-          sum += obj[key];
-        }
-
-        assert.strictEqual(binding.object.sum(obj), sum);
+      let sum = 0;
+      for (const key in obj) {
+        sum += obj[key];
       }
 
-      {
-        const obj = new Proxy({
-          '-forbid': -0x4B1D,
-          '-feedcode': -0xFEEDC0DE,
-          '+office': +0x0FF1CE,
-          '+forbid': +0x4B1D,
-          '+deadbeef': +0xDEADBEEF,
-          '+feedcode': +0xFEEDC0DE,
-        }, {
-          getOwnPropertyDescriptor(target, p) {
-            throw new Error("getOwnPropertyDescriptor error");
-          },
-          ownKeys(target) {
-            throw new Error("ownKeys error");
-          },
-        });
+      assert.strictEqual(binding.object.sum(obj), sum);
+    }
 
-        assert.throws(() => {
-          binding.object.sum(obj);
-        }, /ownKeys error/);
+    {
+      const obj = new Proxy({
+        '-forbid': -0x4B1D,
+        '-feedcode': -0xFEEDC0DE,
+        '+office': +0x0FF1CE,
+        '+forbid': +0x4B1D,
+        '+deadbeef': +0xDEADBEEF,
+        '+feedcode': +0xFEEDC0DE
+      }, {
+        getOwnPropertyDescriptor (target, p) {
+          throw new Error('getOwnPropertyDescriptor error');
+        },
+        ownKeys (target) {
+          throw new Error('ownKeys error');
+        }
+      });
+
+      assert.throws(() => {
+        binding.object.sum(obj);
+      }, /ownKeys error/);
     }
   }
 
   if ('increment' in binding.object) {
     const obj = {
-      'a': 0,
-      'b': 1,
-      'c': 2,
+      a: 0,
+      b: 1,
+      c: 2
     };
 
     binding.object.increment(obj);
 
     assert.deepStrictEqual(obj, {
-      'a': 1,
-      'b': 2,
-      'c': 3,
+      a: 1,
+      b: 2,
+      c: 3
     });
   }
 }

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -101,6 +101,7 @@ function test (binding) {
   testDefineProperties('string');
   testDefineProperties('value');
 
+  // eslint-disable-next-line no-lone-blocks
   {
     assert.strictEqual(binding.object.emptyConstructor(true), true);
     assert.strictEqual(binding.object.emptyConstructor(false), false);
@@ -114,13 +115,13 @@ function test (binding) {
 
   {
     const obj = {};
-    const testSym = Symbol();
+    const testSym = Symbol('testSym');
     binding.object.defineValueProperty(obj, testSym, 1);
     assert.strictEqual(obj[testSym], 1);
   }
 
   {
-    const testSym = Symbol();
+    const testSym = Symbol('testSym');
     const obj = { one: 1, two: 2, three: 3, [testSym]: 4 };
     const arr = binding.object.GetPropertyNames(obj);
     assert.deepStrictEqual(arr, ['one', 'two', 'three']);

--- a/test/object/object_deprecated.cc
+++ b/test/object/object_deprecated.cc
@@ -7,15 +7,15 @@ static bool testValue = true;
 namespace {
 
 Value TestGetter(const CallbackInfo& info) {
-   return Boolean::New(info.Env(), testValue);
+  return Boolean::New(info.Env(), testValue);
 }
 
 void TestSetter(const CallbackInfo& info) {
-   testValue = info[0].As<Boolean>();
+  testValue = info[0].As<Boolean>();
 }
 
 Value TestFunction(const CallbackInfo& info) {
-   return Boolean::New(info.Env(), true);
+  return Boolean::New(info.Env(), true);
 }
 
 void DefineProperties(const CallbackInfo& info) {
@@ -25,37 +25,41 @@ void DefineProperties(const CallbackInfo& info) {
 
   if (nameType.Utf8Value() == "literal") {
     obj.DefineProperties({
-      PropertyDescriptor::Accessor("readonlyAccessor", TestGetter),
-      PropertyDescriptor::Accessor("readwriteAccessor", TestGetter, TestSetter),
-      PropertyDescriptor::Function("function", TestFunction),
+        PropertyDescriptor::Accessor("readonlyAccessor", TestGetter),
+        PropertyDescriptor::Accessor(
+            "readwriteAccessor", TestGetter, TestSetter),
+        PropertyDescriptor::Function("function", TestFunction),
     });
   } else if (nameType.Utf8Value() == "string") {
-    // VS2013 has lifetime issues when passing temporary objects into the constructor of another
-    // object. It generates code to destruct the object as soon as the constructor call returns.
-    // Since this isn't a common case for using std::string objects, I'm refactoring the test to
-    // work around the issue.
+    // VS2013 has lifetime issues when passing temporary objects into the
+    // constructor of another object. It generates code to destruct the object
+    // as soon as the constructor call returns. Since this isn't a common case
+    // for using std::string objects, I'm refactoring the test to work around
+    // the issue.
     std::string str1("readonlyAccessor");
     std::string str2("readwriteAccessor");
     std::string str7("function");
 
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(str1, TestGetter),
-      PropertyDescriptor::Accessor(str2, TestGetter, TestSetter),
-      PropertyDescriptor::Function(str7, TestFunction),
+        PropertyDescriptor::Accessor(str1, TestGetter),
+        PropertyDescriptor::Accessor(str2, TestGetter, TestSetter),
+        PropertyDescriptor::Function(str7, TestFunction),
     });
   } else if (nameType.Utf8Value() == "value") {
     obj.DefineProperties({
-      PropertyDescriptor::Accessor(
-        Napi::String::New(env, "readonlyAccessor"), TestGetter),
-      PropertyDescriptor::Accessor(
-        Napi::String::New(env, "readwriteAccessor"), TestGetter, TestSetter),
-      PropertyDescriptor::Function(
-        Napi::String::New(env, "function"), TestFunction),
+        PropertyDescriptor::Accessor(Napi::String::New(env, "readonlyAccessor"),
+                                     TestGetter),
+        PropertyDescriptor::Accessor(
+            Napi::String::New(env, "readwriteAccessor"),
+            TestGetter,
+            TestSetter),
+        PropertyDescriptor::Function(Napi::String::New(env, "function"),
+                                     TestFunction),
     });
   }
 }
 
-} // end of anonymous namespace
+}  // end of anonymous namespace
 
 Object InitObjectDeprecated(Env env) {
   Object exports = Object::New(env);

--- a/test/object/object_deprecated.js
+++ b/test/object/object_deprecated.js
@@ -4,23 +4,23 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   if (!('object_deprecated' in binding)) {
     return;
   }
-  function assertPropertyIs(obj, key, attribute) {
+  function assertPropertyIs (obj, key, attribute) {
     const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(propDesc[attribute]);
   }
 
-  function assertPropertyIsNot(obj, key, attribute) {
+  function assertPropertyIsNot (obj, key, attribute) {
     const propDesc = Object.getOwnPropertyDescriptor(obj, key);
     assert.ok(propDesc);
     assert.ok(!propDesc[attribute]);
   }
 
-  function testDefineProperties(nameType) {
+  function testDefineProperties (nameType) {
     const obj = {};
     binding.object.defineProperties(obj, nameType);
 

--- a/test/object/object_deprecated.js
+++ b/test/object/object_deprecated.js
@@ -8,11 +8,6 @@ function test (binding) {
   if (!('object_deprecated' in binding)) {
     return;
   }
-  function assertPropertyIs (obj, key, attribute) {
-    const propDesc = Object.getOwnPropertyDescriptor(obj, key);
-    assert.ok(propDesc);
-    assert.ok(propDesc[attribute]);
-  }
 
   function assertPropertyIsNot (obj, key, attribute) {
     const propDesc = Object.getOwnPropertyDescriptor(obj, key);

--- a/test/object/object_freeze_seal.js
+++ b/test/object/object_freeze_seal.js
@@ -4,58 +4,58 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-    {
-        const obj = { x: 'a', y: 'b', z: 'c' };
-        assert.strictEqual(binding.object_freeze_seal.freeze(obj), true);
-        assert.strictEqual(Object.isFrozen(obj), true);
-        assert.throws(() => {
-          obj.x = 10;
-        }, /Cannot assign to read only property 'x' of object '#<Object>/);
-        assert.throws(() => {
-          obj.w = 15;
-        }, /Cannot add property w, object is not extensible/);
-        assert.throws(() => {
-          delete obj.x;
-        }, /Cannot delete property 'x' of #<Object>/);
-    }
+function test (binding) {
+  {
+    const obj = { x: 'a', y: 'b', z: 'c' };
+    assert.strictEqual(binding.object_freeze_seal.freeze(obj), true);
+    assert.strictEqual(Object.isFrozen(obj), true);
+    assert.throws(() => {
+      obj.x = 10;
+    }, /Cannot assign to read only property 'x' of object '#<Object>/);
+    assert.throws(() => {
+      obj.w = 15;
+    }, /Cannot add property w, object is not extensible/);
+    assert.throws(() => {
+      delete obj.x;
+    }, /Cannot delete property 'x' of #<Object>/);
+  }
 
-    {
-        const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
-          preventExtensions() {
-            throw new Error('foo');
-          },
-        });
+  {
+    const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+      preventExtensions () {
+        throw new Error('foo');
+      }
+    });
 
-        assert.throws(() => {
-          binding.object_freeze_seal.freeze(obj);
-        }, /foo/);
-    }
+    assert.throws(() => {
+      binding.object_freeze_seal.freeze(obj);
+    }, /foo/);
+  }
 
-    {
-        const obj = { x: 'a', y: 'b', z: 'c' };
-        assert.strictEqual(binding.object_freeze_seal.seal(obj), true);
-        assert.strictEqual(Object.isSealed(obj), true);
-        assert.throws(() => {
-          obj.w = 'd';
-        }, /Cannot add property w, object is not extensible/);
-        assert.throws(() => {
-          delete obj.x;
-        }, /Cannot delete property 'x' of #<Object>/);
-        // Sealed objects allow updating existing properties,
-        // so this should not throw.
-        obj.x = 'd';
-    }
+  {
+    const obj = { x: 'a', y: 'b', z: 'c' };
+    assert.strictEqual(binding.object_freeze_seal.seal(obj), true);
+    assert.strictEqual(Object.isSealed(obj), true);
+    assert.throws(() => {
+      obj.w = 'd';
+    }, /Cannot add property w, object is not extensible/);
+    assert.throws(() => {
+      delete obj.x;
+    }, /Cannot delete property 'x' of #<Object>/);
+    // Sealed objects allow updating existing properties,
+    // so this should not throw.
+    obj.x = 'd';
+  }
 
-    {
-        const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
-          preventExtensions() {
-            throw new Error('foo');
-          },
-        });
+  {
+    const obj = new Proxy({ x: 'a', y: 'b', z: 'c' }, {
+      preventExtensions () {
+        throw new Error('foo');
+      }
+    });
 
-        assert.throws(() => {
-          binding.object_freeze_seal.seal(obj);
-        }, /foo/);
-    }
+    assert.throws(() => {
+      binding.object_freeze_seal.seal(obj);
+    }, /foo/);
+  }
 }

--- a/test/object/subscript_operator.js
+++ b/test/object/subscript_operator.js
@@ -4,8 +4,8 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
-  function testProperty(obj, key, value, nativeGetProperty, nativeSetProperty) {
+function test (binding) {
+  function testProperty (obj, key, value, nativeGetProperty, nativeSetProperty) {
     nativeSetProperty(obj, key, value);
     assert.strictEqual(nativeGetProperty(obj, key), value);
   }

--- a/test/object_reference.js
+++ b/test/object_reference.js
@@ -18,9 +18,9 @@ module.exports = require('./common').runTest(test);
 
 function test (binding) {
   function testCastedEqual (testToCompare) {
-    const compare_test = ['hello', 'world', '!'];
+    const compareTest = ['hello', 'world', '!'];
     if (testToCompare instanceof Array) {
-      assert.deepEqual(compare_test, testToCompare);
+      assert.deepEqual(compareTest, testToCompare);
     } else if (testToCompare instanceof String) {
       assert.deepEqual('No Referenced Value', testToCompare);
     } else {
@@ -33,7 +33,7 @@ function test (binding) {
     () => {
       binding.objectreference.setCastedObjects();
       const test = binding.objectreference.getCastedFromValue('weak');
-      const test2 = new Array();
+      const test2 = [];
       test2[0] = binding.objectreference.getCastedFromGetter('weak', 0);
       test2[1] = binding.objectreference.getCastedFromGetter('weak', 1);
       test2[2] = binding.objectreference.getCastedFromGetter('weak', 2);
@@ -46,7 +46,7 @@ function test (binding) {
     () => {
       binding.objectreference.setCastedObjects();
       const test = binding.objectreference.getCastedFromValue('persistent');
-      const test2 = new Array();
+      const test2 = [];
       test2[0] = binding.objectreference.getCastedFromGetter('persistent', 0);
       test2[1] = binding.objectreference.getCastedFromGetter('persistent', 1);
       test2[2] = binding.objectreference.getCastedFromGetter('persistent', 2);
@@ -61,7 +61,7 @@ function test (binding) {
     () => {
       binding.objectreference.setCastedObjects();
       const test = binding.objectreference.getCastedFromValue();
-      const test2 = new Array();
+      const test2 = [];
       test2[0] = binding.objectreference.getCastedFromGetter('reference', 0);
       test2[1] = binding.objectreference.getCastedFromGetter('reference', 1);
       test2[2] = binding.objectreference.getCastedFromGetter('reference', 2);

--- a/test/object_reference.js
+++ b/test/object_reference.js
@@ -16,13 +16,13 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
-  function testCastedEqual(testToCompare) {
-    var compare_test = ["hello", "world", "!"];
+function test (binding) {
+  function testCastedEqual (testToCompare) {
+    const compare_test = ['hello', 'world', '!'];
     if (testToCompare instanceof Array) {
       assert.deepEqual(compare_test, testToCompare);
     } else if (testToCompare instanceof String) {
-      assert.deepEqual("No Referenced Value", testToCompare);
+      assert.deepEqual('No Referenced Value', testToCompare);
     } else {
       assert.fail();
     }
@@ -32,11 +32,11 @@ function test(binding) {
     'Weak Casted Array',
     () => {
       binding.objectreference.setCastedObjects();
-      var test = binding.objectreference.getCastedFromValue("weak");
-      var test2 = new Array();
-      test2[0] = binding.objectreference.getCastedFromGetter("weak", 0);
-      test2[1] = binding.objectreference.getCastedFromGetter("weak", 1);
-      test2[2] = binding.objectreference.getCastedFromGetter("weak", 2);
+      const test = binding.objectreference.getCastedFromValue('weak');
+      const test2 = new Array();
+      test2[0] = binding.objectreference.getCastedFromGetter('weak', 0);
+      test2[1] = binding.objectreference.getCastedFromGetter('weak', 1);
+      test2[2] = binding.objectreference.getCastedFromGetter('weak', 2);
 
       testCastedEqual(test);
       testCastedEqual(test2);
@@ -45,11 +45,11 @@ function test(binding) {
     'Persistent Casted Array',
     () => {
       binding.objectreference.setCastedObjects();
-      const test = binding.objectreference.getCastedFromValue("persistent");
+      const test = binding.objectreference.getCastedFromValue('persistent');
       const test2 = new Array();
-      test2[0] = binding.objectreference.getCastedFromGetter("persistent", 0);
-      test2[1] = binding.objectreference.getCastedFromGetter("persistent", 1);
-      test2[2] = binding.objectreference.getCastedFromGetter("persistent", 2);
+      test2[0] = binding.objectreference.getCastedFromGetter('persistent', 0);
+      test2[1] = binding.objectreference.getCastedFromGetter('persistent', 1);
+      test2[2] = binding.objectreference.getCastedFromGetter('persistent', 2);
 
       assert.ok(test instanceof Array);
       assert.ok(test2 instanceof Array);
@@ -62,9 +62,9 @@ function test(binding) {
       binding.objectreference.setCastedObjects();
       const test = binding.objectreference.getCastedFromValue();
       const test2 = new Array();
-      test2[0] = binding.objectreference.getCastedFromGetter("reference", 0);
-      test2[1] = binding.objectreference.getCastedFromGetter("reference", 1);
-      test2[2] = binding.objectreference.getCastedFromGetter("reference", 2);
+      test2[0] = binding.objectreference.getCastedFromGetter('reference', 0);
+      test2[1] = binding.objectreference.getCastedFromGetter('reference', 1);
+      test2[2] = binding.objectreference.getCastedFromGetter('reference', 2);
 
       assert.ok(test instanceof Array);
       assert.ok(test2 instanceof Array);
@@ -74,57 +74,57 @@ function test(binding) {
 
     'Weak',
     () => {
-      binding.objectreference.setObjects("hello", "world");
-      const test = binding.objectreference.getFromValue("weak");
-      const test2 = binding.objectreference.getFromGetter("weak", "hello");
+      binding.objectreference.setObjects('hello', 'world');
+      const test = binding.objectreference.getFromValue('weak');
+      const test2 = binding.objectreference.getFromGetter('weak', 'hello');
 
-      assert.deepEqual({ hello: "world"}, test);
-      assert.equal("world", test2);
-      assert.equal(test["hello"], test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.equal('world', test2);
+      assert.equal(test.hello, test2);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world", "javascript");
-      const test = binding.objectreference.getFromValue("weak");
-      const test2 = binding.objectreference.getFromValue("weak", "hello");
+      binding.objectreference.setObjects('hello', 'world', 'javascript');
+      const test = binding.objectreference.getFromValue('weak');
+      const test2 = binding.objectreference.getFromValue('weak', 'hello');
 
-      assert.deepEqual({ hello: "world" }, test);
-      assert.deepEqual({ hello: "world" }, test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.deepEqual({ hello: 'world' }, test2);
       assert.equal(test, test2);
     },
     () => {
-      binding.objectreference.setObjects(1, "hello world");
-      const test = binding.objectreference.getFromValue("weak");
-      const test2 = binding.objectreference.getFromGetter("weak", 1);
+      binding.objectreference.setObjects(1, 'hello world');
+      const test = binding.objectreference.getFromValue('weak');
+      const test2 = binding.objectreference.getFromGetter('weak', 1);
 
-      assert.deepEqual({ 1: "hello world" }, test);
-      assert.equal("hello world", test2);
+      assert.deepEqual({ 1: 'hello world' }, test);
+      assert.equal('hello world', test2);
       assert.equal(test[1], test2);
     },
     () => {
-      binding.objectreference.setObjects(0, "hello");
-      binding.objectreference.setObjects(1, "world");
-      const test = binding.objectreference.getFromValue("weak");
-      const test2 = binding.objectreference.getFromGetter("weak", 0);
-      const test3 = binding.objectreference.getFromGetter("weak", 1);
+      binding.objectreference.setObjects(0, 'hello');
+      binding.objectreference.setObjects(1, 'world');
+      const test = binding.objectreference.getFromValue('weak');
+      const test2 = binding.objectreference.getFromGetter('weak', 0);
+      const test3 = binding.objectreference.getFromGetter('weak', 1);
 
-      assert.deepEqual({ 1: "world" }, test);
+      assert.deepEqual({ 1: 'world' }, test);
       assert.equal(undefined, test2);
-      assert.equal("world", test3);
+      assert.equal('world', test3);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world");
+      binding.objectreference.setObjects('hello', 'world');
       assert.doesNotThrow(
         () => {
-          var rcount = binding.objectreference.refObjects("weak");
+          let rcount = binding.objectreference.refObjects('weak');
           assert.equal(rcount, 1);
-          rcount = binding.objectreference.unrefObjects("weak");
+          rcount = binding.objectreference.unrefObjects('weak');
           assert.equal(rcount, 0);
         },
         Error
       );
       assert.throws(
         () => {
-          binding.objectreference.unrefObjects("weak");
+          binding.objectreference.unrefObjects('weak');
         },
         Error
       );
@@ -132,63 +132,63 @@ function test(binding) {
 
     'Persistent',
     () => {
-      binding.objectreference.setObjects("hello", "world");
-      const test = binding.objectreference.getFromValue("persistent");
-      const test2 = binding.objectreference.getFromGetter("persistent", "hello");
+      binding.objectreference.setObjects('hello', 'world');
+      const test = binding.objectreference.getFromValue('persistent');
+      const test2 = binding.objectreference.getFromGetter('persistent', 'hello');
 
-      assert.deepEqual({ hello: "world" }, test);
-      assert.equal("world", test2);
-      assert.equal(test["hello"], test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.equal('world', test2);
+      assert.equal(test.hello, test2);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world", "javascript");
-      const test = binding.objectreference.getFromValue("persistent");
-      const test2 = binding.objectreference.getFromValue("persistent", "hello");
+      binding.objectreference.setObjects('hello', 'world', 'javascript');
+      const test = binding.objectreference.getFromValue('persistent');
+      const test2 = binding.objectreference.getFromValue('persistent', 'hello');
 
-      assert.deepEqual({ hello: "world" }, test);
-      assert.deepEqual({ hello: "world" }, test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.deepEqual({ hello: 'world' }, test2);
       assert.deepEqual(test, test2);
     },
     () => {
-      binding.objectreference.setObjects(1, "hello world");
-      const test = binding.objectreference.getFromValue("persistent");
-      const test2 = binding.objectreference.getFromGetter("persistent", 1);
+      binding.objectreference.setObjects(1, 'hello world');
+      const test = binding.objectreference.getFromValue('persistent');
+      const test2 = binding.objectreference.getFromGetter('persistent', 1);
 
-      assert.deepEqual({ 1: "hello world"}, test);
-      assert.equal("hello world", test2);
+      assert.deepEqual({ 1: 'hello world' }, test);
+      assert.equal('hello world', test2);
       assert.equal(test[1], test2);
     },
     () => {
-      binding.objectreference.setObjects(0, "hello");
-      binding.objectreference.setObjects(1, "world");
-      const test = binding.objectreference.getFromValue("persistent");
-      const test2 = binding.objectreference.getFromGetter("persistent", 0);
-      const test3 = binding.objectreference.getFromGetter("persistent", 1);
+      binding.objectreference.setObjects(0, 'hello');
+      binding.objectreference.setObjects(1, 'world');
+      const test = binding.objectreference.getFromValue('persistent');
+      const test2 = binding.objectreference.getFromGetter('persistent', 0);
+      const test3 = binding.objectreference.getFromGetter('persistent', 1);
 
-      assert.deepEqual({ 1: "world"}, test);
+      assert.deepEqual({ 1: 'world' }, test);
       assert.equal(undefined, test2);
-      assert.equal("world", test3);
+      assert.equal('world', test3);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world");
+      binding.objectreference.setObjects('hello', 'world');
       assert.doesNotThrow(
         () => {
-          var rcount = binding.objectreference.unrefObjects("persistent");
+          let rcount = binding.objectreference.unrefObjects('persistent');
           assert.equal(rcount, 0);
-          rcount = binding.objectreference.refObjects("persistent");
+          rcount = binding.objectreference.refObjects('persistent');
           assert.equal(rcount, 1);
-          rcount = binding.objectreference.unrefObjects("persistent");
+          rcount = binding.objectreference.unrefObjects('persistent');
           assert.equal(rcount, 0);
-          rcount = binding.objectreference.refObjects("persistent");
+          rcount = binding.objectreference.refObjects('persistent');
           assert.equal(rcount, 1);
-          rcount = binding.objectreference.unrefObjects("persistent");
+          rcount = binding.objectreference.unrefObjects('persistent');
           assert.equal(rcount, 0);
         },
         Error
       );
       assert.throws(
         () => {
-          binding.objectreference.unrefObjects("persistent");
+          binding.objectreference.unrefObjects('persistent');
         },
         Error
       );
@@ -196,64 +196,64 @@ function test(binding) {
 
     'References',
     () => {
-      binding.objectreference.setObjects("hello", "world");
+      binding.objectreference.setObjects('hello', 'world');
       const test = binding.objectreference.getFromValue();
-      const test2 = binding.objectreference.getFromGetter("hello");
+      const test2 = binding.objectreference.getFromGetter('hello');
 
-      assert.deepEqual({ hello: "world" }, test);
-      assert.equal("world", test2);
-      assert.equal(test["hello"], test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.equal('world', test2);
+      assert.equal(test.hello, test2);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world", "javascript");
+      binding.objectreference.setObjects('hello', 'world', 'javascript');
       const test = binding.objectreference.getFromValue();
-      const test2 = binding.objectreference.getFromValue("hello");
+      const test2 = binding.objectreference.getFromValue('hello');
 
-      assert.deepEqual({ hello: "world" }, test);
-      assert.deepEqual({ hello: "world" }, test2);
+      assert.deepEqual({ hello: 'world' }, test);
+      assert.deepEqual({ hello: 'world' }, test2);
       assert.deepEqual(test, test2);
     },
     () => {
-      binding.objectreference.setObjects(1, "hello world");
+      binding.objectreference.setObjects(1, 'hello world');
       const test = binding.objectreference.getFromValue();
       const test2 = binding.objectreference.getFromGetter(1);
 
-      assert.deepEqual({ 1: "hello world"}, test);
-      assert.equal("hello world", test2);
+      assert.deepEqual({ 1: 'hello world' }, test);
+      assert.equal('hello world', test2);
       assert.equal(test[1], test2);
     },
     () => {
-      binding.objectreference.setObjects(0, "hello");
-      binding.objectreference.setObjects(1, "world");
+      binding.objectreference.setObjects(0, 'hello');
+      binding.objectreference.setObjects(1, 'world');
       const test = binding.objectreference.getFromValue();
       const test2 = binding.objectreference.getFromGetter(0);
       const test3 = binding.objectreference.getFromGetter(1);
 
-      assert.deepEqual({ 1: "world"}, test);
+      assert.deepEqual({ 1: 'world' }, test);
       assert.equal(undefined, test2);
-      assert.equal("world", test3);
+      assert.equal('world', test3);
     },
     () => {
-      binding.objectreference.setObjects("hello", "world");
+      binding.objectreference.setObjects('hello', 'world');
       assert.doesNotThrow(
         () => {
-          var rcount = binding.objectreference.unrefObjects("references");
+          let rcount = binding.objectreference.unrefObjects('references');
           assert.equal(rcount, 1);
-          rcount = binding.objectreference.refObjects("references");
+          rcount = binding.objectreference.refObjects('references');
           assert.equal(rcount, 2);
-          rcount = binding.objectreference.unrefObjects("references");
+          rcount = binding.objectreference.unrefObjects('references');
           assert.equal(rcount, 1);
-          rcount = binding.objectreference.unrefObjects("references");
+          rcount = binding.objectreference.unrefObjects('references');
           assert.equal(rcount, 0);
         },
         Error
       );
       assert.throws(
         () => {
-          binding.objectreference.unrefObjects("references");
+          binding.objectreference.unrefObjects('references');
         },
         Error
       );
     }
-  ])
-};
+  ]);
+}

--- a/test/objectwrap.cc
+++ b/test/objectwrap.cc
@@ -7,7 +7,8 @@ Napi::Value StaticGetter(const Napi::CallbackInfo& /*info*/) {
   return MaybeUnwrap(testStaticContextRef.Value().Get("value"));
 }
 
-void StaticSetter(const Napi::CallbackInfo& /*info*/, const Napi::Value& value) {
+void StaticSetter(const Napi::CallbackInfo& /*info*/,
+                  const Napi::Value& value) {
   testStaticContextRef.Value().Set("value", value);
 }
 
@@ -22,11 +23,9 @@ Napi::Value TestStaticMethodInternal(const Napi::CallbackInfo& info) {
 }
 
 class Test : public Napi::ObjectWrap<Test> {
-public:
-  Test(const Napi::CallbackInfo& info) :
-    Napi::ObjectWrap<Test>(info) {
-
-    if(info.Length() > 0) {
+ public:
+  Test(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Test>(info) {
+    if (info.Length() > 0) {
       finalizeCb_ = Napi::Persistent(info[0].As<Napi::Function>());
     }
     // Create an own instance property.
@@ -35,20 +34,19 @@ public:
                                            info.This().As<Napi::Object>(),
                                            "ownProperty",
                                            OwnPropertyGetter,
-                                           napi_enumerable, this));
+                                           napi_enumerable,
+                                           this));
 
     // Create an own instance property with a templated function.
     info.This().As<Napi::Object>().DefineProperty(
-        Napi::PropertyDescriptor::Accessor<OwnPropertyGetter>("ownPropertyT",
-                                                              napi_enumerable, this));
+        Napi::PropertyDescriptor::Accessor<OwnPropertyGetter>(
+            "ownPropertyT", napi_enumerable, this));
 
     bufref_ = Napi::Persistent(Napi::Buffer<uint8_t>::New(
         Env(),
         static_cast<uint8_t*>(malloc(1)),
         1,
-        [](Napi::Env, uint8_t* bufaddr) {
-            free(bufaddr);
-        }));
+        [](Napi::Env, uint8_t* bufaddr) { free(bufaddr); }));
   }
 
   static Napi::Value OwnPropertyGetter(const Napi::CallbackInfo& info) {
@@ -88,16 +86,16 @@ public:
             .Call(array, {}));
   }
 
-  void TestVoidMethodT(const Napi::CallbackInfo &info) {
+  void TestVoidMethodT(const Napi::CallbackInfo& info) {
     value_ = MaybeUnwrap(info[0].ToString());
   }
 
-  Napi::Value TestMethodT(const Napi::CallbackInfo &info) {
-      return Napi::String::New(info.Env(), value_);
+  Napi::Value TestMethodT(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), value_);
   }
 
   static Napi::Value TestStaticMethodT(const Napi::CallbackInfo& info) {
-      return Napi::String::New(info.Env(), s_staticMethodText);
+    return Napi::String::New(info.Env(), s_staticMethodText);
   }
 
   static void TestStaticVoidMethodT(const Napi::CallbackInfo& info) {
@@ -105,20 +103,31 @@ public:
   }
 
   static void Initialize(Napi::Env env, Napi::Object exports) {
+    Napi::Symbol kTestStaticValueInternal =
+        Napi::Symbol::New(env, "kTestStaticValueInternal");
+    Napi::Symbol kTestStaticAccessorInternal =
+        Napi::Symbol::New(env, "kTestStaticAccessorInternal");
+    Napi::Symbol kTestStaticAccessorTInternal =
+        Napi::Symbol::New(env, "kTestStaticAccessorTInternal");
+    Napi::Symbol kTestStaticMethodInternal =
+        Napi::Symbol::New(env, "kTestStaticMethodInternal");
+    Napi::Symbol kTestStaticMethodTInternal =
+        Napi::Symbol::New(env, "kTestStaticMethodTInternal");
+    Napi::Symbol kTestStaticVoidMethodTInternal =
+        Napi::Symbol::New(env, "kTestStaticVoidMethodTInternal");
 
-    Napi::Symbol kTestStaticValueInternal = Napi::Symbol::New(env, "kTestStaticValueInternal");
-    Napi::Symbol kTestStaticAccessorInternal = Napi::Symbol::New(env, "kTestStaticAccessorInternal");
-    Napi::Symbol kTestStaticAccessorTInternal = Napi::Symbol::New(env, "kTestStaticAccessorTInternal");
-    Napi::Symbol kTestStaticMethodInternal = Napi::Symbol::New(env, "kTestStaticMethodInternal");
-    Napi::Symbol kTestStaticMethodTInternal     = Napi::Symbol::New(env, "kTestStaticMethodTInternal");
-    Napi::Symbol kTestStaticVoidMethodTInternal = Napi::Symbol::New(env, "kTestStaticVoidMethodTInternal");
-
-    Napi::Symbol kTestValueInternal = Napi::Symbol::New(env, "kTestValueInternal");
-    Napi::Symbol kTestAccessorInternal = Napi::Symbol::New(env, "kTestAccessorInternal");
-    Napi::Symbol kTestAccessorTInternal = Napi::Symbol::New(env, "kTestAccessorTInternal");
-    Napi::Symbol kTestMethodInternal = Napi::Symbol::New(env, "kTestMethodInternal");
-    Napi::Symbol kTestMethodTInternal     = Napi::Symbol::New(env, "kTestMethodTInternal");
-    Napi::Symbol kTestVoidMethodTInternal = Napi::Symbol::New(env, "kTestVoidMethodTInternal");
+    Napi::Symbol kTestValueInternal =
+        Napi::Symbol::New(env, "kTestValueInternal");
+    Napi::Symbol kTestAccessorInternal =
+        Napi::Symbol::New(env, "kTestAccessorInternal");
+    Napi::Symbol kTestAccessorTInternal =
+        Napi::Symbol::New(env, "kTestAccessorTInternal");
+    Napi::Symbol kTestMethodInternal =
+        Napi::Symbol::New(env, "kTestMethodInternal");
+    Napi::Symbol kTestMethodTInternal =
+        Napi::Symbol::New(env, "kTestMethodTInternal");
+    Napi::Symbol kTestVoidMethodTInternal =
+        Napi::Symbol::New(env, "kTestVoidMethodTInternal");
 
     exports.Set(
         "Test",
@@ -237,17 +246,15 @@ public:
   }
 
   void Finalize(Napi::Env env) {
-
-    if(finalizeCb_.IsEmpty()) {
+    if (finalizeCb_.IsEmpty()) {
       return;
     }
 
     finalizeCb_.Call(env.Global(), {Napi::Boolean::New(env, true)});
     finalizeCb_.Unref();
-
   }
 
-private:
+ private:
   std::string value_;
   Napi::FunctionReference finalizeCb_;
 

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -5,7 +5,7 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   const Test = binding.objectwrap.Test;
 
   const testValue = (obj, clazz) => {
@@ -107,19 +107,19 @@ async function test(binding) {
     // for..in: object and prototype
     {
       const keys = [];
-      for (let key in obj) {
+      for (const key in obj) {
         keys.push(key);
       }
 
       assert(keys.length == 6);
       // on prototype
-      assert(keys.includes("testGetSet"));
-      assert(keys.includes("testGetter"));
-      assert(keys.includes("testValue"));
-      assert(keys.includes("testMethod"));
+      assert(keys.includes('testGetSet'));
+      assert(keys.includes('testGetter'));
+      assert(keys.includes('testValue'));
+      assert(keys.includes('testMethod'));
       // on object only
-      assert(keys.includes("ownProperty"));
-      assert(keys.includes("ownPropertyT"));
+      assert(keys.includes('ownProperty'));
+      assert(keys.includes('ownPropertyT'));
     }
   };
 
@@ -135,7 +135,7 @@ async function test(binding) {
       obj.testSetter = 'iterator';
       const values = [];
 
-      for (let item of obj) {
+      for (const item of obj) {
         values.push(item);
       }
 
@@ -146,7 +146,7 @@ async function test(binding) {
   const testStaticValue = (clazz) => {
     assert.strictEqual(clazz.testStaticValue, 'value');
     assert.strictEqual(clazz[clazz.kTestStaticValueInternal], 5);
-  }
+  };
 
   const testStaticAccessor = (clazz) => {
     // read-only, write-only
@@ -227,7 +227,7 @@ async function test(binding) {
     // for..in
     {
       const keys = [];
-      for (let key in clazz) {
+      for (const key in clazz) {
         keys.push(key);
       }
 
@@ -240,21 +240,21 @@ async function test(binding) {
     }
   };
 
-  async function testFinalize(clazz) {
+  async function testFinalize (clazz) {
     let finalizeCalled = false;
     await testUtil.runGCTests([
       'test finalize',
       () => {
-        const finalizeCb = function(called) {
+        const finalizeCb = function (called) {
           finalizeCalled = called;
         };
 
-        //Scope Test instance so that it can be gc'd.
+        // Scope Test instance so that it can be gc'd.
         (() => { new Test(finalizeCb); })();
       },
       () => assert.strictEqual(finalizeCalled, true)
     ]);
-  };
+  }
 
   const testObj = (obj, clazz) => {
     testValue(obj, clazz);
@@ -264,16 +264,16 @@ async function test(binding) {
     testEnumerables(obj, clazz);
 
     testConventions(obj, clazz);
-  }
+  };
 
-  async function testClass(clazz) {
+  async function testClass (clazz) {
     testStaticValue(clazz);
     testStaticAccessor(clazz);
     testStaticMethod(clazz);
 
     testStaticEnumerables(clazz);
     await testFinalize(clazz);
-  };
+  }
 
   // `Test` is needed for accessing exposed symbols
   testObj(new Test(), Test);

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-lone-blocks */
 'use strict';
 
 const assert = require('assert');
@@ -28,6 +29,7 @@ async function test (binding) {
     // read write-only
     {
       let error;
+      // eslint-disable-next-line no-unused-vars
       try { const read = obj.testSetter; } catch (e) { error = e; }
       // no error
       assert.strictEqual(error, undefined);
@@ -111,7 +113,7 @@ async function test (binding) {
         keys.push(key);
       }
 
-      assert(keys.length == 6);
+      assert(keys.length === 6);
       // on prototype
       assert(keys.includes('testGetSet'));
       assert(keys.includes('testGetter'));
@@ -165,6 +167,7 @@ async function test (binding) {
     // read write-only
     {
       let error;
+      // eslint-disable-next-line no-unused-vars
       try { const read = clazz.testStaticSetter; } catch (e) { error = e; }
       // no error
       assert.strictEqual(error, undefined);
@@ -250,6 +253,7 @@ async function test (binding) {
         };
 
         // Scope Test instance so that it can be gc'd.
+        // eslint-disable-next-line no-new
         (() => { new Test(finalizeCb); })();
       },
       () => assert.strictEqual(finalizeCalled, true)

--- a/test/objectwrap_constructor_exception.cc
+++ b/test/objectwrap_constructor_exception.cc
@@ -1,10 +1,10 @@
 #include <napi.h>
 
-class ConstructorExceptionTest :
-  public Napi::ObjectWrap<ConstructorExceptionTest> {
-public:
-  ConstructorExceptionTest(const Napi::CallbackInfo& info) :
-    Napi::ObjectWrap<ConstructorExceptionTest>(info) {
+class ConstructorExceptionTest
+    : public Napi::ObjectWrap<ConstructorExceptionTest> {
+ public:
+  ConstructorExceptionTest(const Napi::CallbackInfo& info)
+      : Napi::ObjectWrap<ConstructorExceptionTest>(info) {
     Napi::Error error = Napi::Error::New(info.Env(), "an exception");
 #ifdef NAPI_DISABLE_CPP_EXCEPTIONS
     error.ThrowAsJavaScriptException();

--- a/test/objectwrap_constructor_exception.js
+++ b/test/objectwrap_constructor_exception.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const testUtil = require('./testUtil');
 
-function test(binding) {
+function test (binding) {
   return testUtil.runGCTests([
     'objectwrap constructor exception',
     () => {

--- a/test/objectwrap_multiple_inheritance.cc
+++ b/test/objectwrap_multiple_inheritance.cc
@@ -1,25 +1,25 @@
 #include <napi.h>
 
 class TestMIBase {
-public:
+ public:
   TestMIBase() : test(0) {}
   virtual void dummy() {}
   uint32_t test;
 };
 
 class TestMI : public TestMIBase, public Napi::ObjectWrap<TestMI> {
-public:
-  TestMI(const Napi::CallbackInfo& info) :
-    Napi::ObjectWrap<TestMI>(info) {}
+ public:
+  TestMI(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TestMI>(info) {}
 
   Napi::Value GetTest(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), test);
   }
 
   static void Initialize(Napi::Env env, Napi::Object exports) {
-    exports.Set("TestMI", DefineClass(env, "TestMI", {
-      InstanceAccessor<&TestMI::GetTest>("test")
-    }));
+    exports.Set(
+        "TestMI",
+        DefineClass(
+            env, "TestMI", {InstanceAccessor<&TestMI::GetTest>("test")}));
   }
 };
 

--- a/test/objectwrap_multiple_inheritance.js
+++ b/test/objectwrap_multiple_inheritance.js
@@ -8,6 +8,6 @@ const test = bindingName => {
   const testmi = new TestMI();
 
   assert.strictEqual(testmi.test, 0);
-}
+};
 
 module.exports = require('./common').runTestWithBindingPath(test);

--- a/test/objectwrap_removewrap.js
+++ b/test/objectwrap_removewrap.js
@@ -11,7 +11,7 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTestWithBindingPath(test);
 
-function test(bindingName) {
+function test (bindingName) {
   return testUtil.runGCTests([
     'objectwrap removewrap test',
     () => {

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const { Worker, isMainThread, workerData } = require('worker_threads');
+const { Worker, isMainThread } = require('worker_threads');
 
 module.exports = require('./common').runTestWithBuildType(test);
 

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -4,7 +4,7 @@ const { Worker, isMainThread, workerData } = require('worker_threads');
 
 module.exports = require('./common').runTestWithBuildType(test);
 
-async function test(buildType) {
+async function test (buildType) {
   if (isMainThread) {
     const buildType = process.config.target_defaults.default_configuration;
     const worker = new Worker(__filename, { workerData: buildType });

--- a/test/promise.js
+++ b/test/promise.js
@@ -5,7 +5,7 @@ const common = require('./common');
 
 module.exports = common.runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   assert.strictEqual(binding.promise.isPromise({}), false);
 
   const resolving = binding.promise.resolvePromise('resolved');

--- a/test/reference.cc
+++ b/test/reference.cc
@@ -4,7 +4,7 @@ using namespace Napi;
 
 static Reference<Buffer<uint8_t>> weak;
 
-void  CreateWeakArray(const CallbackInfo& info) {
+void CreateWeakArray(const CallbackInfo& info) {
   weak = Weak(Buffer<uint8_t>::New(info.Env(), 1));
   weak.SuppressDestruct();
 }

--- a/test/reference.js
+++ b/test/reference.js
@@ -5,10 +5,10 @@ const testUtil = require('./testUtil');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   return testUtil.runGCTests([
     'test reference',
     () => binding.reference.createWeakArray(),
     () => assert.strictEqual(true, binding.reference.accessWeakArrayEmpty())
   ]);
-};
+}

--- a/test/run_script.cc
+++ b/test/run_script.cc
@@ -42,7 +42,7 @@ Value RunWithContext(const CallbackInfo& info) {
   return MaybeUnwrap(fn.Call(args));
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitRunScript(Env env) {
   Object exports = Object::New(env);

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -5,69 +5,61 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
+function test (binding) {
+  const majorNodeVersion = process.versions.node.split('.')[0];
 
-function test(binding)
-{
-    const majorNodeVersion = process.versions.node.split('.')[0];
+  const wellKnownSymbolFunctions = ['asyncIterator', 'hasInstance', 'isConcatSpreadable', 'iterator', 'match', 'replace', 'search', 'split', 'species', 'toPrimitive', 'toStringTag', 'unscopables'];
+  if (majorNodeVersion >= 12) {
+    wellKnownSymbolFunctions.push('matchAll');
+  }
 
-    let wellKnownSymbolFunctions = ['asyncIterator','hasInstance','isConcatSpreadable', 'iterator','match','replace','search','split','species','toPrimitive','toStringTag','unscopables'];
-    if (majorNodeVersion >= 12) {
-      wellKnownSymbolFunctions.push('matchAll');
-    }
+  function assertCanCreateSymbol (symbol) {
+    assert(binding.symbol.createNewSymbolWithCppStr(symbol) !== null);
+    assert(binding.symbol.createNewSymbolWithCStr(symbol) !== null);
+    assert(binding.symbol.createNewSymbolWithNapi(symbol) !== null);
+  }
 
-    function assertCanCreateSymbol(symbol)
-    {
-      assert(binding.symbol.createNewSymbolWithCppStr(symbol) !== null);
-      assert(binding.symbol.createNewSymbolWithCStr(symbol) !== null);
-      assert(binding.symbol.createNewSymbolWithNapi(symbol) !== null);
-    }
+  function assertSymbolAreUnique (symbol) {
+    const symbolOne = binding.symbol.createNewSymbolWithCppStr(symbol);
+    const symbolTwo = binding.symbol.createNewSymbolWithCppStr(symbol);
 
-    function assertSymbolAreUnique(symbol)
-    {
-        const symbolOne = binding.symbol.createNewSymbolWithCppStr(symbol);
-        const symbolTwo = binding.symbol.createNewSymbolWithCppStr(symbol);
+    assert(symbolOne !== symbolTwo);
+  }
 
-        assert(symbolOne !== symbolTwo);
-    }
+  function assertSymbolIsWellknown (symbol) {
+    const symbOne = binding.symbol.getWellKnownSymbol(symbol);
+    const symbTwo = binding.symbol.getWellKnownSymbol(symbol);
+    assert(symbOne && symbTwo);
+    assert(symbOne === symbTwo);
+  }
 
-    function assertSymbolIsWellknown(symbol)
-    {
-      const symbOne = binding.symbol.getWellKnownSymbol(symbol);
-      const symbTwo = binding.symbol.getWellKnownSymbol(symbol);
-      assert(symbOne && symbTwo);
-      assert(symbOne === symbTwo);
-    }
+  function assertSymbolIsNotWellknown (symbol) {
+    const symbolTest = binding.symbol.getWellKnownSymbol(symbol);
+    assert(symbolTest === undefined);
+  }
 
-    function assertSymbolIsNotWellknown(symbol)
-    {
-      const symbolTest = binding.symbol.getWellKnownSymbol(symbol);
-      assert(symbolTest === undefined);
-    }
+  function assertCanCreateOrFetchGlobalSymbols (symbol, fetchFunction) {
+    const symbOne = fetchFunction(symbol);
+    const symbTwo = fetchFunction(symbol);
+    assert(symbOne && symbTwo);
+    assert(symbOne === symbTwo);
+  }
 
-    function assertCanCreateOrFetchGlobalSymbols(symbol, fetchFunction)
-    {
-      const symbOne = fetchFunction(symbol);
-      const symbTwo = fetchFunction(symbol);
-      assert(symbOne && symbTwo);
-      assert(symbOne === symbTwo);
-    }
+  assertCanCreateSymbol('testing');
+  assertSymbolAreUnique('symbol');
+  assertSymbolIsNotWellknown('testing');
 
-    assertCanCreateSymbol("testing");
-    assertSymbolAreUnique("symbol");
-    assertSymbolIsNotWellknown("testing");
+  for (const wellknownProperty of wellKnownSymbolFunctions) {
+    assertSymbolIsWellknown(wellknownProperty);
+  }
 
-     for(const wellknownProperty of wellKnownSymbolFunctions)
-     {
-       assertSymbolIsWellknown(wellknownProperty);
-     }
+  assertCanCreateOrFetchGlobalSymbols('data', binding.symbol.getSymbolFromGlobalRegistry);
+  assertCanCreateOrFetchGlobalSymbols('CppKey', binding.symbol.getSymbolFromGlobalRegistryWithCppKey);
+  assertCanCreateOrFetchGlobalSymbols('CKey', binding.symbol.getSymbolFromGlobalRegistryWithCKey);
 
-     assertCanCreateOrFetchGlobalSymbols("data", binding.symbol.getSymbolFromGlobalRegistry);
-     assertCanCreateOrFetchGlobalSymbols("CppKey", binding.symbol.getSymbolFromGlobalRegistryWithCppKey);
-     assertCanCreateOrFetchGlobalSymbols("CKey", binding.symbol.getSymbolFromGlobalRegistryWithCKey);
+  assert(binding.symbol.createNewSymbolWithNoArgs() === undefined);
 
-    assert(binding.symbol.createNewSymbolWithNoArgs() === undefined);
-
-    assert(binding.symbol.testNullSymbolCanBeCreated() === binding.symbol.testNullSymbolCanBeCreated());
-    assert(binding.symbol.testUndefinedSymbolCanBeCreated() === binding.symbol.testUndefinedSymbolCanBeCreated());
-    assert(binding.symbol.testUndefinedSymbolCanBeCreated() !== binding.symbol.testNullSymbolCanBeCreated());
+  assert(binding.symbol.testNullSymbolCanBeCreated() === binding.symbol.testNullSymbolCanBeCreated());
+  assert(binding.symbol.testUndefinedSymbolCanBeCreated() === binding.symbol.testUndefinedSymbolCanBeCreated());
+  assert(binding.symbol.testUndefinedSymbolCanBeCreated() !== binding.symbol.testNullSymbolCanBeCreated());
 }

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
@@ -59,7 +58,9 @@ function test (binding) {
 
   assert(binding.symbol.createNewSymbolWithNoArgs() === undefined);
 
+  // eslint-disable-next-line no-self-compare
   assert(binding.symbol.testNullSymbolCanBeCreated() === binding.symbol.testNullSymbolCanBeCreated());
+  // eslint-disable-next-line no-self-compare
   assert(binding.symbol.testUndefinedSymbolCanBeCreated() === binding.symbol.testUndefinedSymbolCanBeCreated());
   assert(binding.symbol.testUndefinedSymbolCanBeCreated() !== binding.symbol.testNullSymbolCanBeCreated());
 }

--- a/test/testUtil.js
+++ b/test/testUtil.js
@@ -1,9 +1,9 @@
 // Run each test function in sequence,
 // with an async delay and GC call between each.
 
-function tick(x) {
+function tick (x) {
   return new Promise((resolve) => {
-    setImmediate(function ontick() {
+    setImmediate(function ontick () {
       if (--x === 0) {
         resolve();
       } else {
@@ -11,9 +11,9 @@ function tick(x) {
       }
     });
   });
-};
+}
 
-async function runGCTests(tests) {
+async function runGCTests (tests) {
   // Break up test list into a list of lists of the form
   // [ [ 'test name', function() {}, ... ], ..., ].
   const testList = [];
@@ -27,7 +27,7 @@ async function runGCTests(tests) {
   }
 
   for (const test of testList) {
-    await (async function(test) {
+    await (async function (test) {
       let title;
       for (let i = 0; i < test.length; i++) {
         if (i === 0) {
@@ -50,5 +50,5 @@ async function runGCTests(tests) {
 }
 
 module.exports = {
-  runGCTests,
+  runGCTests
 };

--- a/test/threadsafe_function/threadsafe_function.cc
+++ b/test/threadsafe_function/threadsafe_function.cc
@@ -15,11 +15,7 @@ static std::thread threads[2];
 static ThreadSafeFunction tsfn;
 
 struct ThreadSafeFunctionInfo {
-  enum CallType {
-    DEFAULT,
-    BLOCKING,
-    NON_BLOCKING
-  } type;
+  enum CallType { DEFAULT, BLOCKING, NON_BLOCKING } type;
   bool abort;
   bool startSecondary;
   FunctionReference jsFinalizeCallback;
@@ -55,7 +51,7 @@ static void DataSourceThread() {
   for (int index = ARRAY_LENGTH - 1; index > -1 && !queueWasClosing; index--) {
     napi_status status = napi_generic_failure;
     auto callback = [](Env env, Function jsCallback, int* data) {
-      jsCallback.Call({ Number::New(env, *data) });
+      jsCallback.Call({Number::New(env, *data)});
     };
 
     switch (info->type) {
@@ -80,20 +76,20 @@ static void DataSourceThread() {
     }
 
     switch (status) {
-    case napi_queue_full:
-      queueWasFull = true;
-      index++;
-      // fall through
+      case napi_queue_full:
+        queueWasFull = true;
+        index++;
+        // fall through
 
-    case napi_ok:
-      continue;
+      case napi_ok:
+        continue;
 
-    case napi_closing:
-      queueWasClosing = true;
-      break;
+      case napi_closing:
+        queueWasClosing = true;
+        break;
 
-    default:
-      Error::Fatal("DataSourceThread", "ThreadSafeFunction.*Call() failed");
+      default:
+        Error::Fatal("DataSourceThread", "ThreadSafeFunction.*Call() failed");
     }
   }
 
@@ -140,15 +136,21 @@ static void JoinTheThreads(Env /* env */,
 }
 
 static Value StartThreadInternal(const CallbackInfo& info,
-    ThreadSafeFunctionInfo::CallType type) {
+                                 ThreadSafeFunctionInfo::CallType type) {
   tsfnInfo.type = type;
   tsfnInfo.abort = info[1].As<Boolean>();
   tsfnInfo.startSecondary = info[2].As<Boolean>();
   tsfnInfo.maxQueueSize = info[3].As<Number>().Uint32Value();
   tsfnInfo.closeCalledFromJs = false;
 
-  tsfn = ThreadSafeFunction::New(info.Env(), info[0].As<Function>(),
-      "Test", tsfnInfo.maxQueueSize, 2, &tsfnInfo, JoinTheThreads, threads);
+  tsfn = ThreadSafeFunction::New(info.Env(),
+                                 info[0].As<Function>(),
+                                 "Test",
+                                 tsfnInfo.maxQueueSize,
+                                 2,
+                                 &tsfnInfo,
+                                 JoinTheThreads,
+                                 threads);
 
   threads[0] = std::thread(DataSourceThread);
 

--- a/test/threadsafe_function/threadsafe_function.js
+++ b/test/threadsafe_function/threadsafe_function.js
@@ -5,8 +5,8 @@ const common = require('../common');
 
 module.exports = common.runTest(test);
 
-async function test(binding) {
-  const expectedArray = (function(arrayLength) {
+async function test (binding) {
+  const expectedArray = (function (arrayLength) {
     const result = [];
     for (let index = 0; index < arrayLength; index++) {
       result.push(arrayLength - 1 - index);
@@ -14,15 +14,16 @@ async function test(binding) {
     return result;
   })(binding.threadsafe_function.ARRAY_LENGTH);
 
-  function testWithJSMarshaller({
+  function testWithJSMarshaller ({
     threadStarter,
     quitAfter,
     abort,
     maxQueueSize,
-    launchSecondary }) {
+    launchSecondary
+  }) {
     return new Promise((resolve) => {
       const array = [];
-      binding.threadsafe_function[threadStarter](function testCallback(value) {
+      binding.threadsafe_function[threadStarter](function testCallback (value) {
         array.push(value);
         if (array.length === quitAfter) {
           binding.threadsafe_function.stopThread(common.mustCall(() => {
@@ -39,9 +40,9 @@ async function test(binding) {
     });
   }
 
-  await new Promise(function testWithoutJSMarshaller(resolve) {
+  await new Promise(function testWithoutJSMarshaller (resolve) {
     let callCount = 0;
-    binding.threadsafe_function.startThreadNoNative(function testCallback() {
+    binding.threadsafe_function.startThreadNoNative(function testCallback () {
       callCount++;
 
       // The default call-into-JS implementation passes no arguments.
@@ -65,7 +66,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: binding.threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -76,7 +77,7 @@ async function test(binding) {
       maxQueueSize: 0,
       quitAfter: binding.threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in non-blocking mode, and assert that all values are
@@ -87,7 +88,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: binding.threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that all values are passed.
@@ -98,7 +99,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -109,9 +110,8 @@ async function test(binding) {
       maxQueueSize: 0,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
-
 
   // Start the thread in non-blocking mode, and assert that all values are
   // passed. Quit early, but let the thread finish.
@@ -121,7 +121,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that all values are passed.
@@ -134,7 +134,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       launchSecondary: true
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in non-blocking mode, and assert that all values are
@@ -147,7 +147,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       launchSecondary: true
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that it could not finish.
@@ -159,7 +159,7 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -171,7 +171,7 @@ async function test(binding) {
       maxQueueSize: 0,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 
   // Start the thread in non-blocking mode, and assert that it could not finish.
@@ -183,6 +183,6 @@ async function test(binding) {
       maxQueueSize: binding.threadsafe_function.MAX_QUEUE_SIZE,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 }

--- a/test/threadsafe_function/threadsafe_function_ctx.cc
+++ b/test/threadsafe_function/threadsafe_function_ctx.cc
@@ -7,30 +7,31 @@ using namespace Napi;
 namespace {
 
 class TSFNWrap : public ObjectWrap<TSFNWrap> {
-public:
+ public:
   static Object Init(Napi::Env env, Object exports);
-  TSFNWrap(const CallbackInfo &info);
+  TSFNWrap(const CallbackInfo& info);
 
-  Napi::Value GetContext(const CallbackInfo & /*info*/) {
-    Reference<Napi::Value> *ctx = _tsfn.GetContext();
+  Napi::Value GetContext(const CallbackInfo& /*info*/) {
+    Reference<Napi::Value>* ctx = _tsfn.GetContext();
     return ctx->Value();
   };
 
-  Napi::Value Release(const CallbackInfo &info) {
+  Napi::Value Release(const CallbackInfo& info) {
     Napi::Env env = info.Env();
     _deferred = std::unique_ptr<Promise::Deferred>(new Promise::Deferred(env));
     _tsfn.Release();
     return _deferred->Promise();
   };
 
-private:
+ private:
   ThreadSafeFunction _tsfn;
   std::unique_ptr<Promise::Deferred> _deferred;
 };
 
 Object TSFNWrap::Init(Napi::Env env, Object exports) {
   Function func =
-      DefineClass(env, "TSFNWrap",
+      DefineClass(env,
+                  "TSFNWrap",
                   {InstanceMethod("getContext", &TSFNWrap::GetContext),
                    InstanceMethod("release", &TSFNWrap::Release)});
 
@@ -38,23 +39,28 @@ Object TSFNWrap::Init(Napi::Env env, Object exports) {
   return exports;
 }
 
-TSFNWrap::TSFNWrap(const CallbackInfo &info) : ObjectWrap<TSFNWrap>(info) {
+TSFNWrap::TSFNWrap(const CallbackInfo& info) : ObjectWrap<TSFNWrap>(info) {
   Napi::Env env = info.Env();
 
-  Reference<Napi::Value> *_ctx = new Reference<Napi::Value>;
+  Reference<Napi::Value>* _ctx = new Reference<Napi::Value>;
   *_ctx = Persistent(info[0]);
 
   _tsfn = ThreadSafeFunction::New(
-      info.Env(), Function::New(env, [](const CallbackInfo & /*info*/) {}),
-      Object::New(env), "Test", 1, 1, _ctx,
-      [this](Napi::Env env, Reference<Napi::Value> *ctx) {
+      info.Env(),
+      Function::New(env, [](const CallbackInfo& /*info*/) {}),
+      Object::New(env),
+      "Test",
+      1,
+      1,
+      _ctx,
+      [this](Napi::Env env, Reference<Napi::Value>* ctx) {
         _deferred->Resolve(env.Undefined());
         ctx->Reset();
         delete ctx;
       });
 }
 
-} // namespace
+}  // namespace
 
 Object InitThreadSafeFunctionCtx(Env env) {
   return TSFNWrap::Init(env, Object::New(env));

--- a/test/threadsafe_function/threadsafe_function_ctx.js
+++ b/test/threadsafe_function/threadsafe_function_ctx.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   const ctx = { };
   const tsfn = new binding.threadsafe_function_ctx.TSFNWrap(ctx);
   assert(tsfn.getContext() === ctx);

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.cc
@@ -9,21 +9,20 @@ using namespace Napi;
 namespace {
 
 struct TestContext {
-  TestContext(Promise::Deferred &&deferred)
+  TestContext(Promise::Deferred&& deferred)
       : deferred(std::move(deferred)), callData(nullptr){};
 
   napi_threadsafe_function tsfn;
   Promise::Deferred deferred;
-  double *callData;
+  double* callData;
 
   ~TestContext() {
-    if (callData != nullptr)
-      delete callData;
+    if (callData != nullptr) delete callData;
   };
 };
 
-void FinalizeCB(napi_env env, void * /*finalizeData */, void *context) {
-  TestContext *testContext = static_cast<TestContext *>(context);
+void FinalizeCB(napi_env env, void* /*finalizeData */, void* context) {
+  TestContext* testContext = static_cast<TestContext*>(context);
   if (testContext->callData != nullptr) {
     testContext->deferred.Resolve(Number::New(env, *testContext->callData));
   } else {
@@ -32,10 +31,12 @@ void FinalizeCB(napi_env env, void * /*finalizeData */, void *context) {
   delete testContext;
 }
 
-void CallJSWithData(napi_env env, napi_value /* callback */, void *context,
-                    void *data) {
-  TestContext *testContext = static_cast<TestContext *>(context);
-  testContext->callData = static_cast<double *>(data);
+void CallJSWithData(napi_env env,
+                    napi_value /* callback */,
+                    void* context,
+                    void* data) {
+  TestContext* testContext = static_cast<TestContext*>(context);
+  testContext->callData = static_cast<double*>(data);
 
   napi_status status =
       napi_release_threadsafe_function(testContext->tsfn, napi_tsfn_release);
@@ -43,9 +44,11 @@ void CallJSWithData(napi_env env, napi_value /* callback */, void *context,
   NAPI_THROW_IF_FAILED_VOID(env, status);
 }
 
-void CallJSNoData(napi_env env, napi_value /* callback */, void *context,
-                  void * /*data*/) {
-  TestContext *testContext = static_cast<TestContext *>(context);
+void CallJSNoData(napi_env env,
+                  napi_value /* callback */,
+                  void* context,
+                  void* /*data*/) {
+  TestContext* testContext = static_cast<TestContext*>(context);
   testContext->callData = nullptr;
 
   napi_status status =
@@ -54,7 +57,7 @@ void CallJSNoData(napi_env env, napi_value /* callback */, void *context,
   NAPI_THROW_IF_FAILED_VOID(env, status);
 }
 
-static Value TestCall(const CallbackInfo &info) {
+static Value TestCall(const CallbackInfo& info) {
   Napi::Env env = info.Env();
   bool isBlocking = false;
   bool hasData = false;
@@ -71,15 +74,22 @@ static Value TestCall(const CallbackInfo &info) {
   }
 
   // Allow optional callback passed from JS. Useful for testing.
-  Function cb = Function::New(env, [](const CallbackInfo & /*info*/) {});
+  Function cb = Function::New(env, [](const CallbackInfo& /*info*/) {});
 
-  TestContext *testContext = new TestContext(Napi::Promise::Deferred(env));
+  TestContext* testContext = new TestContext(Napi::Promise::Deferred(env));
 
-  napi_status status = napi_create_threadsafe_function(
-      env, cb, Object::New(env), String::New(env, "Test"), 0, 1,
-      nullptr, /*finalize data*/
-      FinalizeCB, testContext, hasData ? CallJSWithData : CallJSNoData,
-      &testContext->tsfn);
+  napi_status status =
+      napi_create_threadsafe_function(env,
+                                      cb,
+                                      Object::New(env),
+                                      String::New(env, "Test"),
+                                      0,
+                                      1,
+                                      nullptr, /*finalize data*/
+                                      FinalizeCB,
+                                      testContext,
+                                      hasData ? CallJSWithData : CallJSNoData,
+                                      &testContext->tsfn);
 
   NAPI_THROW_IF_FAILED(env, status, Value());
 
@@ -88,22 +98,22 @@ static Value TestCall(const CallbackInfo &info) {
   // Test the four napi_threadsafe_function direct-accessing calls
   if (isBlocking) {
     if (hasData) {
-      wrapped.BlockingCall(static_cast<void *>(new double(std::rand())));
+      wrapped.BlockingCall(static_cast<void*>(new double(std::rand())));
     } else {
-      wrapped.BlockingCall(static_cast<void *>(nullptr));
+      wrapped.BlockingCall(static_cast<void*>(nullptr));
     }
   } else {
     if (hasData) {
-      wrapped.NonBlockingCall(static_cast<void *>(new double(std::rand())));
+      wrapped.NonBlockingCall(static_cast<void*>(new double(std::rand())));
     } else {
-      wrapped.NonBlockingCall(static_cast<void *>(nullptr));
+      wrapped.NonBlockingCall(static_cast<void*>(nullptr));
     }
   }
 
   return testContext->deferred.Promise();
 }
 
-} // namespace
+}  // namespace
 
 Object InitThreadSafeFunctionExistingTsfn(Env env) {
   Object exports = Object::New(env);

--- a/test/threadsafe_function/threadsafe_function_existing_tsfn.js
+++ b/test/threadsafe_function/threadsafe_function_existing_tsfn.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   const testCall = binding.threadsafe_function_existing_tsfn.testCall;
 
-  assert.strictEqual(typeof await testCall({ blocking: true,  data: true  }), "number");
-  assert.strictEqual(typeof await testCall({ blocking: true,  data: false }), "undefined");
-  assert.strictEqual(typeof await testCall({ blocking: false, data: true  }), "number");
-  assert.strictEqual(typeof await testCall({ blocking: false, data: false }), "undefined");
+  assert.strictEqual(typeof await testCall({ blocking: true, data: true }), 'number');
+  assert.strictEqual(typeof await testCall({ blocking: true, data: false }), 'undefined');
+  assert.strictEqual(typeof await testCall({ blocking: false, data: true }), 'number');
+  assert.strictEqual(typeof await testCall({ blocking: false, data: false }), 'undefined');
 }

--- a/test/threadsafe_function/threadsafe_function_ptr.cc
+++ b/test/threadsafe_function/threadsafe_function_ptr.cc
@@ -9,12 +9,13 @@ namespace {
 static Value Test(const CallbackInfo& info) {
   Object resource = info[0].As<Object>();
   Function cb = info[1].As<Function>();
-  ThreadSafeFunction tsfn = ThreadSafeFunction::New(info.Env(), cb, resource, "Test", 1, 1);
+  ThreadSafeFunction tsfn =
+      ThreadSafeFunction::New(info.Env(), cb, resource, "Test", 1, 1);
   tsfn.Release();
   return info.Env().Undefined();
 }
 
-}
+}  // namespace
 
 Object InitThreadSafeFunctionPtr(Env env) {
   Object exports = Object::New(env);

--- a/test/threadsafe_function/threadsafe_function_ptr.js
+++ b/test/threadsafe_function/threadsafe_function_ptr.js
@@ -2,6 +2,6 @@
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   binding.threadsafe_function_ptr.test({}, () => {});
 }

--- a/test/threadsafe_function/threadsafe_function_sum.cc
+++ b/test/threadsafe_function/threadsafe_function_sum.cc
@@ -1,8 +1,8 @@
-#include "napi.h"
-#include <thread>
-#include <cstdlib>
 #include <condition_variable>
+#include <cstdlib>
 #include <mutex>
+#include <thread>
+#include "napi.h"
 
 #if (NAPI_VERSION > 3)
 
@@ -11,9 +11,8 @@ using namespace Napi;
 namespace {
 
 struct TestData {
+  TestData(Promise::Deferred&& deferred) : deferred(std::move(deferred)){};
 
-  TestData(Promise::Deferred&& deferred) : deferred(std::move(deferred)) {};
-  
   // Native Promise returned to JavaScript
   Promise::Deferred deferred;
 
@@ -28,7 +27,7 @@ struct TestData {
   size_t expected_calls = 0;
 };
 
-void FinalizerCallback(Napi::Env env, TestData* finalizeData){
+void FinalizerCallback(Napi::Env env, TestData* finalizeData) {
   for (size_t i = 0; i < finalizeData->threads.size(); ++i) {
     finalizeData->threads[i].join();
   }
@@ -42,8 +41,8 @@ void FinalizerCallback(Napi::Env env, TestData* finalizeData){
 
 void entryWithTSFN(ThreadSafeFunction tsfn, int threadId) {
   std::this_thread::sleep_for(std::chrono::milliseconds(std::rand() % 100 + 1));
-  tsfn.BlockingCall( [=](Napi::Env env, Function callback) {
-    callback.Call( { Number::New(env, static_cast<double>(threadId))});
+  tsfn.BlockingCall([=](Napi::Env env, Function callback) {
+    callback.Call({Number::New(env, static_cast<double>(threadId))});
   });
   tsfn.Release();
 }
@@ -54,15 +53,20 @@ static Value TestWithTSFN(const CallbackInfo& info) {
 
   // We pass the test data to the Finalizer for cleanup. The finalizer is
   // responsible for deleting this data as well.
-  TestData *testData = new TestData(Promise::Deferred::New(info.Env()));
+  TestData* testData = new TestData(Promise::Deferred::New(info.Env()));
 
   ThreadSafeFunction tsfn = ThreadSafeFunction::New(
-      info.Env(), cb, "Test", 0, threadCount,
-      std::function<decltype(FinalizerCallback)>(FinalizerCallback), testData);
+      info.Env(),
+      cb,
+      "Test",
+      0,
+      threadCount,
+      std::function<decltype(FinalizerCallback)>(FinalizerCallback),
+      testData);
 
   for (int i = 0; i < threadCount; ++i) {
     // A copy of the ThreadSafeFunction will go to the thread entry point
-    testData->threads.push_back( std::thread(entryWithTSFN, tsfn, i) );
+    testData->threads.push_back(std::thread(entryWithTSFN, tsfn, i));
   }
 
   return testData->deferred.Promise();
@@ -70,7 +74,7 @@ static Value TestWithTSFN(const CallbackInfo& info) {
 
 // Task instance created for each new std::thread
 class DelayedTSFNTask {
-public:
+ public:
   // Each instance has its own tsfn
   ThreadSafeFunction tsfn;
 
@@ -90,8 +94,7 @@ public:
 };
 
 struct TestDataDelayed {
-
-  TestDataDelayed(Promise::Deferred &&deferred)
+  TestDataDelayed(Promise::Deferred&& deferred)
       : deferred(std::move(deferred)){};
   ~TestDataDelayed() { taskInsts.clear(); };
   // Native Promise returned to JavaScript
@@ -107,7 +110,7 @@ struct TestDataDelayed {
   ThreadSafeFunction tsfn = ThreadSafeFunction();
 };
 
-void FinalizerCallbackDelayed(Napi::Env env, TestDataDelayed *finalizeData) {
+void FinalizerCallbackDelayed(Napi::Env env, TestDataDelayed* finalizeData) {
   for (size_t i = 0; i < finalizeData->threads.size(); ++i) {
     finalizeData->threads[i].join();
   }
@@ -115,15 +118,19 @@ void FinalizerCallbackDelayed(Napi::Env env, TestDataDelayed *finalizeData) {
   delete finalizeData;
 }
 
-static Value TestDelayedTSFN(const CallbackInfo &info) {
+static Value TestDelayedTSFN(const CallbackInfo& info) {
   int threadCount = info[0].As<Number>().Int32Value();
   Function cb = info[1].As<Function>();
 
-  TestDataDelayed *testData =
+  TestDataDelayed* testData =
       new TestDataDelayed(Promise::Deferred::New(info.Env()));
 
   testData->tsfn =
-      ThreadSafeFunction::New(info.Env(), cb, "Test", 0, threadCount,
+      ThreadSafeFunction::New(info.Env(),
+                              cb,
+                              "Test",
+                              0,
+                              threadCount,
                               std::function<decltype(FinalizerCallbackDelayed)>(
                                   FinalizerCallbackDelayed),
                               testData);
@@ -137,7 +144,7 @@ static Value TestDelayedTSFN(const CallbackInfo &info) {
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(std::rand() % 100 + 1));
 
-  for (auto &task : testData->taskInsts) {
+  for (auto& task : testData->taskInsts) {
     std::lock_guard<std::mutex> lk(task->mtx);
     task->tsfn = testData->tsfn;
     task->cv.notify_all();
@@ -149,7 +156,7 @@ static Value TestDelayedTSFN(const CallbackInfo &info) {
 void AcquireFinalizerCallback(Napi::Env env,
                               TestData* finalizeData,
                               TestData* context) {
-  (void) context;
+  (void)context;
   for (size_t i = 0; i < finalizeData->threads.size(); ++i) {
     finalizeData->threads[i].join();
   }
@@ -161,13 +168,13 @@ void entryAcquire(ThreadSafeFunction tsfn, int threadId) {
   tsfn.Acquire();
   TestData* testData = tsfn.GetContext();
   std::this_thread::sleep_for(std::chrono::milliseconds(std::rand() % 100 + 1));
-  tsfn.BlockingCall( [=](Napi::Env env, Function callback) {
+  tsfn.BlockingCall([=](Napi::Env env, Function callback) {
     // This lambda runs on the main thread so it's OK to access the variables
     // `expected_calls` and `mainWantsRelease`.
     testData->expected_calls--;
     if (testData->expected_calls == 0 && testData->mainWantsRelease)
       testData->tsfn.Release();
-    callback.Call( { Number::New(env, static_cast<double>(threadId))});
+    callback.Call({Number::New(env, static_cast<double>(threadId))});
   });
   tsfn.Release();
 }
@@ -182,7 +189,7 @@ static Value CreateThread(const CallbackInfo& info) {
   ThreadSafeFunction tsfn = testData->tsfn;
   int threadId = testData->threads.size();
   // A copy of the ThreadSafeFunction will go to the thread entry point
-  testData->threads.push_back( std::thread(entryAcquire, tsfn, threadId) );
+  testData->threads.push_back(std::thread(entryAcquire, tsfn, threadId));
   return Number::New(info.Env(), threadId);
 }
 
@@ -198,21 +205,29 @@ static Value TestAcquire(const CallbackInfo& info) {
 
   // We pass the test data to the Finalizer for cleanup. The finalizer is
   // responsible for deleting this data as well.
-  TestData *testData = new TestData(Promise::Deferred::New(info.Env()));
+  TestData* testData = new TestData(Promise::Deferred::New(info.Env()));
 
-  testData->tsfn = ThreadSafeFunction::New(
-    env, cb, "Test", 0, 1, testData,
-    std::function<decltype(AcquireFinalizerCallback)>(AcquireFinalizerCallback),
-    testData);
+  testData->tsfn =
+      ThreadSafeFunction::New(env,
+                              cb,
+                              "Test",
+                              0,
+                              1,
+                              testData,
+                              std::function<decltype(AcquireFinalizerCallback)>(
+                                  AcquireFinalizerCallback),
+                              testData);
 
   Object result = Object::New(env);
-  result["createThread"] = Function::New( env, CreateThread, "createThread", testData);
-  result["stopThreads"] = Function::New( env, StopThreads, "stopThreads", testData);
+  result["createThread"] =
+      Function::New(env, CreateThread, "createThread", testData);
+  result["stopThreads"] =
+      Function::New(env, StopThreads, "stopThreads", testData);
   result["promise"] = testData->deferred.Promise();
 
   return result;
 }
-}
+}  // namespace
 
 Object InitThreadSafeFunctionSum(Env env) {
   Object exports = Object::New(env);

--- a/test/threadsafe_function/threadsafe_function_sum.js
+++ b/test/threadsafe_function/threadsafe_function_sum.js
@@ -33,15 +33,15 @@ module.exports = require('../common').runTest(test);
 /** @param {number[]} N */
 const sum = (N) => N.reduce((sum, n) => sum + n, 0);
 
-function test(binding) {
-  async function check(bindingFunction) {
+function test (binding) {
+  async function check (bindingFunction) {
     const calls = [];
     const result = await bindingFunction(THREAD_COUNT, Array.prototype.push.bind(calls));
     assert.ok(result);
     assert.equal(sum(calls), EXPECTED_SUM);
   }
 
-  async function checkAcquire() {
+  async function checkAcquire () {
     const calls = [];
     const { promise, createThread, stopThreads } = binding.threadsafe_function_sum.testAcquire(Array.prototype.push.bind(calls));
     for (let i = 0; i < THREAD_COUNT; i++) {

--- a/test/threadsafe_function/threadsafe_function_unref.cc
+++ b/test/threadsafe_function/threadsafe_function_unref.cc
@@ -15,23 +15,23 @@ static Value TestUnref(const CallbackInfo& info) {
   Function setTimeout = MaybeUnwrap(global.Get("setTimeout")).As<Function>();
   ThreadSafeFunction* tsfn = new ThreadSafeFunction;
 
-  *tsfn = ThreadSafeFunction::New(info.Env(), cb, resource, "Test", 1, 1, [tsfn](Napi::Env /* env */) {
-    delete tsfn;
-  });
+  *tsfn = ThreadSafeFunction::New(
+      info.Env(), cb, resource, "Test", 1, 1, [tsfn](Napi::Env /* env */) {
+        delete tsfn;
+      });
 
   tsfn->BlockingCall();
 
-  setTimeout.Call( global, {
-    Function::New(env, [tsfn](const CallbackInfo& info) {
-      tsfn->Unref(info.Env());
-    }),
-    Number::New(env, 100)
-  });
+  setTimeout.Call(
+      global,
+      {Function::New(
+           env, [tsfn](const CallbackInfo& info) { tsfn->Unref(info.Env()); }),
+       Number::New(env, 100)});
 
   return info.Env().Undefined();
 }
 
-}
+}  // namespace
 
 Object InitThreadSafeFunctionUnref(Env env) {
   Object exports = Object::New(env);

--- a/test/threadsafe_function/threadsafe_function_unref.js
+++ b/test/threadsafe_function/threadsafe_function_unref.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const isMainProcess = process.argv[1] != __filename;
+const isMainProcess = process.argv[1] !== __filename;
 
 /**
  * In order to test that the event loop exits even with an active TSFN, we need

--- a/test/threadsafe_function/threadsafe_function_unref.js
+++ b/test/threadsafe_function/threadsafe_function_unref.js
@@ -19,7 +19,7 @@ if (isMainProcess) {
   test(process.argv[2]);
 }
 
-function test(bindingFile) {
+function test (bindingFile) {
   if (isMainProcess) {
     // Main process
     return new Promise((resolve, reject) => {
@@ -27,21 +27,21 @@ function test(bindingFile) {
         '--expose-gc', __filename, bindingFile
       ], { stdio: 'inherit' });
 
-      let timeout = setTimeout( function() {
+      let timeout = setTimeout(function () {
         child.kill();
         timeout = 0;
-        reject(new Error("Expected child to die"));
+        reject(new Error('Expected child to die'));
       }, 5000);
 
-      child.on("error", (err) => {
+      child.on('error', (err) => {
         clearTimeout(timeout);
         timeout = 0;
         reject(new Error(err));
-      })
+      });
 
-      child.on("close", (code) => {
+      child.on('close', (code) => {
         if (timeout) clearTimeout(timeout);
-        assert.strictEqual(code, 0, "Expected return value 0");
+        assert.strictEqual(code, 0, 'Expected return value 0');
         resolve();
       });
     });

--- a/test/thunking_manual.cc
+++ b/test/thunking_manual.cc
@@ -22,64 +22,59 @@ static Napi::Value TestGetter(const Napi::CallbackInfo& /*info*/) {
   return Napi::Value();
 }
 
-static void TestSetter(const Napi::CallbackInfo& /*info*/) {
-}
+static void TestSetter(const Napi::CallbackInfo& /*info*/) {}
 
 class TestClass : public Napi::ObjectWrap<TestClass> {
  public:
-  TestClass(const Napi::CallbackInfo& info):
-      ObjectWrap<TestClass>(info) {
-  }
+  TestClass(const Napi::CallbackInfo& info) : ObjectWrap<TestClass>(info) {}
   static Napi::Value TestClassStaticMethod(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), 42);
   }
 
-  static void TestClassStaticVoidMethod(const Napi::CallbackInfo& /*info*/) {
-  }
+  static void TestClassStaticVoidMethod(const Napi::CallbackInfo& /*info*/) {}
 
   Napi::Value TestClassInstanceMethod(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), 42);
   }
 
-  void TestClassInstanceVoidMethod(const Napi::CallbackInfo& /*info*/) {
-  }
+  void TestClassInstanceVoidMethod(const Napi::CallbackInfo& /*info*/) {}
 
   Napi::Value TestClassInstanceGetter(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), 42);
   }
 
   void TestClassInstanceSetter(const Napi::CallbackInfo& /*info*/,
-                               const Napi::Value& /*new_value*/) {
-  }
+                               const Napi::Value& /*new_value*/) {}
 
   static Napi::Function NewClass(Napi::Env env) {
-    return DefineClass(env, "TestClass", {
-      // Make sure to check that the deleter gets called.
-      StaticMethod("staticMethod", TestClassStaticMethod),
-      // Make sure to check that the deleter gets called.
-      StaticMethod("staticVoidMethod", TestClassStaticVoidMethod),
-      // Make sure to check that the deleter gets called.
-      StaticMethod(Napi::Symbol::New(env, "staticMethod"),
-                   TestClassStaticMethod),
-      // Make sure to check that the deleter gets called.
-      StaticMethod(Napi::Symbol::New(env, "staticVoidMethod"),
-                   TestClassStaticVoidMethod),
-      // Make sure to check that the deleter gets called.
-      InstanceMethod("instanceMethod", &TestClass::TestClassInstanceMethod),
-      // Make sure to check that the deleter gets called.
-      InstanceMethod("instanceVoidMethod",
-                     &TestClass::TestClassInstanceVoidMethod),
-      // Make sure to check that the deleter gets called.
-      InstanceMethod(Napi::Symbol::New(env, "instanceMethod"),
-                     &TestClass::TestClassInstanceMethod),
-      // Make sure to check that the deleter gets called.
-      InstanceMethod(Napi::Symbol::New(env, "instanceVoidMethod"),
-                     &TestClass::TestClassInstanceVoidMethod),
-      // Make sure to check that the deleter gets called.
-      InstanceAccessor("instanceAccessor",
-                       &TestClass::TestClassInstanceGetter,
-                       &TestClass::TestClassInstanceSetter)
-    });
+    return DefineClass(
+        env,
+        "TestClass",
+        {// Make sure to check that the deleter gets called.
+         StaticMethod("staticMethod", TestClassStaticMethod),
+         // Make sure to check that the deleter gets called.
+         StaticMethod("staticVoidMethod", TestClassStaticVoidMethod),
+         // Make sure to check that the deleter gets called.
+         StaticMethod(Napi::Symbol::New(env, "staticMethod"),
+                      TestClassStaticMethod),
+         // Make sure to check that the deleter gets called.
+         StaticMethod(Napi::Symbol::New(env, "staticVoidMethod"),
+                      TestClassStaticVoidMethod),
+         // Make sure to check that the deleter gets called.
+         InstanceMethod("instanceMethod", &TestClass::TestClassInstanceMethod),
+         // Make sure to check that the deleter gets called.
+         InstanceMethod("instanceVoidMethod",
+                        &TestClass::TestClassInstanceVoidMethod),
+         // Make sure to check that the deleter gets called.
+         InstanceMethod(Napi::Symbol::New(env, "instanceMethod"),
+                        &TestClass::TestClassInstanceMethod),
+         // Make sure to check that the deleter gets called.
+         InstanceMethod(Napi::Symbol::New(env, "instanceVoidMethod"),
+                        &TestClass::TestClassInstanceVoidMethod),
+         // Make sure to check that the deleter gets called.
+         InstanceAccessor("instanceAccessor",
+                          &TestClass::TestClassInstanceGetter,
+                          &TestClass::TestClassInstanceSetter)});
   }
 };
 
@@ -91,42 +86,34 @@ static Napi::Value CreateTestObject(const Napi::CallbackInfo& info) {
   item["testMethod"] = Napi::Function::New(env, TestMethod, "testMethod");
 
   item.DefineProperties({
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       "accessor_1",
-                                       TestGetter),
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       std::string("accessor_1_std_string"),
-                                       TestGetter),
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       Napi::String::New(info.Env(),
-                                                        "accessor_1_js_string"),
-                                       TestGetter),
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       "accessor_2",
-                                       TestGetter,
-                                       TestSetter),
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       std::string("accessor_2_std_string"),
-                                       TestGetter,
-                                       TestSetter),
-    // Make sure to check that the deleter gets called.
-    Napi::PropertyDescriptor::Accessor(env,
-                                       item,
-                                       Napi::String::New(env,
-                                                        "accessor_2_js_string"),
-                                       TestGetter,
-                                       TestSetter),
-    Napi::PropertyDescriptor::Value("TestClass", TestClass::NewClass(env)),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(env, item, "accessor_1", TestGetter),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(
+          env, item, std::string("accessor_1_std_string"), TestGetter),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(
+          env,
+          item,
+          Napi::String::New(info.Env(), "accessor_1_js_string"),
+          TestGetter),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(
+          env, item, "accessor_2", TestGetter, TestSetter),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(env,
+                                         item,
+                                         std::string("accessor_2_std_string"),
+                                         TestGetter,
+                                         TestSetter),
+      // Make sure to check that the deleter gets called.
+      Napi::PropertyDescriptor::Accessor(
+          env,
+          item,
+          Napi::String::New(env, "accessor_2_js_string"),
+          TestGetter,
+          TestSetter),
+      Napi::PropertyDescriptor::Value("TestClass", TestClass::NewClass(env)),
   });
 
   return item;

--- a/test/thunking_manual.js
+++ b/test/thunking_manual.js
@@ -1,8 +1,6 @@
 // Flags: --expose-gc
 'use strict';
 
-const assert = require('assert');
-
 module.exports = require('./common').runTest(test);
 
 function test (binding) {
@@ -10,6 +8,7 @@ function test (binding) {
   global.gc();
   console.log('Thunking: Creating test object');
   let object = binding.thunking_manual.createTestObject();
+  // eslint-disable-next-line no-unused-vars
   object = null;
   console.log('Thunking: About to GC\n--------');
   global.gc();

--- a/test/thunking_manual.js
+++ b/test/thunking_manual.js
@@ -5,13 +5,13 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
-  console.log("Thunking: Performing initial GC");
+function test (binding) {
+  console.log('Thunking: Performing initial GC');
   global.gc();
-  console.log("Thunking: Creating test object");
+  console.log('Thunking: Creating test object');
   let object = binding.thunking_manual.createTestObject();
   object = null;
-  console.log("Thunking: About to GC\n--------");
+  console.log('Thunking: About to GC\n--------');
   global.gc();
-  console.log("--------\nThunking: GC complete");
+  console.log('--------\nThunking: GC complete');
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function.js
@@ -5,7 +5,7 @@ const common = require('../common');
 
 module.exports = common.runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   const expectedArray = (function (arrayLength) {
     const result = [];
     for (let index = 0; index < arrayLength; index++) {
@@ -14,15 +14,16 @@ async function test(binding) {
     return result;
   })(binding.typed_threadsafe_function.ARRAY_LENGTH);
 
-  function testWithJSMarshaller({
+  function testWithJSMarshaller ({
     threadStarter,
     quitAfter,
     abort,
     maxQueueSize,
-    launchSecondary }) {
+    launchSecondary
+  }) {
     return new Promise((resolve) => {
       const array = [];
-      binding.typed_threadsafe_function[threadStarter](function testCallback(value) {
+      binding.typed_threadsafe_function[threadStarter](function testCallback (value) {
         array.push(value);
         if (array.length === quitAfter) {
           binding.typed_threadsafe_function.stopThread(common.mustCall(() => {
@@ -39,9 +40,9 @@ async function test(binding) {
     });
   }
 
-  await new Promise(function testWithoutJSMarshaller(resolve) {
+  await new Promise(function testWithoutJSMarshaller (resolve) {
     let callCount = 0;
-    binding.typed_threadsafe_function.startThreadNoNative(function testCallback() {
+    binding.typed_threadsafe_function.startThreadNoNative(function testCallback () {
       callCount++;
 
       // The default call-into-JS implementation passes no arguments.
@@ -54,7 +55,7 @@ async function test(binding) {
         });
       }
     }, false /* abort */, false /* launchSecondary */,
-      binding.typed_threadsafe_function.MAX_QUEUE_SIZE);
+    binding.typed_threadsafe_function.MAX_QUEUE_SIZE);
   });
 
   // Start the thread in blocking mode, and assert that all values are passed.
@@ -65,7 +66,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: binding.typed_threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -76,7 +77,7 @@ async function test(binding) {
       maxQueueSize: 0,
       quitAfter: binding.typed_threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in non-blocking mode, and assert that all values are
@@ -87,7 +88,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: binding.typed_threadsafe_function.ARRAY_LENGTH
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that all values are passed.
@@ -98,7 +99,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -109,9 +110,8 @@ async function test(binding) {
       maxQueueSize: 0,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
-
 
   // Start the thread in non-blocking mode, and assert that all values are
   // passed. Quit early, but let the thread finish.
@@ -121,7 +121,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       quitAfter: 1
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that all values are passed.
@@ -134,7 +134,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       launchSecondary: true
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in non-blocking mode, and assert that all values are
@@ -147,7 +147,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       launchSecondary: true
     }),
-    expectedArray,
+    expectedArray
   );
 
   // Start the thread in blocking mode, and assert that it could not finish.
@@ -159,7 +159,7 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 
   // Start the thread in blocking mode with an infinite queue, and assert that
@@ -171,7 +171,7 @@ async function test(binding) {
       maxQueueSize: 0,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 
   // Start the thread in non-blocking mode, and assert that it could not finish.
@@ -183,6 +183,6 @@ async function test(binding) {
       maxQueueSize: binding.typed_threadsafe_function.MAX_QUEUE_SIZE,
       abort: true
     })).indexOf(0),
-    -1,
+    -1
   );
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_existing_tsfn.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 
 module.exports = require('../common').runTest(test);
 
-async function test(binding) {
+async function test (binding) {
   const testCall = binding.typed_threadsafe_function_existing_tsfn.testCall;
 
-  assert.strictEqual(typeof await testCall({ blocking: true,  data: true  }), "number");
-  assert.strictEqual(typeof await testCall({ blocking: true,  data: false }), "undefined");
-  assert.strictEqual(typeof await testCall({ blocking: false, data: true  }), "number");
-  assert.strictEqual(typeof await testCall({ blocking: false, data: false }), "undefined");
+  assert.strictEqual(typeof await testCall({ blocking: true, data: true }), 'number');
+  assert.strictEqual(typeof await testCall({ blocking: true, data: false }), 'undefined');
+  assert.strictEqual(typeof await testCall({ blocking: false, data: true }), 'number');
+  assert.strictEqual(typeof await testCall({ blocking: false, data: false }), 'undefined');
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function_ptr.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ptr.js
@@ -2,6 +2,6 @@
 
 module.exports = require('../common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   binding.typed_threadsafe_function_ptr.test({}, () => {});
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function_sum.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_sum.js
@@ -33,15 +33,15 @@ module.exports = require('../common').runTest(test);
 /** @param {number[]} N */
 const sum = (N) => N.reduce((sum, n) => sum + n, 0);
 
-function test(binding) {
-  async function check(bindingFunction) {
+function test (binding) {
+  async function check (bindingFunction) {
     const calls = [];
     const result = await bindingFunction(THREAD_COUNT, Array.prototype.push.bind(calls));
     assert.ok(result);
     assert.equal(sum(calls), EXPECTED_SUM);
   }
 
-  async function checkAcquire() {
+  async function checkAcquire () {
     const calls = [];
     const { promise, createThread, stopThreads } = binding.typed_threadsafe_function_sum.testAcquire(Array.prototype.push.bind(calls));
     for (let i = 0; i < THREAD_COUNT; i++) {

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const isMainProcess = process.argv[1] != __filename;
+const isMainProcess = process.argv[1] !== __filename;
 
 /**
  * In order to test that the event loop exits even with an active TSFN, we need

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -19,7 +19,7 @@ if (isMainProcess) {
   test(process.argv[2]);
 }
 
-function test(bindingFile) {
+function test (bindingFile) {
   if (isMainProcess) {
     // Main process
     return new Promise((resolve, reject) => {
@@ -27,21 +27,21 @@ function test(bindingFile) {
         '--expose-gc', __filename, bindingFile
       ], { stdio: 'inherit' });
 
-      let timeout = setTimeout( function() {
+      let timeout = setTimeout(function () {
         child.kill();
         timeout = 0;
-        reject(new Error("Expected child to die"));
+        reject(new Error('Expected child to die'));
       }, 5000);
 
-      child.on("error", (err) => {
+      child.on('error', (err) => {
         clearTimeout(timeout);
         timeout = 0;
         reject(new Error(err));
-      })
+      });
 
-      child.on("close", (code) => {
+      child.on('close', (code) => {
         if (timeout) clearTimeout(timeout);
-        assert.strictEqual(code, 0, "Expected return value 0");
+        assert.strictEqual(code, 0, 'Expected return value 0');
         resolve();
       });
     });

--- a/test/typedarray-bigint.js
+++ b/test/typedarray-bigint.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   [
     ['bigint64', BigInt64Array],
-    ['biguint64', BigUint64Array],
+    ['biguint64', BigUint64Array]
   ].forEach(([type, Constructor]) => {
     try {
       const length = 4;

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -3,12 +3,16 @@
 using namespace Napi;
 
 #if defined(NAPI_HAS_CONSTEXPR)
-#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length)
-#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
+#define NAPI_TYPEDARRAY_NEW(className, env, length, type)                      \
+  className::New(env, length)
+#define NAPI_TYPEDARRAY_NEW_BUFFER(                                            \
+    className, env, length, buffer, bufferOffset, type)                        \
   className::New(env, length, buffer, bufferOffset)
 #else
-#define NAPI_TYPEDARRAY_NEW(className, env, length, type) className::New(env, length, type)
-#define NAPI_TYPEDARRAY_NEW_BUFFER(className, env, length, buffer, bufferOffset, type) \
+#define NAPI_TYPEDARRAY_NEW(className, env, length, type)                      \
+  className::New(env, length, type)
+#define NAPI_TYPEDARRAY_NEW_BUFFER(                                            \
+    className, env, length, buffer, bufferOffset, type)                        \
   className::New(env, length, buffer, bufferOffset, type)
 #endif
 
@@ -18,91 +22,160 @@ Value CreateTypedArray(const CallbackInfo& info) {
   std::string arrayType = info[0].As<String>();
   size_t length = info[1].As<Number>().Uint32Value();
   ArrayBuffer buffer = info[2].As<ArrayBuffer>();
-  size_t bufferOffset = info[3].IsUndefined() ? 0 : info[3].As<Number>().Uint32Value();
+  size_t bufferOffset =
+      info[3].IsUndefined() ? 0 : info[3].As<Number>().Uint32Value();
 
   if (arrayType == "int8") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int8Array, info.Env(), length, napi_int8_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int8_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Int8Array, info.Env(), length, napi_int8_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_int8_array);
   } else if (arrayType == "uint8") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint8Array, info.Env(), length, napi_uint8_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint8Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint8_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Uint8Array, info.Env(), length, napi_uint8_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint8Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_uint8_array);
   } else if (arrayType == "uint8_clamped") {
-    return buffer.IsUndefined() ?
-      Uint8Array::New(info.Env(), length, napi_uint8_clamped_array) :
-      Uint8Array::New(info.Env(), length, buffer, bufferOffset, napi_uint8_clamped_array);
+    return buffer.IsUndefined()
+               ? Uint8Array::New(info.Env(), length, napi_uint8_clamped_array)
+               : Uint8Array::New(info.Env(),
+                                 length,
+                                 buffer,
+                                 bufferOffset,
+                                 napi_uint8_clamped_array);
   } else if (arrayType == "int16") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int16Array, info.Env(), length, napi_int16_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int16Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int16_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Int16Array, info.Env(), length, napi_int16_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int16Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_int16_array);
   } else if (arrayType == "uint16") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint16Array, info.Env(), length, napi_uint16_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint16Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint16_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Uint16Array, info.Env(), length, napi_uint16_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint16Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_uint16_array);
   } else if (arrayType == "int32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Int32Array, info.Env(), length, napi_int32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Int32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_int32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Int32Array, info.Env(), length, napi_int32_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Int32Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_int32_array);
   } else if (arrayType == "uint32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Uint32Array, info.Env(), length, napi_uint32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Uint32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_uint32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Uint32Array, info.Env(), length, napi_uint32_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Uint32Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_uint32_array);
   } else if (arrayType == "float32") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Float32Array, info.Env(), length, napi_float32_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Float32Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_float32_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Float32Array, info.Env(), length, napi_float32_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Float32Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_float32_array);
   } else if (arrayType == "float64") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(Float64Array, info.Env(), length, napi_float64_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_float64_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     Float64Array, info.Env(), length, napi_float64_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(Float64Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_float64_array);
 #if (NAPI_VERSION > 5)
   } else if (arrayType == "bigint64") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(BigInt64Array, info.Env(), length, napi_bigint64_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(BigInt64Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_bigint64_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     BigInt64Array, info.Env(), length, napi_bigint64_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(BigInt64Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_bigint64_array);
   } else if (arrayType == "biguint64") {
-    return buffer.IsUndefined() ?
-      NAPI_TYPEDARRAY_NEW(BigUint64Array, info.Env(), length, napi_biguint64_array) :
-      NAPI_TYPEDARRAY_NEW_BUFFER(BigUint64Array, info.Env(), length, buffer, bufferOffset,
-                                 napi_biguint64_array);
+    return buffer.IsUndefined()
+               ? NAPI_TYPEDARRAY_NEW(
+                     BigUint64Array, info.Env(), length, napi_biguint64_array)
+               : NAPI_TYPEDARRAY_NEW_BUFFER(BigUint64Array,
+                                            info.Env(),
+                                            length,
+                                            buffer,
+                                            bufferOffset,
+                                            napi_biguint64_array);
 #endif
   } else {
-    Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+    Error::New(info.Env(), "Invalid typed-array type.")
+        .ThrowAsJavaScriptException();
     return Value();
   }
 }
 
 Value CreateInvalidTypedArray(const CallbackInfo& info) {
-  return NAPI_TYPEDARRAY_NEW_BUFFER(Int8Array, info.Env(), 1, ArrayBuffer(), 0, napi_int8_array);
+  return NAPI_TYPEDARRAY_NEW_BUFFER(
+      Int8Array, info.Env(), 1, ArrayBuffer(), 0, napi_int8_array);
 }
 
 Value GetTypedArrayType(const CallbackInfo& info) {
   TypedArray array = info[0].As<TypedArray>();
   switch (array.TypedArrayType()) {
-    case napi_int8_array: return String::New(info.Env(), "int8");
-    case napi_uint8_array: return String::New(info.Env(), "uint8");
-    case napi_uint8_clamped_array: return String::New(info.Env(), "uint8_clamped");
-    case napi_int16_array: return String::New(info.Env(), "int16");
-    case napi_uint16_array: return String::New(info.Env(), "uint16");
-    case napi_int32_array: return String::New(info.Env(), "int32");
-    case napi_uint32_array: return String::New(info.Env(), "uint32");
-    case napi_float32_array: return String::New(info.Env(), "float32");
-    case napi_float64_array: return String::New(info.Env(), "float64");
+    case napi_int8_array:
+      return String::New(info.Env(), "int8");
+    case napi_uint8_array:
+      return String::New(info.Env(), "uint8");
+    case napi_uint8_clamped_array:
+      return String::New(info.Env(), "uint8_clamped");
+    case napi_int16_array:
+      return String::New(info.Env(), "int16");
+    case napi_uint16_array:
+      return String::New(info.Env(), "uint16");
+    case napi_int32_array:
+      return String::New(info.Env(), "int32");
+    case napi_uint32_array:
+      return String::New(info.Env(), "uint32");
+    case napi_float32_array:
+      return String::New(info.Env(), "float32");
+    case napi_float64_array:
+      return String::New(info.Env(), "float64");
 #if (NAPI_VERSION > 5)
-    case napi_bigint64_array: return String::New(info.Env(), "bigint64");
-    case napi_biguint64_array: return String::New(info.Env(), "biguint64");
+    case napi_bigint64_array:
+      return String::New(info.Env(), "bigint64");
+    case napi_biguint64_array:
+      return String::New(info.Env(), "biguint64");
 #endif
-    default: return String::New(info.Env(), "invalid");
+    default:
+      return String::New(info.Env(), "invalid");
   }
 }
 
@@ -145,7 +218,8 @@ Value GetTypedArrayElement(const CallbackInfo& info) {
       return BigInt::New(info.Env(), array.As<BigUint64Array>()[index]);
 #endif
     default:
-      Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+      Error::New(info.Env(), "Invalid typed-array type.")
+          .ThrowAsJavaScriptException();
       return Value();
   }
 }
@@ -168,7 +242,8 @@ void SetTypedArrayElement(const CallbackInfo& info) {
       array.As<Int16Array>()[index] = static_cast<int16_t>(value.Int32Value());
       break;
     case napi_uint16_array:
-      array.As<Uint16Array>()[index] = static_cast<uint16_t>(value.Uint32Value());
+      array.As<Uint16Array>()[index] =
+          static_cast<uint16_t>(value.Uint32Value());
       break;
     case napi_int32_array:
       array.As<Int32Array>()[index] = value.Int32Value();
@@ -185,27 +260,31 @@ void SetTypedArrayElement(const CallbackInfo& info) {
 #if (NAPI_VERSION > 5)
     case napi_bigint64_array: {
       bool lossless;
-      array.As<BigInt64Array>()[index] = value.As<BigInt>().Int64Value(&lossless);
+      array.As<BigInt64Array>()[index] =
+          value.As<BigInt>().Int64Value(&lossless);
       break;
     }
     case napi_biguint64_array: {
       bool lossless;
-      array.As<BigUint64Array>()[index] = value.As<BigInt>().Uint64Value(&lossless);
+      array.As<BigUint64Array>()[index] =
+          value.As<BigInt>().Uint64Value(&lossless);
       break;
     }
 #endif
     default:
-      Error::New(info.Env(), "Invalid typed-array type.").ThrowAsJavaScriptException();
+      Error::New(info.Env(), "Invalid typed-array type.")
+          .ThrowAsJavaScriptException();
   }
 }
 
-} // end anonymous namespace
+}  // end anonymous namespace
 
 Object InitTypedArray(Env env) {
   Object exports = Object::New(env);
 
   exports["createTypedArray"] = Function::New(env, CreateTypedArray);
-  exports["createInvalidTypedArray"] = Function::New(env, CreateInvalidTypedArray);
+  exports["createInvalidTypedArray"] =
+      Function::New(env, CreateInvalidTypedArray);
   exports["getTypedArrayType"] = Function::New(env, GetTypedArrayType);
   exports["getTypedArrayLength"] = Function::New(env, GetTypedArrayLength);
   exports["getTypedArrayBuffer"] = Function::New(env, GetTypedArrayBuffer);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -4,17 +4,17 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function test(binding) {
+function test (binding) {
   const testData = [
-    [ 'int8', Int8Array ],
-    [ 'uint8', Uint8Array ],
-    [ 'uint8_clamped', Uint8ClampedArray ],
-    [ 'int16', Int16Array ],
-    [ 'uint16', Uint16Array ],
-    [ 'int32', Int32Array ],
-    [ 'uint32', Uint32Array ],
-    [ 'float32', Float32Array ],
-    [ 'float64', Float64Array ],
+    ['int8', Int8Array],
+    ['uint8', Uint8Array],
+    ['uint8_clamped', Uint8ClampedArray],
+    ['int16', Int16Array],
+    ['uint16', Uint16Array],
+    ['int32', Int32Array],
+    ['uint32', Uint32Array],
+    ['float32', Float32Array],
+    ['float64', Float64Array]
   ];
 
   testData.forEach(data => {

--- a/test/version_management.cc
+++ b/test/version_management.cc
@@ -3,25 +3,26 @@
 using namespace Napi;
 
 Value getNapiVersion(const CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    uint32_t napi_version = VersionManagement::GetNapiVersion(env);
-    return Number::New(env, napi_version);
+  Napi::Env env = info.Env();
+  uint32_t napi_version = VersionManagement::GetNapiVersion(env);
+  return Number::New(env, napi_version);
 }
 
 Value getNodeVersion(const CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    const napi_node_version*  node_version = VersionManagement::GetNodeVersion(env);
-    Object version = Object::New(env);
-    version.Set("major", Number::New(env, node_version->major));
-    version.Set("minor", Number::New(env, node_version->minor));
-    version.Set("patch", Number::New(env, node_version->patch));
-    version.Set("release", String::New(env, node_version->release));
-    return version;
+  Napi::Env env = info.Env();
+  const napi_node_version* node_version =
+      VersionManagement::GetNodeVersion(env);
+  Object version = Object::New(env);
+  version.Set("major", Number::New(env, node_version->major));
+  version.Set("minor", Number::New(env, node_version->minor));
+  version.Set("patch", Number::New(env, node_version->patch));
+  version.Set("release", String::New(env, node_version->release));
+  return version;
 }
 
 Object InitVersionManagement(Env env) {
-    Object exports = Object::New(env);
-    exports["getNapiVersion"] = Function::New(env, getNapiVersion);
-    exports["getNodeVersion"] = Function::New(env, getNodeVersion);
-    return exports;
+  Object exports = Object::New(env);
+  exports["getNapiVersion"] = Function::New(env, getNapiVersion);
+  exports["getNodeVersion"] = Function::New(env, getNodeVersion);
+  return exports;
 }

--- a/test/version_management.js
+++ b/test/version_management.js
@@ -4,28 +4,26 @@ const assert = require('assert');
 
 module.exports = require('./common').runTest(test);
 
-function parseVersion() {
-    const expected = {};
-    expected.napi = parseInt(process.versions.napi);
-    expected.release = process.release.name;
-    const nodeVersion = process.versions.node.split('.');
-    expected.major = parseInt(nodeVersion[0]);
-    expected.minor = parseInt(nodeVersion[1]);
-    expected.patch = parseInt(nodeVersion[2]);
-    return expected;
+function parseVersion () {
+  const expected = {};
+  expected.napi = parseInt(process.versions.napi);
+  expected.release = process.release.name;
+  const nodeVersion = process.versions.node.split('.');
+  expected.major = parseInt(nodeVersion[0]);
+  expected.minor = parseInt(nodeVersion[1]);
+  expected.patch = parseInt(nodeVersion[2]);
+  return expected;
 }
 
-function test(binding) {
+function test (binding) {
+  const expected = parseVersion();
 
-    const expected = parseVersion();
+  const napiVersion = binding.version_management.getNapiVersion();
+  assert.strictEqual(napiVersion, expected.napi);
 
-    const napiVersion = binding.version_management.getNapiVersion();
-    assert.strictEqual(napiVersion, expected.napi);
-
-    const nodeVersion = binding.version_management.getNodeVersion();
-    assert.strictEqual(nodeVersion.major, expected.major);
-    assert.strictEqual(nodeVersion.minor, expected.minor);
-    assert.strictEqual(nodeVersion.patch, expected.patch);
-    assert.strictEqual(nodeVersion.release, expected.release);
-
+  const nodeVersion = binding.version_management.getNodeVersion();
+  assert.strictEqual(nodeVersion.major, expected.major);
+  assert.strictEqual(nodeVersion.minor, expected.minor);
+  assert.strictEqual(nodeVersion.patch, expected.patch);
+  assert.strictEqual(nodeVersion.release, expected.release);
 }

--- a/tools/check-napi.js
+++ b/tools/check-napi.js
@@ -8,12 +8,12 @@ const child_process = require('child_process');
 
 // Read the output of the command, break it into lines, and use the reducer to
 // decide whether the file is an N-API module or not.
-function checkFile(file, command, argv, reducer) {
+function checkFile (file, command, argv, reducer) {
   const child = child_process.spawn(command, argv, {
     stdio: ['inherit', 'pipe', 'inherit']
   });
   let leftover = '';
-  let isNapi = undefined;
+  let isNapi;
   child.stdout.on('data', (chunk) => {
     if (isNapi === undefined) {
       chunk = (leftover + chunk.toString()).split(/[\r\n]+/);
@@ -27,11 +27,11 @@ function checkFile(file, command, argv, reducer) {
   child.on('close', (code, signal) => {
     if ((code === null && signal !== null) || (code !== 0)) {
       console.log(
-        command + ' exited with code: '  + code + ' and signal: ' + signal);
+        command + ' exited with code: ' + code + ' and signal: ' + signal);
     } else {
       // Green if it's a N-API module, red otherwise.
       console.log(
-          '\x1b[' + (isNapi ? '42' : '41') + 'm' +
+        '\x1b[' + (isNapi ? '42' : '41') + 'm' +
           (isNapi ? '    N-API' : 'Not N-API') +
           '\x1b[0m: ' + file);
     }
@@ -39,7 +39,7 @@ function checkFile(file, command, argv, reducer) {
 }
 
 // Use nm -a to list symbols.
-function checkFileUNIX(file) {
+function checkFileUNIX (file) {
   checkFile(file, 'nm', ['-a', file], (soFar, line) => {
     if (soFar === undefined) {
       line = line.match(/([0-9a-f]*)? ([a-zA-Z]) (.*$)/);
@@ -54,7 +54,7 @@ function checkFileUNIX(file) {
 }
 
 // Use dumpbin /imports to list symbols.
-function checkFileWin32(file) {
+function checkFileWin32 (file) {
   checkFile(file, 'dumpbin', ['/imports', file], (soFar, line) => {
     if (soFar === undefined) {
       line = line.match(/([0-9a-f]*)? +([a-zA-Z0-9]) (.*$)/);
@@ -68,16 +68,16 @@ function checkFileWin32(file) {
 
 // Descend into a directory structure and pass each file ending in '.node' to
 // one of the above checks, depending on the OS.
-function recurse(top) {
+function recurse (top) {
   fs.readdir(top, (error, items) => {
     if (error) {
-      throw ("error reading directory " + top + ": " + error);
+      throw ('error reading directory ' + top + ': ' + error);
     }
     items.forEach((item) => {
       item = path.join(top, item);
       fs.stat(item, ((item) => (error, stats) => {
         if (error) {
-          throw ("error about " + item + ": " + error);
+          throw ('error about ' + item + ': ' + error);
         }
         if (stats.isDirectory()) {
           recurse(item);
@@ -86,9 +86,9 @@ function recurse(top) {
             // artefacts of node-addon-api having identified a version of
             // Node.js that ships with a correct implementation of N-API.
             path.basename(item) !== 'nothing.node') {
-          process.platform === 'win32' ?
-              checkFileWin32(item) :
-              checkFileUNIX(item);
+          process.platform === 'win32'
+            ? checkFileWin32(item)
+            : checkFileUNIX(item);
         }
       })(item));
     });

--- a/tools/check-napi.js
+++ b/tools/check-napi.js
@@ -4,12 +4,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const child_process = require('child_process');
 
 // Read the output of the command, break it into lines, and use the reducer to
 // decide whether the file is an N-API module or not.
 function checkFile (file, command, argv, reducer) {
-  const child = child_process.spawn(command, argv, {
+  const child = require('child_process').spawn(command, argv, {
     stdio: ['inherit', 'pipe', 'inherit']
   });
   let leftover = '';
@@ -71,13 +70,13 @@ function checkFileWin32 (file) {
 function recurse (top) {
   fs.readdir(top, (error, items) => {
     if (error) {
-      throw ('error reading directory ' + top + ': ' + error);
+      throw new Error('error reading directory ' + top + ': ' + error);
     }
     items.forEach((item) => {
       item = path.join(top, item);
       fs.stat(item, ((item) => (error, stats) => {
         if (error) {
-          throw ('error about ' + item + ': ' + error);
+          throw new Error('error about ' + item + ': ' + error);
         }
         if (stats.isDirectory()) {
           recurse(item);

--- a/tools/conversion.js
+++ b/tools/conversion.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-'use strict'
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
@@ -15,255 +15,246 @@ if (!dir) {
 const NodeApiVersion = require('../package.json').version;
 
 const disable = args[1];
-if (disable != "--disable" && dir != "--disable") {
+if (disable != '--disable' && dir != '--disable') {
   var ConfigFileOperations = {
     'package.json': [
-       [ /([ ]*)"dependencies": {/g, '$1"dependencies": {\n$1  "node-addon-api": "' + NodeApiVersion + '",'],
-       [ /[ ]*"nan": *"[^"]+"(,|)[\n\r]/g, '' ]
+      [/([ ]*)"dependencies": {/g, '$1"dependencies": {\n$1  "node-addon-api": "' + NodeApiVersion + '",'],
+      [/[ ]*"nan": *"[^"]+"(,|)[\n\r]/g, '']
     ],
     'binding.gyp': [
-       [ /([ ]*)'include_dirs': \[/g, '$1\'include_dirs\': [\n$1  \'<!(node -p "require(\\\'node-addon-api\\\').include_dir")\',' ],
-       [ /([ ]*)"include_dirs": \[/g, '$1"include_dirs": [\n$1  "<!(node -p \\"require(\'node-addon-api\').include_dir\\")",' ],
-       [ /[ ]*("|')<!\(node -e ("|'|\\"|\\')require\(("|'|\\"|\\')nan("|'|\\"|\\')\)("|'|\\"|\\')\)("|')(,|)[\r\n]/g, '' ],
-       [ /([ ]*)("|')target_name("|'): ("|')(.+?)("|'),/g, '$1$2target_name$2: $4$5$6,\n      $2cflags!$2: [ $2-fno-exceptions$2 ],\n      $2cflags_cc!$2: [ $2-fno-exceptions$2 ],\n      $2xcode_settings$2: { $2GCC_ENABLE_CPP_EXCEPTIONS$2: $2YES$2,\n        $2CLANG_CXX_LIBRARY$2: $2libc++$2,\n        $2MACOSX_DEPLOYMENT_TARGET$2: $210.7$2,\n      },\n      $2msvs_settings$2: {\n        $2VCCLCompilerTool$2: { $2ExceptionHandling$2: 1 },\n      },' ],
+      [/([ ]*)'include_dirs': \[/g, '$1\'include_dirs\': [\n$1  \'<!(node -p "require(\\\'node-addon-api\\\').include_dir")\','],
+      [/([ ]*)"include_dirs": \[/g, '$1"include_dirs": [\n$1  "<!(node -p \\"require(\'node-addon-api\').include_dir\\")",'],
+      [/[ ]*("|')<!\(node -e ("|'|\\"|\\')require\(("|'|\\"|\\')nan("|'|\\"|\\')\)("|'|\\"|\\')\)("|')(,|)[\r\n]/g, ''],
+      [/([ ]*)("|')target_name("|'): ("|')(.+?)("|'),/g, '$1$2target_name$2: $4$5$6,\n      $2cflags!$2: [ $2-fno-exceptions$2 ],\n      $2cflags_cc!$2: [ $2-fno-exceptions$2 ],\n      $2xcode_settings$2: { $2GCC_ENABLE_CPP_EXCEPTIONS$2: $2YES$2,\n        $2CLANG_CXX_LIBRARY$2: $2libc++$2,\n        $2MACOSX_DEPLOYMENT_TARGET$2: $210.7$2,\n      },\n      $2msvs_settings$2: {\n        $2VCCLCompilerTool$2: { $2ExceptionHandling$2: 1 },\n      },']
     ]
   };
 } else {
   var ConfigFileOperations = {
     'package.json': [
-      [ /([ ]*)"dependencies": {/g, '$1"dependencies": {\n$1  "node-addon-api": "' + NodeApiVersion + '",'],
-      [ /[ ]*"nan": *"[^"]+"(,|)[\n\r]/g, '' ]
+      [/([ ]*)"dependencies": {/g, '$1"dependencies": {\n$1  "node-addon-api": "' + NodeApiVersion + '",'],
+      [/[ ]*"nan": *"[^"]+"(,|)[\n\r]/g, '']
     ],
     'binding.gyp': [
-      [ /([ ]*)'include_dirs': \[/g, '$1\'include_dirs\': [\n$1  \'<!(node -p "require(\\\'node-addon-api\\\').include_dir")\',' ],
-      [ /([ ]*)"include_dirs": \[/g, '$1"include_dirs": [\n$1  "<!(node -p \'require(\\\"node-addon-api\\\").include_dir\')",' ],
-      [ /[ ]*("|')<!\(node -e ("|'|\\"|\\')require\(("|'|\\"|\\')nan("|'|\\"|\\')\)("|'|\\"|\\')\)("|')(,|)[\r\n]/g, '' ],
-      [ /([ ]*)("|')target_name("|'): ("|')(.+?)("|'),/g, '$1$2target_name$2: $4$5$6,\n      $2cflags!$2: [ $2-fno-exceptions$2 ],\n      $2cflags_cc!$2: [ $2-fno-exceptions$2 ],\n      $2defines$2: [ $2NAPI_DISABLE_CPP_EXCEPTIONS$2 ],\n      $2conditions$2: [\n        [\'OS==\"win\"\', { $2defines$2: [ $2_HAS_EXCEPTIONS=1$2 ] }]\n      ]' ],
+      [/([ ]*)'include_dirs': \[/g, '$1\'include_dirs\': [\n$1  \'<!(node -p "require(\\\'node-addon-api\\\').include_dir")\','],
+      [/([ ]*)"include_dirs": \[/g, '$1"include_dirs": [\n$1  "<!(node -p \'require(\\\"node-addon-api\\\").include_dir\')",'],
+      [/[ ]*("|')<!\(node -e ("|'|\\"|\\')require\(("|'|\\"|\\')nan("|'|\\"|\\')\)("|'|\\"|\\')\)("|')(,|)[\r\n]/g, ''],
+      [/([ ]*)("|')target_name("|'): ("|')(.+?)("|'),/g, '$1$2target_name$2: $4$5$6,\n      $2cflags!$2: [ $2-fno-exceptions$2 ],\n      $2cflags_cc!$2: [ $2-fno-exceptions$2 ],\n      $2defines$2: [ $2NAPI_DISABLE_CPP_EXCEPTIONS$2 ],\n      $2conditions$2: [\n        [\'OS==\"win\"\', { $2defines$2: [ $2_HAS_EXCEPTIONS=1$2 ] }]\n      ]']
     ]
   };
 }
 
-var SourceFileOperations = [
-  [ /Nan::SetMethod\(target,[\s]*\"(.*)\"[\s]*,[\s]*([^)]+)\)/g, 'exports.Set(Napi::String::New(env, \"$1\"), Napi::Function::New(env, $2))' ],
+const SourceFileOperations = [
+  [/Nan::SetMethod\(target,[\s]*\"(.*)\"[\s]*,[\s]*([^)]+)\)/g, 'exports.Set(Napi::String::New(env, \"$1\"), Napi::Function::New(env, $2))'],
 
-  [ /v8::Local<v8::FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);(?:\w+->Reset\(\1\))?\s+\1->SetClassName\(Nan::String::New\("(\w+)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$2", {' ],
-  [ /Local<FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);\s+(\w+)\.Reset\((\1)\);\s+\1->SetClassName\((Nan::String::New|Nan::New<(v8::)*String>)\("(.+?)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$6", {'],
-  [ /Local<FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);(?:\w+->Reset\(\1\))?\s+\1->SetClassName\(Nan::String::New\("(\w+)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$2", {' ],
-  [ /Nan::New<v8::FunctionTemplate>\(([\w\d:]+)\)->GetFunction\(\)/g, 'Napi::Function::New(env, $1)' ],
-  [ /Nan::New<FunctionTemplate>\(([\w\d:]+)\)->GetFunction()/g, 'Napi::Function::New(env, $1);' ],
-  [ /Nan::New<v8::FunctionTemplate>\(([\w\d:]+)\)/g, 'Napi::Function::New(env, $1)' ],
-  [ /Nan::New<FunctionTemplate>\(([\w\d:]+)\)/g, 'Napi::Function::New(env, $1)' ],
+  [/v8::Local<v8::FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);(?:\w+->Reset\(\1\))?\s+\1->SetClassName\(Nan::String::New\("(\w+)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$2", {'],
+  [/Local<FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);\s+(\w+)\.Reset\((\1)\);\s+\1->SetClassName\((Nan::String::New|Nan::New<(v8::)*String>)\("(.+?)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$6", {'],
+  [/Local<FunctionTemplate>\s+(\w+)\s*=\s*Nan::New<FunctionTemplate>\([\w\d:]+\);(?:\w+->Reset\(\1\))?\s+\1->SetClassName\(Nan::String::New\("(\w+)"\)\);/g, 'Napi::Function $1 = DefineClass(env, "$2", {'],
+  [/Nan::New<v8::FunctionTemplate>\(([\w\d:]+)\)->GetFunction\(\)/g, 'Napi::Function::New(env, $1)'],
+  [/Nan::New<FunctionTemplate>\(([\w\d:]+)\)->GetFunction()/g, 'Napi::Function::New(env, $1);'],
+  [/Nan::New<v8::FunctionTemplate>\(([\w\d:]+)\)/g, 'Napi::Function::New(env, $1)'],
+  [/Nan::New<FunctionTemplate>\(([\w\d:]+)\)/g, 'Napi::Function::New(env, $1)'],
 
   // FunctionTemplate to FunctionReference
-  [ /Nan::Persistent<(v8::)*FunctionTemplate>/g, 'Napi::FunctionReference' ],
-  [ /Nan::Persistent<(v8::)*Function>/g, 'Napi::FunctionReference' ],
-  [ /v8::Local<v8::FunctionTemplate>/g, 'Napi::FunctionReference' ],
-  [ /Local<FunctionTemplate>/g, 'Napi::FunctionReference' ],
-  [ /v8::FunctionTemplate/g, 'Napi::FunctionReference' ],
-  [ /FunctionTemplate/g, 'Napi::FunctionReference' ],
+  [/Nan::Persistent<(v8::)*FunctionTemplate>/g, 'Napi::FunctionReference'],
+  [/Nan::Persistent<(v8::)*Function>/g, 'Napi::FunctionReference'],
+  [/v8::Local<v8::FunctionTemplate>/g, 'Napi::FunctionReference'],
+  [/Local<FunctionTemplate>/g, 'Napi::FunctionReference'],
+  [/v8::FunctionTemplate/g, 'Napi::FunctionReference'],
+  [/FunctionTemplate/g, 'Napi::FunctionReference'],
 
-
-  [ /([ ]*)Nan::SetPrototypeMethod\(\w+, "(\w+)", (\w+)\);/g, '$1InstanceMethod("$2", &$3),' ],
-  [ /([ ]*)(?:\w+\.Reset\(\w+\);\s+)?\(target\)\.Set\("(\w+)",\s*Nan::GetFunction\((\w+)\)\);/gm,
+  [/([ ]*)Nan::SetPrototypeMethod\(\w+, "(\w+)", (\w+)\);/g, '$1InstanceMethod("$2", &$3),'],
+  [/([ ]*)(?:\w+\.Reset\(\w+\);\s+)?\(target\)\.Set\("(\w+)",\s*Nan::GetFunction\((\w+)\)\);/gm,
     '});\n\n' +
     '$1constructor = Napi::Persistent($3);\n' +
     '$1constructor.SuppressDestruct();\n' +
-    '$1target.Set("$2", $3);' ],
-
+    '$1target.Set("$2", $3);'],
 
   // TODO: Other attribute combinations
-  [ /static_cast<PropertyAttribute>\(ReadOnly\s*\|\s*DontDelete\)/gm,
-    'static_cast<napi_property_attributes>(napi_enumerable | napi_configurable)' ],
+  [/static_cast<PropertyAttribute>\(ReadOnly\s*\|\s*DontDelete\)/gm,
+    'static_cast<napi_property_attributes>(napi_enumerable | napi_configurable)'],
 
-  [ /([\w\d:<>]+?)::Cast\((.+?)\)/g, '$2.As<$1>()' ],
+  [/([\w\d:<>]+?)::Cast\((.+?)\)/g, '$2.As<$1>()'],
 
-  [ /\*Nan::Utf8String\(([^)]+)\)/g, '$1->As<Napi::String>().Utf8Value().c_str()' ],
-  [ /Nan::Utf8String +(\w+)\(([^)]+)\)/g, 'std::string $1 = $2.As<Napi::String>()' ],
-  [ /Nan::Utf8String/g, 'std::string' ],
+  [/\*Nan::Utf8String\(([^)]+)\)/g, '$1->As<Napi::String>().Utf8Value().c_str()'],
+  [/Nan::Utf8String +(\w+)\(([^)]+)\)/g, 'std::string $1 = $2.As<Napi::String>()'],
+  [/Nan::Utf8String/g, 'std::string'],
 
-  [ /v8::String::Utf8Value (.+?)\((.+?)\)/g, 'Napi::String $1(env, $2)' ],
-  [ /String::Utf8Value (.+?)\((.+?)\)/g, 'Napi::String $1(env, $2)' ],
-  [ /\.length\(\)/g, '.Length()' ],
+  [/v8::String::Utf8Value (.+?)\((.+?)\)/g, 'Napi::String $1(env, $2)'],
+  [/String::Utf8Value (.+?)\((.+?)\)/g, 'Napi::String $1(env, $2)'],
+  [/\.length\(\)/g, '.Length()'],
 
-  [ /Nan::MakeCallback\(([^,]+),[\s\\]+([^,]+),/gm, '$2.MakeCallback($1,' ],
+  [/Nan::MakeCallback\(([^,]+),[\s\\]+([^,]+),/gm, '$2.MakeCallback($1,'],
 
-  [ /class\s+(\w+)\s*:\s*public\s+Nan::ObjectWrap/g, 'class $1 : public Napi::ObjectWrap<$1>' ],
-  [ /(\w+)\(([^\)]*)\)\s*:\s*Nan::ObjectWrap\(\)\s*(,)?/gm, '$1($2) : Napi::ObjectWrap<$1>()$3' ],
+  [/class\s+(\w+)\s*:\s*public\s+Nan::ObjectWrap/g, 'class $1 : public Napi::ObjectWrap<$1>'],
+  [/(\w+)\(([^\)]*)\)\s*:\s*Nan::ObjectWrap\(\)\s*(,)?/gm, '$1($2) : Napi::ObjectWrap<$1>()$3'],
 
   // HandleOKCallback to OnOK
-  [ /HandleOKCallback/g, 'OnOK' ],
+  [/HandleOKCallback/g, 'OnOK'],
   // HandleErrorCallback to OnError
-  [ /HandleErrorCallback/g, 'OnError' ],
+  [/HandleErrorCallback/g, 'OnError'],
 
   // ex. .As<Function>() to .As<Napi::Object>()
-  [ /\.As<v8::(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>\(\)/g, '.As<Napi::$1>()' ],
-  [ /\.As<(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>\(\)/g, '.As<Napi::$1>()' ],
+  [/\.As<v8::(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>\(\)/g, '.As<Napi::$1>()'],
+  [/\.As<(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>\(\)/g, '.As<Napi::$1>()'],
 
   // ex. Nan::New<Number>(info[0]) to Napi::Number::New(info[0])
-  [ /Nan::New<(v8::)*Integer>\((.+?)\)/g, 'Napi::Number::New(env, $2)' ],
-  [ /Nan::New\(([0-9\.]+)\)/g, 'Napi::Number::New(env, $1)' ],
-  [ /Nan::New<(v8::)*String>\("(.+?)"\)/g, 'Napi::String::New(env, "$2")' ],
-  [ /Nan::New\("(.+?)"\)/g, 'Napi::String::New(env, "$1")' ],
-  [ /Nan::New<(v8::)*(.+?)>\(\)/g, 'Napi::$2::New(env)' ],
-  [ /Nan::New<(.+?)>\(\)/g, 'Napi::$1::New(env)' ],
-  [ /Nan::New<(v8::)*(.+?)>\(/g, 'Napi::$2::New(env, ' ],
-  [ /Nan::New<(.+?)>\(/g, 'Napi::$1::New(env, ' ],
-  [ /Nan::NewBuffer\(/g, 'Napi::Buffer<char>::New(env, ' ],
+  [/Nan::New<(v8::)*Integer>\((.+?)\)/g, 'Napi::Number::New(env, $2)'],
+  [/Nan::New\(([0-9\.]+)\)/g, 'Napi::Number::New(env, $1)'],
+  [/Nan::New<(v8::)*String>\("(.+?)"\)/g, 'Napi::String::New(env, "$2")'],
+  [/Nan::New\("(.+?)"\)/g, 'Napi::String::New(env, "$1")'],
+  [/Nan::New<(v8::)*(.+?)>\(\)/g, 'Napi::$2::New(env)'],
+  [/Nan::New<(.+?)>\(\)/g, 'Napi::$1::New(env)'],
+  [/Nan::New<(v8::)*(.+?)>\(/g, 'Napi::$2::New(env, '],
+  [/Nan::New<(.+?)>\(/g, 'Napi::$1::New(env, '],
+  [/Nan::NewBuffer\(/g, 'Napi::Buffer<char>::New(env, '],
   // TODO: Properly handle this
-  [ /Nan::New\(/g, 'Napi::New(env, ' ],
+  [/Nan::New\(/g, 'Napi::New(env, '],
 
-  [ /\.IsInt32\(\)/g, '.IsNumber()' ],
-  [ /->IsInt32\(\)/g, '.IsNumber()' ],
+  [/\.IsInt32\(\)/g, '.IsNumber()'],
+  [/->IsInt32\(\)/g, '.IsNumber()'],
 
-
-  [ /(.+?)->BooleanValue\(\)/g, '$1.As<Napi::Boolean>().Value()' ],
-  [ /(.+?)->Int32Value\(\)/g, '$1.As<Napi::Number>().Int32Value()' ],
-  [ /(.+?)->Uint32Value\(\)/g, '$1.As<Napi::Number>().Uint32Value()' ],
-  [ /(.+?)->IntegerValue\(\)/g, '$1.As<Napi::Number>().Int64Value()' ],
-  [ /(.+?)->NumberValue\(\)/g, '$1.As<Napi::Number>().DoubleValue()' ],
+  [/(.+?)->BooleanValue\(\)/g, '$1.As<Napi::Boolean>().Value()'],
+  [/(.+?)->Int32Value\(\)/g, '$1.As<Napi::Number>().Int32Value()'],
+  [/(.+?)->Uint32Value\(\)/g, '$1.As<Napi::Number>().Uint32Value()'],
+  [/(.+?)->IntegerValue\(\)/g, '$1.As<Napi::Number>().Int64Value()'],
+  [/(.+?)->NumberValue\(\)/g, '$1.As<Napi::Number>().DoubleValue()'],
 
   // ex. Nan::To<bool>(info[0]) to info[0].Value()
-  [ /Nan::To<v8::(Boolean|String|Number|Object|Array|Symbol|Function)>\((.+?)\)/g, '$2.To<Napi::$1>()' ],
-  [ /Nan::To<(Boolean|String|Number|Object|Array|Symbol|Function)>\((.+?)\)/g, '$2.To<Napi::$1>()' ],
+  [/Nan::To<v8::(Boolean|String|Number|Object|Array|Symbol|Function)>\((.+?)\)/g, '$2.To<Napi::$1>()'],
+  [/Nan::To<(Boolean|String|Number|Object|Array|Symbol|Function)>\((.+?)\)/g, '$2.To<Napi::$1>()'],
   // ex. Nan::To<bool>(info[0]) to info[0].As<Napi::Boolean>().Value()
-  [ /Nan::To<bool>\((.+?)\)/g, '$1.As<Napi::Boolean>().Value()' ],
+  [/Nan::To<bool>\((.+?)\)/g, '$1.As<Napi::Boolean>().Value()'],
   // ex. Nan::To<int>(info[0]) to info[0].As<Napi::Number>().Int32Value()
-  [ /Nan::To<int>\((.+?)\)/g, '$1.As<Napi::Number>().Int32Value()' ],
+  [/Nan::To<int>\((.+?)\)/g, '$1.As<Napi::Number>().Int32Value()'],
   // ex. Nan::To<int32_t>(info[0]) to info[0].As<Napi::Number>().Int32Value()
-  [ /Nan::To<int32_t>\((.+?)\)/g, '$1.As<Napi::Number>().Int32Value()' ],
+  [/Nan::To<int32_t>\((.+?)\)/g, '$1.As<Napi::Number>().Int32Value()'],
   // ex. Nan::To<uint32_t>(info[0]) to info[0].As<Napi::Number>().Uint32Value()
-  [ /Nan::To<uint32_t>\((.+?)\)/g, '$1.As<Napi::Number>().Uint32Value()' ],
+  [/Nan::To<uint32_t>\((.+?)\)/g, '$1.As<Napi::Number>().Uint32Value()'],
   // ex. Nan::To<int64_t>(info[0]) to info[0].As<Napi::Number>().Int64Value()
-  [ /Nan::To<int64_t>\((.+?)\)/g, '$1.As<Napi::Number>().Int64Value()' ],
+  [/Nan::To<int64_t>\((.+?)\)/g, '$1.As<Napi::Number>().Int64Value()'],
   // ex. Nan::To<float>(info[0]) to info[0].As<Napi::Number>().FloatValue()
-  [ /Nan::To<float>\((.+?)\)/g, '$1.As<Napi::Number>().FloatValue()' ],
+  [/Nan::To<float>\((.+?)\)/g, '$1.As<Napi::Number>().FloatValue()'],
   // ex. Nan::To<double>(info[0]) to info[0].As<Napi::Number>().DoubleValue()
-  [ /Nan::To<double>\((.+?)\)/g, '$1.As<Napi::Number>().DoubleValue()' ],
+  [/Nan::To<double>\((.+?)\)/g, '$1.As<Napi::Number>().DoubleValue()'],
 
-  [ /Nan::New\((\w+)\)->HasInstance\((\w+)\)/g, '$2.InstanceOf($1.Value())' ],
+  [/Nan::New\((\w+)\)->HasInstance\((\w+)\)/g, '$2.InstanceOf($1.Value())'],
 
-  [ /Nan::Has\(([^,]+),\s*/gm, '($1).Has(' ],
-  [ /\.Has\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\)/gm, '.Has($1)' ],
-  [ /\.Has\([\s|\\]*Nan::New\(([^)]+)\)\)/gm, '.Has($1)' ],
+  [/Nan::Has\(([^,]+),\s*/gm, '($1).Has('],
+  [/\.Has\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\)/gm, '.Has($1)'],
+  [/\.Has\([\s|\\]*Nan::New\(([^)]+)\)\)/gm, '.Has($1)'],
 
-  [ /Nan::Get\(([^,]+),\s*/gm, '($1).Get(' ],
-  [ /\.Get\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\)/gm, '.Get($1)' ],
-  [ /\.Get\([\s|\\]*Nan::New\(([^)]+)\)\)/gm, '.Get($1)' ],
+  [/Nan::Get\(([^,]+),\s*/gm, '($1).Get('],
+  [/\.Get\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\)/gm, '.Get($1)'],
+  [/\.Get\([\s|\\]*Nan::New\(([^)]+)\)\)/gm, '.Get($1)'],
 
-  [ /Nan::Set\(([^,]+),\s*/gm, '($1).Set(' ],
-  [ /\.Set\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\s*,/gm, '.Set($1,' ],
-  [ /\.Set\([\s|\\]*Nan::New\(([^)]+)\)\s*,/gm, '.Set($1,' ],
-
+  [/Nan::Set\(([^,]+),\s*/gm, '($1).Set('],
+  [/\.Set\([\s|\\]*Nan::New<(v8::)*String>\(([^)]+)\)\s*,/gm, '.Set($1,'],
+  [/\.Set\([\s|\\]*Nan::New\(([^)]+)\)\s*,/gm, '.Set($1,'],
 
   // ex. node::Buffer::HasInstance(info[0]) to info[0].IsBuffer()
-  [ /node::Buffer::HasInstance\((.+?)\)/g, '$1.IsBuffer()' ],
+  [/node::Buffer::HasInstance\((.+?)\)/g, '$1.IsBuffer()'],
   // ex. node::Buffer::Length(info[0]) to info[0].Length()
-  [ /node::Buffer::Length\((.+?)\)/g, '$1.As<Napi::Buffer<char>>().Length()' ],
+  [/node::Buffer::Length\((.+?)\)/g, '$1.As<Napi::Buffer<char>>().Length()'],
   // ex. node::Buffer::Data(info[0]) to info[0].Data()
-  [ /node::Buffer::Data\((.+?)\)/g, '$1.As<Napi::Buffer<char>>().Data()' ],
-  [ /Nan::CopyBuffer\(/g, 'Napi::Buffer::Copy(env, ' ],
+  [/node::Buffer::Data\((.+?)\)/g, '$1.As<Napi::Buffer<char>>().Data()'],
+  [/Nan::CopyBuffer\(/g, 'Napi::Buffer::Copy(env, '],
 
   // Nan::AsyncQueueWorker(worker)
-  [ /Nan::AsyncQueueWorker\((.+)\);/g, '$1.Queue();' ],
-  [ /Nan::(Undefined|Null|True|False)\(\)/g, 'env.$1()' ],
+  [/Nan::AsyncQueueWorker\((.+)\);/g, '$1.Queue();'],
+  [/Nan::(Undefined|Null|True|False)\(\)/g, 'env.$1()'],
 
   // Nan::ThrowError(error) to Napi::Error::New(env, error).ThrowAsJavaScriptException()
-  [ /([ ]*)return Nan::Throw(\w*?)Error\((.+?)\);/g, '$1Napi::$2Error::New(env, $3).ThrowAsJavaScriptException();\n$1return env.Null();' ],
-  [ /Nan::Throw(\w*?)Error\((.+?)\);\n(\s*)return;/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n$3return env.Null();' ],
-  [ /Nan::Throw(\w*?)Error\((.+?)\);/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n' ],
+  [/([ ]*)return Nan::Throw(\w*?)Error\((.+?)\);/g, '$1Napi::$2Error::New(env, $3).ThrowAsJavaScriptException();\n$1return env.Null();'],
+  [/Nan::Throw(\w*?)Error\((.+?)\);\n(\s*)return;/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n$3return env.Null();'],
+  [/Nan::Throw(\w*?)Error\((.+?)\);/g, 'Napi::$1Error::New(env, $2).ThrowAsJavaScriptException();\n'],
   // Nan::RangeError(error) to Napi::RangeError::New(env, error)
-  [ /Nan::(\w*?)Error\((.+)\)/g, 'Napi::$1Error::New(env, $2)' ],
+  [/Nan::(\w*?)Error\((.+)\)/g, 'Napi::$1Error::New(env, $2)'],
 
-  [ /Nan::Set\((.+?),\n* *(.+?),\n* *(.+?),\n* *(.+?)\)/g, '$1.Set($2, $3, $4)' ],
+  [/Nan::Set\((.+?),\n* *(.+?),\n* *(.+?),\n* *(.+?)\)/g, '$1.Set($2, $3, $4)'],
 
-  [ /Nan::(Escapable)?HandleScope\s+(\w+)\s*;/g, 'Napi::$1HandleScope $2(env);' ],
-  [ /Nan::(Escapable)?HandleScope/g, 'Napi::$1HandleScope' ],
-  [ /Nan::ForceSet\(([^,]+), ?/g, '$1->DefineProperty(' ],
-  [ /\.ForceSet\(Napi::String::New\(env, "(\w+)"\),\s*?/g, '.DefineProperty("$1", ' ],
+  [/Nan::(Escapable)?HandleScope\s+(\w+)\s*;/g, 'Napi::$1HandleScope $2(env);'],
+  [/Nan::(Escapable)?HandleScope/g, 'Napi::$1HandleScope'],
+  [/Nan::ForceSet\(([^,]+), ?/g, '$1->DefineProperty('],
+  [/\.ForceSet\(Napi::String::New\(env, "(\w+)"\),\s*?/g, '.DefineProperty("$1", '],
   // [ /Nan::GetPropertyNames\(([^,]+)\)/, '$1->GetPropertyNames()' ],
-  [ /Nan::Equals\(([^,]+),/g, '$1.StrictEquals(' ],
+  [/Nan::Equals\(([^,]+),/g, '$1.StrictEquals('],
 
+  [/(.+)->Set\(/g, '$1.Set\('],
 
-  [ /(.+)->Set\(/g, '$1.Set\(' ],
+  [/Nan::Callback/g, 'Napi::FunctionReference'],
 
+  [/Nan::Persistent<Object>/g, 'Napi::ObjectReference'],
+  [/Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target/g, 'Napi::Env& env, Napi::Object& target'],
 
-  [ /Nan::Callback/g, 'Napi::FunctionReference' ],
+  [/(\w+)\*\s+(\w+)\s*=\s*Nan::ObjectWrap::Unwrap<\w+>\(info\.This\(\)\);/g, '$1* $2 = this;'],
+  [/Nan::ObjectWrap::Unwrap<(\w+)>\((.*)\);/g, '$2.Unwrap<$1>();'],
 
+  [/Nan::NAN_METHOD_RETURN_TYPE/g, 'void'],
+  [/NAN_INLINE/g, 'inline'],
 
-  [ /Nan::Persistent<Object>/g, 'Napi::ObjectReference' ],
-  [ /Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target/g, 'Napi::Env& env, Napi::Object& target' ],
+  [/Nan::NAN_METHOD_ARGS_TYPE/g, 'const Napi::CallbackInfo&'],
+  [/NAN_METHOD\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)'],
+  [/static\s*NAN_GETTER\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)'],
+  [/NAN_GETTER\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)'],
+  [/static\s*NAN_SETTER\(([\w\d:]+?)\)/g, 'void $1(const Napi::CallbackInfo& info, const Napi::Value& value)'],
+  [/NAN_SETTER\(([\w\d:]+?)\)/g, 'void $1(const Napi::CallbackInfo& info, const Napi::Value& value)'],
+  [/void Init\((v8::)*Local<(v8::)*Object> exports\)/g, 'Napi::Object Init(Napi::Env env, Napi::Object exports)'],
+  [/NAN_MODULE_INIT\(([\w\d:]+?)\);/g, 'Napi::Object $1(Napi::Env env, Napi::Object exports);'],
+  [/NAN_MODULE_INIT\(([\w\d:]+?)\)/g, 'Napi::Object $1(Napi::Env env, Napi::Object exports)'],
 
-  [ /(\w+)\*\s+(\w+)\s*=\s*Nan::ObjectWrap::Unwrap<\w+>\(info\.This\(\)\);/g, '$1* $2 = this;' ],
-  [ /Nan::ObjectWrap::Unwrap<(\w+)>\((.*)\);/g, '$2.Unwrap<$1>();' ],
+  [/::(Init(?:ialize)?)\(target\)/g, '::$1(env, target, module)'],
+  [/constructor_template/g, 'constructor'],
 
-  [ /Nan::NAN_METHOD_RETURN_TYPE/g, 'void' ],
-  [ /NAN_INLINE/g, 'inline' ],
+  [/Nan::FunctionCallbackInfo<(v8::)?Value>[ ]*& [ ]*info\)[ ]*{\n*([ ]*)/gm, 'Napi::CallbackInfo& info) {\n$2Napi::Env env = info.Env();\n$2'],
+  [/Nan::FunctionCallbackInfo<(v8::)*Value>\s*&\s*info\);/g, 'Napi::CallbackInfo& info);'],
+  [/Nan::FunctionCallbackInfo<(v8::)*Value>\s*&/g, 'Napi::CallbackInfo&'],
 
-  [ /Nan::NAN_METHOD_ARGS_TYPE/g, 'const Napi::CallbackInfo&' ],
-  [ /NAN_METHOD\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)'],
-  [ /static\s*NAN_GETTER\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)' ],
-  [ /NAN_GETTER\(([\w\d:]+?)\)/g, 'Napi::Value $1(const Napi::CallbackInfo& info)' ],
-  [ /static\s*NAN_SETTER\(([\w\d:]+?)\)/g, 'void $1(const Napi::CallbackInfo& info, const Napi::Value& value)' ],
-  [ /NAN_SETTER\(([\w\d:]+?)\)/g, 'void $1(const Napi::CallbackInfo& info, const Napi::Value& value)' ],
-  [ /void Init\((v8::)*Local<(v8::)*Object> exports\)/g, 'Napi::Object Init(Napi::Env env, Napi::Object exports)' ],
-  [ /NAN_MODULE_INIT\(([\w\d:]+?)\);/g, 'Napi::Object $1(Napi::Env env, Napi::Object exports);' ],
-  [ /NAN_MODULE_INIT\(([\w\d:]+?)\)/g, 'Napi::Object $1(Napi::Env env, Napi::Object exports)' ],
+  [/Buffer::HasInstance\(([^)]+)\)/g, '$1.IsBuffer()'],
 
-
-  [ /::(Init(?:ialize)?)\(target\)/g, '::$1(env, target, module)' ],
-  [ /constructor_template/g, 'constructor' ],
-
-  [ /Nan::FunctionCallbackInfo<(v8::)?Value>[ ]*& [ ]*info\)[ ]*{\n*([ ]*)/gm, 'Napi::CallbackInfo& info) {\n$2Napi::Env env = info.Env();\n$2' ],
-  [ /Nan::FunctionCallbackInfo<(v8::)*Value>\s*&\s*info\);/g, 'Napi::CallbackInfo& info);' ],
-  [ /Nan::FunctionCallbackInfo<(v8::)*Value>\s*&/g, 'Napi::CallbackInfo&' ],
-
-  [ /Buffer::HasInstance\(([^)]+)\)/g, '$1.IsBuffer()' ],
-
-  [ /info\[(\d+)\]->/g, 'info[$1].' ],
-  [ /info\[([\w\d]+)\]->/g, 'info[$1].' ],
-  [ /info\.This\(\)->/g, 'info.This().' ],
-  [ /->Is(Object|String|Int32|Number)\(\)/g, '.Is$1()' ],
-  [ /info.GetReturnValue\(\).SetUndefined\(\)/g, 'return env.Undefined()' ],
-  [ /info\.GetReturnValue\(\)\.Set\(((\n|.)+?)\);/g, 'return $1;' ],
-
+  [/info\[(\d+)\]->/g, 'info[$1].'],
+  [/info\[([\w\d]+)\]->/g, 'info[$1].'],
+  [/info\.This\(\)->/g, 'info.This().'],
+  [/->Is(Object|String|Int32|Number)\(\)/g, '.Is$1()'],
+  [/info.GetReturnValue\(\).SetUndefined\(\)/g, 'return env.Undefined()'],
+  [/info\.GetReturnValue\(\)\.Set\(((\n|.)+?)\);/g, 'return $1;'],
 
   // ex. Local<Value> to Napi::Value
-  [ /v8::Local<v8::(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>/g, 'Napi::$1' ],
-  [ /Local<(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>/g, 'Napi::$1' ],
+  [/v8::Local<v8::(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>/g, 'Napi::$1'],
+  [/Local<(Value|Boolean|String|Number|Object|Array|Symbol|External|Function)>/g, 'Napi::$1'],
 
   // Declare an env in helper functions that take a Napi::Value
-  [ /(\w+)\(Napi::Value (\w+)(,\s*[^\()]+)?\)\s*{\n*([ ]*)/gm, '$1(Napi::Value $2$3) {\n$4Napi::Env env = $2.Env();\n$4' ],
+  [/(\w+)\(Napi::Value (\w+)(,\s*[^\()]+)?\)\s*{\n*([ ]*)/gm, '$1(Napi::Value $2$3) {\n$4Napi::Env env = $2.Env();\n$4'],
 
   // delete #include <node.h> and/or <v8.h>
-  [ /#include +(<|")(?:node|nan).h("|>)/g, "#include $1napi.h$2\n#include $1uv.h$2" ],
+  [/#include +(<|")(?:node|nan).h("|>)/g, '#include $1napi.h$2\n#include $1uv.h$2'],
   // NODE_MODULE to NODE_API_MODULE
-  [ /NODE_MODULE/g, 'NODE_API_MODULE' ],
-  [ /Nan::/g, 'Napi::' ],
-  [ /nan.h/g, 'napi.h' ],
+  [/NODE_MODULE/g, 'NODE_API_MODULE'],
+  [/Nan::/g, 'Napi::'],
+  [/nan.h/g, 'napi.h'],
 
   // delete .FromJust()
-  [ /\.FromJust\(\)/g, '' ],
+  [/\.FromJust\(\)/g, ''],
   // delete .ToLocalCheck()
-  [ /\.ToLocalChecked\(\)/g, '' ],
-  [ /^.*->SetInternalFieldCount\(.*$/gm, '' ],
+  [/\.ToLocalChecked\(\)/g, ''],
+  [/^.*->SetInternalFieldCount\(.*$/gm, ''],
 
   // replace using node; and/or using v8; to using Napi;
-  [ /using (node|v8);/g, 'using Napi;' ],
-  [ /using namespace (node|Nan|v8);/g, 'using namespace Napi;' ],
+  [/using (node|v8);/g, 'using Napi;'],
+  [/using namespace (node|Nan|v8);/g, 'using namespace Napi;'],
   // delete using v8::Local;
-  [ /using v8::Local;\n/g, '' ],
+  [/using v8::Local;\n/g, ''],
   // replace using v8::XXX; with using Napi::XXX
-  [ /using v8::([A-Za-z]+);/g, 'using Napi::$1;' ],
+  [/using v8::([A-Za-z]+);/g, 'using Napi::$1;']
 
 ];
 
-var paths = listFiles(dir);
-paths.forEach(function(dirEntry) {
-  var filename = dirEntry.split('\\').pop().split('/').pop();
+const paths = listFiles(dir);
+paths.forEach(function (dirEntry) {
+  const filename = dirEntry.split('\\').pop().split('/').pop();
 
   // Check whether the file is a source file or a config file
   // then execute function accordingly
-  var sourcePattern = /.+\.h|.+\.cc|.+\.cpp/;
+  const sourcePattern = /.+\.h|.+\.cc|.+\.cpp/;
   if (sourcePattern.test(filename)) {
     convertFile(dirEntry, SourceFileOperations);
   } else if (ConfigFileOperations[filename] != null) {
@@ -271,12 +262,12 @@ paths.forEach(function(dirEntry) {
   }
 });
 
-function listFiles(dir, filelist) {
-  var files = fs.readdirSync(dir);
+function listFiles (dir, filelist) {
+  const files = fs.readdirSync(dir);
   filelist = filelist || [];
-  files.forEach(function(file) {
+  files.forEach(function (file) {
     if (file === 'node_modules') {
-      return
+      return;
     }
 
     if (fs.statSync(path.join(dir, file)).isDirectory()) {
@@ -288,21 +279,21 @@ function listFiles(dir, filelist) {
   return filelist;
 }
 
-function convert(content, operations) {
-  for (let i = 0; i < operations.length; i ++) {
-    let operation = operations[i];
+function convert (content, operations) {
+  for (let i = 0; i < operations.length; i++) {
+    const operation = operations[i];
     content = content.replace(operation[0], operation[1]);
   }
   return content;
 }
 
-function convertFile(fileName, operations) {
-  fs.readFile(fileName, "utf-8", function (err, file) {
+function convertFile (fileName, operations) {
+  fs.readFile(fileName, 'utf-8', function (err, file) {
     if (err) throw err;
 
     file = convert(file, operations);
 
-    fs.writeFile(fileName, file, function(err){
+    fs.writeFile(fileName, file, function (err) {
       if (err) throw err;
     });
   });


### PR DESCRIPTION
Format all JavaScript via `eslint` and all C++ via `clang-format`.

Fixes: #1146 