### PR TITLE
Make CleanupHook public

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -6234,6 +6234,11 @@ Env::CleanupHook<Hook> Env::AddCleanupHook(Hook hook) {
 }
 
 template <typename Hook, typename Arg>
+Env::CleanupHook<Hook, Arg>::CleanupHook() {
+  data = nullptr;
+}
+
+template <typename Hook, typename Arg>
 Env::CleanupHook<Hook, Arg>::CleanupHook(Napi::Env env, Hook hook)
     : wrapper(Env::CleanupHook<Hook, Arg>::Wrapper) {
   data = new CleanupData{std::move(hook), nullptr};

--- a/napi.h
+++ b/napi.h
@@ -283,10 +283,7 @@ using MaybeOrValue = T;
 /// corresponds to an Isolate.
 class Env {
  private:
-#if NAPI_VERSION > 2
-  template <typename Hook, typename Arg = void>
-  class CleanupHook;
-#endif  // NAPI_VERSION > 2
+  napi_env _env;
 #if NAPI_VERSION > 5
   template <typename T>
   static void DefaultFini(Env, T* data);
@@ -310,6 +307,9 @@ class Env {
   MaybeOrValue<Value> RunScript(String script) const;
 
 #if NAPI_VERSION > 2
+  template <typename Hook, typename Arg = void>
+  class CleanupHook;
+
   template <typename Hook>
   CleanupHook<Hook> AddCleanupHook(Hook hook);
 
@@ -335,13 +335,11 @@ class Env {
   void SetInstanceData(DataType* data, HintType* hint) const;
 #endif  // NAPI_VERSION > 5
 
- private:
-  napi_env _env;
-
 #if NAPI_VERSION > 2
   template <typename Hook, typename Arg>
   class CleanupHook {
    public:
+    CleanupHook();
     CleanupHook(Env env, Hook hook, Arg* arg);
     CleanupHook(Env env, Hook hook);
     bool Remove(Env env);
@@ -357,8 +355,8 @@ class Env {
       Arg* arg;
     } * data;
   };
-};
 #endif  // NAPI_VERSION > 2
+};
 
 /// A JavaScript value of unknown type.
 ///

--- a/test/env_cleanup.cc
+++ b/test/env_cleanup.cc
@@ -20,6 +20,15 @@ static void cleanupVoid() {
 static int secret1 = 42;
 static int secret2 = 43;
 
+class TestClass {
+  public:
+    Env::CleanupHook<void (*)(void *arg), int> hook;
+
+    void removeHook(Env env) {
+      hook.Remove(env);
+    }
+};
+
 Value AddHooks(const CallbackInfo& info) {
   auto env = info.Env();
 
@@ -71,6 +80,11 @@ Value AddHooks(const CallbackInfo& info) {
   added += !hook4.IsEmpty();
   added += !hook5.IsEmpty();
   added += !hook6.IsEmpty();
+
+  // Test store a hook in a member class variable
+  auto myclass = TestClass();
+  myclass.hook = env.AddCleanupHook(cleanup, &secret1);
+  myclass.removeHook(env);
 
   return Number::New(env, added);
 }

--- a/test/env_cleanup.cc
+++ b/test/env_cleanup.cc
@@ -21,12 +21,10 @@ static int secret1 = 42;
 static int secret2 = 43;
 
 class TestClass {
-  public:
-    Env::CleanupHook<void (*)(void *arg), int> hook;
+ public:
+  Env::CleanupHook<void (*)(void* arg), int> hook;
 
-    void removeHook(Env env) {
-      hook.Remove(env);
-    }
+  void removeHook(Env env) { hook.Remove(env); }
 };
 
 Value AddHooks(const CallbackInfo& info) {


### PR DESCRIPTION
Make CleanupHook public.
Added default constructor to make easier store the hook in a member class var.
Also fixed a bad #endif position.

This PR fix [issue 1238](https://github.com/nodejs/node-addon-api/issues/1238)

