### PR TITLE
Add condition for window to find eslint

### DIFF
--- a/tools/eslint-format.js
+++ b/tools/eslint-format.js
@@ -4,6 +4,8 @@ const spawn = require('child_process').spawnSync;
 
 const filesToCheck = '*.js';
 const FORMAT_START = process.env.FORMAT_START || 'main';
+const IS_WIN = process.platform === 'win32';
+const ESLINT_PATH = IS_WIN ? 'node_modules\\.bin\\eslint.cmd' : 'node_modules/.bin/eslint';
 
 function main (args) {
   let fix = false;
@@ -44,9 +46,15 @@ function main (args) {
   if (fix) {
     options.push('--fix');
   }
-  const result = spawn('node_modules/.bin/eslint', [...options], {
+
+  const result = spawn(ESLINT_PATH, [...options], {
     encoding: 'utf-8'
   });
+
+  if (result.error && result.error.errno === 'ENOENT') {
+    console.error('Eslint not found! Eslint is supposed to be found at ', ESLINT_PATH);
+    return 2;
+  }
 
   if (result.status === 1) {
     console.error('Eslint error:', result.stdout);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
A small fix for `eslint-format` based on the issue https://github.com/nodejs/node-addon-api/issues/1175. At the moment `npm run lint/fix` is failing silently on windows because it cannot find `eslint` cmd on windows and we do not check for that. 