### PR TITLE
test: Add test coverage to TSFN::New() overloads

### DIFF
--- a/test/typed_threadsafe_function/typed_threadsafe_function_ctx.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ctx.cc
@@ -86,6 +86,25 @@ void AssertGetContextFromTSFNNoFinalizerIsCorrect(const CallbackInfo& info) {
   assert(tsfn.GetContext() == ctx);
   delete ctx;
   tsfn.Release();
+
+  ctx = new SimpleTestContext(52);
+  tsfn = TSFN::New(info.Env(),
+                   "resStrings",
+                   1,
+                   1,
+                   ctx,
+                   [](Napi::Env, void*, SimpleTestContext*) {});
+
+  assert(tsfn.GetContext() == ctx);
+  delete ctx;
+  tsfn.Release();
+
+  ctx = new SimpleTestContext(52);
+  Function emptyFunc;
+  tsfn = TSFN::New(info.Env(), emptyFunc, "resString", 1, 1, ctx);
+  assert(tsfn.GetContext() == ctx);
+  delete ctx;
+  tsfn.Release();
 }
 
 Object InitTypedThreadSafeFunctionCtx(Env env) {

--- a/test/typed_threadsafe_function/typed_threadsafe_function_ctx.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ctx.cc
@@ -39,7 +39,6 @@ Function TSFNWrap::Init(Napi::Env env) {
                   {InstanceMethod("getContext", &TSFNWrap::GetContext),
                    InstanceMethod("release", &TSFNWrap::Release)});
 
-  // exports.Set("TSFNWrap", func);
   return func;
 }
 

--- a/test/typed_threadsafe_function/typed_threadsafe_function_ctx.js
+++ b/test/typed_threadsafe_function/typed_threadsafe_function_ctx.js
@@ -9,4 +9,6 @@ async function test (binding) {
   const tsfn = new binding.typed_threadsafe_function_ctx.TSFNWrap(ctx);
   assert(tsfn.getContext() === ctx);
   await tsfn.release();
+
+  binding.typed_threadsafe_function_ctx.AssertTSFNReturnCorrectCxt();
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Adding test coverage for `TSFN::New` overloads where we provide the async resource name and/or the async resource object but no finalizer callbacks.