### PR TITLE
test: remove update to process.config

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -90,11 +90,6 @@ function loadTestModules (currentDirectory = __dirname, pre = '') {
 
 loadTestModules();
 
-process.config.target_defaults.default_configuration =
-  fs
-    .readdirSync(path.join(__dirname, process.env.REL_BUILD_PATH || '', 'build'))
-    .filter((item) => (item === 'Debug' || item === 'Release'))[0];
-
 let napiVersion = Number(process.versions.napi);
 if (process.env.NAPI_VERSION) {
   // we need this so that we don't try run tests that rely


### PR DESCRIPTION
process.config is now read-only. Remove
attempt to update it. This may break the ability
to run tests in debug mode but is needed to get ci running again.

Signed-off-by: Michael Dawson <mdawson@devrus.com>

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
