### PR TITLE
test: Check for tsfn in condition_variable wait

### DIFF
--- a/test/threadsafe_function/threadsafe_function_sum.cc
+++ b/test/threadsafe_function/threadsafe_function_sum.cc
@@ -81,7 +81,7 @@ public:
   // Entry point for std::thread
   void entryDelayedTSFN(int threadId) {
     std::unique_lock<std::mutex> lk(mtx);
-    cv.wait(lk);
+    cv.wait(lk, [this] { return this->tsfn != nullptr; });
     tsfn.BlockingCall([=](Napi::Env env, Function callback) {
       callback.Call({Number::New(env, static_cast<double>(threadId))});
     });

--- a/test/typed_threadsafe_function/typed_threadsafe_function_sum.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_sum.cc
@@ -99,7 +99,7 @@ class DelayedTSFNTask {
   // Entry point for std::thread
   void entryDelayedTSFN(int threadId) {
     std::unique_lock<std::mutex> lk(mtx);
-    cv.wait(lk);
+    cv.wait(lk, [this] { return this->tsfn != nullptr; });
     tsfn.BlockingCall(new double(threadId));
     tsfn.Release();
   };


### PR DESCRIPTION
Under certain conditions, the main thread may set the TSFN and notify the condition variable prior to the thread waiting on it, causing an indefinite hang. This PR fixes the hang by skipping the wait if the TSFN has been set.

Fixes: #1150