### PR TITLE
test: Add TypedArray ElementSize, ByteLength and ByteOffset tests

### DIFF
--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -184,6 +184,11 @@ Value GetTypedArrayLength(const CallbackInfo& info) {
   return Number::New(info.Env(), static_cast<double>(array.ElementLength()));
 }
 
+Value GetTypedArraySize(const CallbackInfo& info) {
+  TypedArray array = info[0].As<TypedArray>();
+  return Number::New(info.Env(), static_cast<double>(array.ElementSize()));
+}
+
 Value GetTypedArrayBuffer(const CallbackInfo& info) {
   TypedArray array = info[0].As<TypedArray>();
   return array.ArrayBuffer();
@@ -287,6 +292,7 @@ Object InitTypedArray(Env env) {
       Function::New(env, CreateInvalidTypedArray);
   exports["getTypedArrayType"] = Function::New(env, GetTypedArrayType);
   exports["getTypedArrayLength"] = Function::New(env, GetTypedArrayLength);
+  exports["getTypedArraySize"] = Function::New(env, GetTypedArraySize);
   exports["getTypedArrayBuffer"] = Function::New(env, GetTypedArrayBuffer);
   exports["getTypedArrayElement"] = Function::New(env, GetTypedArrayElement);
   exports["setTypedArrayElement"] = Function::New(env, SetTypedArrayElement);

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -189,6 +189,11 @@ Value GetTypedArraySize(const CallbackInfo& info) {
   return Number::New(info.Env(), static_cast<double>(array.ElementSize()));
 }
 
+Value GetTypedArrayByteOffset(const CallbackInfo& info) {
+  TypedArray array = info[0].As<TypedArray>();
+  return Number::New(info.Env(), static_cast<double>(array.ByteOffset()));
+}
+
 Value GetTypedArrayByteLength(const CallbackInfo& info) {
   TypedArray array = info[0].As<TypedArray>();
   return Number::New(info.Env(), static_cast<double>(array.ByteLength()));
@@ -298,6 +303,8 @@ Object InitTypedArray(Env env) {
   exports["getTypedArrayType"] = Function::New(env, GetTypedArrayType);
   exports["getTypedArrayLength"] = Function::New(env, GetTypedArrayLength);
   exports["getTypedArraySize"] = Function::New(env, GetTypedArraySize);
+  exports["getTypedArrayByteOffset"] =
+      Function::New(env, GetTypedArrayByteOffset);
   exports["getTypedArrayByteLength"] =
       Function::New(env, GetTypedArrayByteLength);
   exports["getTypedArrayBuffer"] = Function::New(env, GetTypedArrayBuffer);

--- a/test/typedarray.cc
+++ b/test/typedarray.cc
@@ -189,6 +189,11 @@ Value GetTypedArraySize(const CallbackInfo& info) {
   return Number::New(info.Env(), static_cast<double>(array.ElementSize()));
 }
 
+Value GetTypedArrayByteLength(const CallbackInfo& info) {
+  TypedArray array = info[0].As<TypedArray>();
+  return Number::New(info.Env(), static_cast<double>(array.ByteLength()));
+}
+
 Value GetTypedArrayBuffer(const CallbackInfo& info) {
   TypedArray array = info[0].As<TypedArray>();
   return array.ArrayBuffer();
@@ -293,6 +298,8 @@ Object InitTypedArray(Env env) {
   exports["getTypedArrayType"] = Function::New(env, GetTypedArrayType);
   exports["getTypedArrayLength"] = Function::New(env, GetTypedArrayLength);
   exports["getTypedArraySize"] = Function::New(env, GetTypedArraySize);
+  exports["getTypedArrayByteLength"] =
+      Function::New(env, GetTypedArrayByteLength);
   exports["getTypedArrayBuffer"] = Function::New(env, GetTypedArrayBuffer);
   exports["getTypedArrayElement"] = Function::New(env, GetTypedArrayElement);
   exports["setTypedArrayElement"] = Function::New(env, SetTypedArrayElement);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -6,15 +6,15 @@ module.exports = require('./common').runTest(test);
 
 function test (binding) {
   const testData = [
-    ['int8', Int8Array],
-    ['uint8', Uint8Array],
-    ['uint8_clamped', Uint8ClampedArray],
-    ['int16', Int16Array],
-    ['uint16', Uint16Array],
-    ['int32', Int32Array],
-    ['uint32', Uint32Array],
-    ['float32', Float32Array],
-    ['float64', Float64Array]
+    ['int8', Int8Array, 1],
+    ['uint8', Uint8Array, 1],
+    ['uint8_clamped', Uint8ClampedArray, 1],
+    ['int16', Int16Array, 2],
+    ['uint16', Uint16Array, 2],
+    ['int32', Int32Array, 4],
+    ['uint32', Uint32Array, 4],
+    ['float32', Float32Array, 4],
+    ['float64', Float64Array, 8]
   ];
 
   testData.forEach(data => {
@@ -24,6 +24,7 @@ function test (binding) {
       assert.ok(t instanceof data[1]);
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
+      assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
 
       t[3] = 11;
       assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11);
@@ -49,6 +50,7 @@ function test (binding) {
       assert.ok(t instanceof data[1]);
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
+      assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
 
       t[3] = 11;
       assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -25,6 +25,7 @@ function test (binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
       assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
+      assert.strictEqual(binding.typedarray.getTypedArrayByteLength(t), data[2] * length);
 
       t[3] = 11;
       assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11);
@@ -51,6 +52,7 @@ function test (binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
       assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
+      assert.strictEqual(binding.typedarray.getTypedArrayByteLength(t), data[2] * length);
 
       t[3] = 11;
       assert.strictEqual(binding.typedarray.getTypedArrayElement(t, 3), 11);

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -25,6 +25,7 @@ function test (binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
       assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
+      assert.strictEqual(binding.typedarray.getTypedArrayByteOffset(t), 0);
       assert.strictEqual(binding.typedarray.getTypedArrayByteLength(t), data[2] * length);
 
       t[3] = 11;
@@ -52,6 +53,7 @@ function test (binding) {
       assert.strictEqual(binding.typedarray.getTypedArrayType(t), data[0]);
       assert.strictEqual(binding.typedarray.getTypedArrayLength(t), length);
       assert.strictEqual(binding.typedarray.getTypedArraySize(t), data[2]);
+      assert.strictEqual(binding.typedarray.getTypedArrayByteOffset(t), offset);
       assert.strictEqual(binding.typedarray.getTypedArrayByteLength(t), data[2] * length);
 
       t[3] = 11;


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Mentioned on https://github.com/nodejs/node-addon-api/issues/964

Add tests for the TypeadArray methods:
* ElementSize
* ByteLength
* ByteOffset