### PR TITLE
test: removed the usage of default_configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "benchmark": "node benchmark",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
-    "test:debug": "node-gyp rebuild -C test --debug && node ./test/index.js",
+    "test:debug": "node-gyp rebuild -C test --debug && BUILD_TYPE=Debug node ./test/index.js",
     "predev": "node-gyp rebuild -C test --debug",
     "dev": "node test",
     "predev:incremental": "node-gyp configure build -C test --debug",

--- a/package.json
+++ b/package.json
@@ -405,6 +405,7 @@
     "benchmark": "node benchmark",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
+    "debug": "node-gyp rebuild -C test --debug && node ./test/index.js",
     "predev": "node-gyp rebuild -C test --debug",
     "dev": "node test",
     "predev:incremental": "node-gyp configure build -C test --debug",

--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "benchmark": "node benchmark",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
-    "test:debug": "node-gyp rebuild -C test --debug && BUILD_TYPE=Debug node ./test/index.js",
+    "test:debug": "node-gyp rebuild -C test --debug && NODE_API_BUILD_CONFIG=Debug node ./test/index.js",
     "predev": "node-gyp rebuild -C test --debug",
     "dev": "node test",
     "predev:incremental": "node-gyp configure build -C test --debug",

--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "benchmark": "node benchmark",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
-    "debug": "node-gyp rebuild -C test --debug && node ./test/index.js",
+    "test:debug": "node-gyp rebuild -C test --debug && node ./test/index.js",
     "predev": "node-gyp rebuild -C test --debug",
     "dev": "node test",
     "predev:incremental": "node-gyp configure build -C test --debug",

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -91,8 +91,8 @@ async function checkBuildType (buildType) {
 }
 
 async function whichBuildType () {
-  let buildType;
-  const envBuildType = process.env.BUILD_TYPE;
+  let buildType = 'Release';
+  const envBuildType = process.env.NODE_API_BUILD_CONFIG;
   if (envBuildType) {
     if (Object.values(buildTypes).includes(envBuildType)) {
       if (await checkBuildType(envBuildType)) {
@@ -101,14 +101,7 @@ async function whichBuildType () {
         throw new Error(`The ${envBuildType} build doesn't exists.`);
       }
     } else {
-      throw new Error('Invalid value for BUILD_TYPE environment variable. It should be set to Release or Debug.');
-    }
-  } else {
-    if (await checkBuildType(buildTypes.Release)) {
-      buildType = buildTypes.Release;
-    }
-    if (await checkBuildType(buildTypes.Debug)) {
-      buildType = buildTypes.Debug;
+      throw new Error('Invalid value for NODE_API_BUILD_CONFIG environment variable. It should be set to Release or Debug.');
     }
   }
   return buildType;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -91,7 +91,7 @@ async function checkBuildType (buildType) {
 }
 
 async function whichBuildType () {
-  let buildType;
+  let buildType = 'Release';
   if (await checkBuildType(buildTypes.Release)) {
     buildType = buildTypes.Release;
   }
@@ -104,7 +104,7 @@ async function whichBuildType () {
 exports.whichBuildType = whichBuildType;
 
 exports.runTest = async function (test, buildType, buildPathRoot = process.env.BUILD_PATH || '') {
-  buildType = buildType || await whichBuildType() || 'Release';
+  buildType = buildType || await whichBuildType();
   const bindings = [
     path.join(buildPathRoot, `../build/${buildType}/binding.node`),
     path.join(buildPathRoot, `../build/${buildType}/binding_noexcept.node`),
@@ -119,7 +119,7 @@ exports.runTest = async function (test, buildType, buildPathRoot = process.env.B
 };
 
 exports.runTestWithBindingPath = async function (test, buildType, buildPathRoot = process.env.BUILD_PATH || '') {
-  buildType = buildType || await whichBuildType() || 'Release';
+  buildType = buildType || await whichBuildType();
 
   const bindings = [
     path.join(buildPathRoot, `../build/${buildType}/binding.node`),
@@ -134,7 +134,7 @@ exports.runTestWithBindingPath = async function (test, buildType, buildPathRoot 
 };
 
 exports.runTestWithBuildType = async function (test, buildType) {
-  buildType = buildType || await whichBuildType() || 'Release';
+  buildType = buildType || await whichBuildType();
 
   await Promise.resolve(test(buildType))
     .finally(exports.mustCall());

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -91,12 +91,25 @@ async function checkBuildType (buildType) {
 }
 
 async function whichBuildType () {
-  let buildType = 'Release';
-  if (await checkBuildType(buildTypes.Release)) {
-    buildType = buildTypes.Release;
-  }
-  if (await checkBuildType(buildTypes.Debug)) {
-    buildType = buildTypes.Debug;
+  let buildType;
+  const envBuildType = process.env.BUILD_TYPE;
+  if (envBuildType) {
+    if (Object.values(buildTypes).includes(envBuildType)) {
+      if (await checkBuildType(envBuildType)) {
+        buildType = envBuildType;
+      } else {
+        throw new Error(`The ${envBuildType} build doesn't exists.`);
+      }
+    } else {
+      throw new Error('Invalid value for BUILD_TYPE environment variable. It should be set to Release or Debug.');
+    }
+  } else {
+    if (await checkBuildType(buildTypes.Release)) {
+      buildType = buildTypes.Release;
+    }
+    if (await checkBuildType(buildTypes.Debug)) {
+      buildType = buildTypes.Debug;
+    }
   }
   return buildType;
 }

--- a/test/error_terminating_environment.js
+++ b/test/error_terminating_environment.js
@@ -1,6 +1,7 @@
 'use strict';
-const buildType = process.config.target_defaults.default_configuration;
+
 const assert = require('assert');
+const { whichBuildType } = require('./common');
 
 // These tests ensure that Error types can be used in a terminating
 // environment without triggering any fatal errors.
@@ -63,11 +64,16 @@ if (process.argv[2] === 'runInChildProcess') {
     assert.fail('This should not be reachable');
   }
 
-  test(`./build/${buildType}/binding.node`, true);
-  test(`./build/${buildType}/binding_noexcept.node`, true);
-  test(`./build/${buildType}/binding_swallowexcept.node`, false);
-  test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
-  test(`./build/${buildType}/binding_custom_namespace.node`, true);
+  wrapTest();
+
+  async function wrapTest () {
+    const buildType = await whichBuildType();
+    test(`./build/${buildType}/binding.node`, true);
+    test(`./build/${buildType}/binding_noexcept.node`, true);
+    test(`./build/${buildType}/binding_swallowexcept.node`, false);
+    test(`./build/${buildType}/binding_swallowexcept_noexcept.node`, false);
+    test(`./build/${buildType}/binding_custom_namespace.node`, true);
+  }
 
   function test (bindingPath, processShouldAbort) {
     const numberOfTestCases = 5;

--- a/test/maybe/index.js
+++ b/test/maybe/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
-const buildType = process.config.target_defaults.default_configuration;
 const assert = require('assert');
+const { whichBuildType } = require('../common');
 
 const napiChild = require('../napi_child');
 
-module.exports = test(require(`../build/${buildType}/binding_noexcept_maybe.node`).maybe_check);
+module.exports = async function wrapTest () {
+  const buildType = await whichBuildType();
+  test(require(`../build/${buildType}/binding_noexcept_maybe.node`).maybe_check);
+};
 
 function test (binding) {
   if (process.argv.includes('child')) {

--- a/test/objectwrap_worker_thread.js
+++ b/test/objectwrap_worker_thread.js
@@ -1,12 +1,13 @@
 'use strict';
 const path = require('path');
 const { Worker, isMainThread } = require('worker_threads');
+const { runTestWithBuildType, whichBuildType } = require('./common');
 
-module.exports = require('./common').runTestWithBuildType(test);
+module.exports = runTestWithBuildType(test);
 
-async function test (buildType) {
+async function test () {
   if (isMainThread) {
-    const buildType = process.config.target_defaults.default_configuration;
+    const buildType = await whichBuildType();
     const worker = new Worker(__filename, { workerData: buildType });
     return new Promise((resolve, reject) => {
       worker.on('exit', () => {


### PR DESCRIPTION
This PR remove the usage of  `process.config.target_defaults.default_configuration` in all test suite.
A new function `whichBuildType` has been introduced and it has the reponsability to check which type of build `node-gyp` made so the test can refer to the right folders.

Refs:
- https://github.com/nodejs/node-addon-api/issues/1207

