### PR TITLE
test: Add test cased for failed task cancellations

### DIFF
--- a/test/async_worker.js
+++ b/test/async_worker.js
@@ -66,6 +66,15 @@ async function test (binding) {
   const libUvThreadCount = Number(process.env.UV_THREADPOOL_SIZE || 4);
   binding.asyncworker.tryCancelQueuedWork(() => {}, 'echoString', libUvThreadCount);
 
+  let taskFailed = false;
+  try {
+    binding.asyncworker.expectCancelToFail(() => {});
+  } catch (e) {
+    taskFailed = true;
+  }
+
+  assert.equal(taskFailed, true, 'We expect task cancellation to fail');
+
   if (!checkAsyncHooks()) {
     await new Promise((resolve) => {
       binding.asyncworker.doWork(true, {}, function (e) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
A follow up to https://github.com/nodejs/node-addon-api/pull/1202#discussion_r974497323. Adding a test for checking when a task cancellation is unsuccessful (task is already queued and executing).