### PR TITLE
test: Add test case for canceling async worker tasks

### DIFF
--- a/test/async_worker.cc
+++ b/test/async_worker.cc
@@ -4,7 +4,7 @@
 #include "napi.h"
 
 using namespace Napi;
-#define MAX_CANCEL_THREADS 6
+
 class TestWorker : public AsyncWorker {
  public:
   static void DoWork(const CallbackInfo& info) {

--- a/test/async_worker.cc
+++ b/test/async_worker.cc
@@ -1,5 +1,4 @@
 #include <chrono>
-#include <iostream>
 #include <thread>
 #include "assert.h"
 #include "napi.h"

--- a/test/async_worker.js
+++ b/test/async_worker.js
@@ -63,6 +63,8 @@ function installAsyncHooksForTest () {
 }
 
 async function test (binding) {
+  binding.asyncworker.tryCancelQueuedWork(() => {}, 'echoString');
+
   if (!checkAsyncHooks()) {
     await new Promise((resolve) => {
       binding.asyncworker.doWork(true, {}, function (e) {

--- a/test/async_worker.js
+++ b/test/async_worker.js
@@ -63,7 +63,8 @@ function installAsyncHooksForTest () {
 }
 
 async function test (binding) {
-  binding.asyncworker.tryCancelQueuedWork(() => {}, 'echoString');
+  const libUvThreadCount = Number(process.env.UV_THREADPOOL_SIZE || 4);
+  binding.asyncworker.tryCancelQueuedWork(() => {}, 'echoString', libUvThreadCount);
 
   if (!checkAsyncHooks()) {
     await new Promise((resolve) => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Adding a small test case for Async workers' `Cancel`  functionality, where if the cancellation is successful neither `OnOk` or `OnError` should be invoked.  