### PR TITLE
chore: fix stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
         stale-issue-label: 'stale'
-        exempt-issue-label: 'never stale'
+        exempt-issue-labels: 'never-stale'
         days-before-stale: 90
         days-before-close: 30
 


### PR DESCRIPTION
From `actions/stale@v2` the option for exempt labels was renamed to `exempt-issue-labels` (plural). Also it appears that this repository is using [`never-stale`](https://github.com/nodejs/node-addon-api/issues?q=is%3Aissue+is%3Aopen+label%3Anever-stale) (with a hyphen instead of a space character).

Refs: https://github.com/actions/stale/pull/19

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
