### PR TITLE
Update CI component versions

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,14 +7,14 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version:  [10.x, 12.x, 14.x, 15.x, 16.x]
+        node-version:  [14.x, 16.x, 18.x]
         os:
           - windows-2019
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Check Node.js installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         node --version
         npm --version
-  - name: Install dependencies
+    - name: Install dependencies
       run: |
         npm install
     - name: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,16 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version:
-          - node/12
-          - node/14
-          - node/16
+        node-version:  [14.x, 16.x, 18.x]
         compiler:
           - gcc
           - clang
         os:
-          - ubuntu-18.04
+          - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install system dependencies
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" -a "${{ matrix.os }}" = ubuntu-* ]; then
@@ -28,14 +25,15 @@ jobs:
           sudo apt-get install g++-6.5
         fi
     - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Check Node.js installation
       run: |
-        git clone --branch v1.4.2 --depth 1 https://github.com/jasongin/nvs ~/.nvs
-        . ~/.nvs/nvs.sh
-        nvs --version
-        nvs add ${{ matrix.node-version }}
-        nvs use ${{ matrix.node-version }}
         node --version
         npm --version
+  - name: Install dependencies
+      run: |
         npm install
     - name: npm test
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,17 +7,17 @@ jobs:
     if: github.repository == 'nodejs/node-addon-api'
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - run: git branch -a
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'


### PR DESCRIPTION
This PR changes versions of components used in CI to the latest available:
-  node-version: [12.x, 14.x, 16.x] -> [14.x, 16.x, 18.x] _(version 12 is not supported anymore)_
- ubuntu-18.04 -> ubuntu-latest
- actions/checkout@v2 -> actions/checkout@v3
- nvs -> actions/setup-node@v3
- actions/setup-node@v1 -> actions/setup-node@v3
- actions/setup-node@v2.1.5 -> actions/setup-node@v3
- actions/stale@v4 -> actions/stale@v5
