### PR TITLE
test: Add test coverage for "TSFN::Ref()"

### DIFF
--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
@@ -63,6 +63,7 @@ static Value TestRef(const CallbackInfo& info) {
       static_cast<FinalizerDataType*>(nullptr));
 
   tsfn->BlockingCall();
+  tsfn->Unref(info.Env());
   tsfn->Ref(info.Env());
 
   return info.Env().Undefined();

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
@@ -32,6 +32,7 @@ static Value TestUnref(const CallbackInfo& info) {
       static_cast<FinalizerDataType*>(nullptr));
 
   tsfn->BlockingCall();
+  tsfn->Ref(info.Env());
 
   setTimeout.Call(
       global,

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
@@ -43,11 +43,37 @@ static Value TestUnref(const CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
+static Value TestRef(const CallbackInfo& info) {
+  Object resource = info[0].As<Object>();
+  Function cb = info[1].As<Function>();
+
+  TSFN* tsfn = new TSFN;
+
+  *tsfn = TSFN::New(
+      info.Env(),
+      cb,
+      resource,
+      "Test",
+      1,
+      1,
+      nullptr,
+      [tsfn](Napi::Env /* env */, FinalizerDataType*, ContextType*) {
+        delete tsfn;
+      },
+      static_cast<FinalizerDataType*>(nullptr));
+
+  tsfn->BlockingCall();
+  tsfn->Ref(info.Env());
+
+  return info.Env().Undefined();
+}
+
 }  // namespace
 
 Object InitTypedThreadSafeFunctionUnref(Env env) {
   Object exports = Object::New(env);
   exports["testUnref"] = Function::New(env, TestUnref);
+  exports["testRef"] = Function::New(env, TestRef);
   return exports;
 }
 

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.cc
@@ -44,27 +44,13 @@ static Value TestUnref(const CallbackInfo& info) {
 }
 
 static Value TestRef(const CallbackInfo& info) {
-  Object resource = info[0].As<Object>();
   Function cb = info[1].As<Function>();
 
-  TSFN* tsfn = new TSFN;
+  auto tsfn = TSFN::New(info.Env(), cb, "testRes", 1, 1, nullptr);
 
-  *tsfn = TSFN::New(
-      info.Env(),
-      cb,
-      resource,
-      "Test",
-      1,
-      1,
-      nullptr,
-      [tsfn](Napi::Env /* env */, FinalizerDataType*, ContextType*) {
-        delete tsfn;
-      },
-      static_cast<FinalizerDataType*>(nullptr));
-
-  tsfn->BlockingCall();
-  tsfn->Unref(info.Env());
-  tsfn->Ref(info.Env());
+  tsfn.BlockingCall();
+  tsfn.Unref(info.Env());
+  tsfn.Ref(info.Env());
 
   return info.Env().Undefined();
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -61,7 +61,7 @@ function testRefCallback (resolve, reject, bindingFile) {
     child.kill();
     timeout = 0;
     resolve();
-  }, 500);
+  }, 1000);
 
   child.on('error', (err) => {
     clearTimeout(timeout);

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -78,11 +78,11 @@ function testRefCallback (resolve, reject, bindingFile) {
 
 function test (bindingFile) {
   // Main process
-  new Promise((resolve, reject) => {
-    testRefCallback(resolve, reject, bindingFile);
+  return new Promise((resolve, reject) => {
+    testUnRefCallback(resolve, reject, bindingFile);
   }).then(() => {
     return new Promise((resolve, reject) => {
-      testUnRefCallback(resolve, reject, bindingFile);
+      testRefCallback(resolve, reject, bindingFile);
     });
   });
 }

--- a/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_unref.js
@@ -11,43 +11,88 @@ const isMainProcess = process.argv[1] !== __filename;
  *   - Child process: creates TSFN. Native module Unref's via setTimeout after some time but does NOT call Release.
  *
  * Main process should expect child process to exit.
+ *
+ * We also added a new test case for `Ref`. The idea being, if a TSFN is active, the event loop that it belongs to should not exit
+ * Our setup is similar to the test for the `Unref` case, with the difference being now we are expecting the child process to hang
  */
 
 if (isMainProcess) {
   module.exports = require('../common').runTestWithBindingPath(test);
 } else {
-  test(process.argv[2]);
+  const isTestingRef = (process.argv[3] === 'true');
+
+  if (isTestingRef) {
+    execTSFNRefTest(process.argv[2]);
+  } else {
+    execTSFNUnrefTest(process.argv[2]);
+  }
+}
+
+function testUnRefCallback (resolve, reject, bindingFile) {
+  const child = require('../napi_child').spawn(process.argv[0], [
+    '--expose-gc', __filename, bindingFile, false
+  ], { stdio: 'inherit' });
+
+  let timeout = setTimeout(function () {
+    child.kill();
+    timeout = 0;
+    reject(new Error('Expected child to die'));
+  }, 5000);
+
+  child.on('error', (err) => {
+    clearTimeout(timeout);
+    timeout = 0;
+    reject(new Error(err));
+  });
+
+  child.on('close', (code) => {
+    if (timeout) clearTimeout(timeout);
+    assert.strictEqual(code, 0, 'Expected return value 0');
+    resolve();
+  });
+}
+
+function testRefCallback (resolve, reject, bindingFile) {
+  const child = require('../napi_child').spawn(process.argv[0], [
+    '--expose-gc', __filename, bindingFile, true
+  ], { stdio: 'inherit' });
+
+  let timeout = setTimeout(function () {
+    child.kill();
+    timeout = 0;
+    resolve();
+  }, 500);
+
+  child.on('error', (err) => {
+    clearTimeout(timeout);
+    timeout = 0;
+    reject(new Error(err));
+  });
+
+  child.on('close', (code) => {
+    if (timeout) clearTimeout(timeout);
+
+    reject(new Error('We expected Child to hang'));
+  });
 }
 
 function test (bindingFile) {
-  if (isMainProcess) {
-    // Main process
+  // Main process
+  new Promise((resolve, reject) => {
+    testRefCallback(resolve, reject, bindingFile);
+  }).then(() => {
     return new Promise((resolve, reject) => {
-      const child = require('../napi_child').spawn(process.argv[0], [
-        '--expose-gc', __filename, bindingFile
-      ], { stdio: 'inherit' });
-
-      let timeout = setTimeout(function () {
-        child.kill();
-        timeout = 0;
-        reject(new Error('Expected child to die'));
-      }, 5000);
-
-      child.on('error', (err) => {
-        clearTimeout(timeout);
-        timeout = 0;
-        reject(new Error(err));
-      });
-
-      child.on('close', (code) => {
-        if (timeout) clearTimeout(timeout);
-        assert.strictEqual(code, 0, 'Expected return value 0');
-        resolve();
-      });
+      testUnRefCallback(resolve, reject, bindingFile);
     });
-  } else {
-    // Child process
-    const binding = require(bindingFile);
-    binding.typed_threadsafe_function_unref.testUnref({}, () => { });
-  }
+  });
+}
+
+function execTSFNUnrefTest (bindingFile) {
+  const binding = require(bindingFile);
+  binding.typed_threadsafe_function_unref.testUnref({}, () => { });
+}
+
+function execTSFNRefTest (bindingFile) {
+  const binding = require(bindingFile);
+  binding.typed_threadsafe_function_unref.testRef({}, () => { });
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
We currently do not have a test for testing the `Ref(Env env)` function attached to the TSFN class. But I am not too sure if this is the best way to test this functionality. From what I understand this method is a wrapper around `napi_ref_threadsafe_function` which prevents the event loop from exiting until the tsfn gets destroyed by a call to `Release()`. 

My thought behind this approach is that we first reference this TSFN function, before the callback in `setTimeout`  Unref's the TSFN which causes the event loop to exit. Though it appears that this tsfn should already be referenced prior to calling `Ref`, and `napi_ref_threadsafe_function` is idempotent so it has no effect.  Is there a better approach to test this method? Also in what scenarios would `napi_ref_threadsafe_function` or `TSFN::Ref()` be used? Thanks!