### PR TITLE
Src refactor call js wrapper

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -254,26 +254,6 @@ struct ThreadSafeFinalize {
   Finalizer callback;
 };
 
-// template <typename ContextType, typename DataType, typename CallJs>
-// typename std::enable_if<call != nullptr>::type static inline CallJsWrapper(
-//     napi_env env, napi_value jsCallback, void* context, void* data, CallJs
-//     call) {
-//   call(env,
-//        Function(env, jsCallback),
-//        static_cast<ContextType*>(context),
-//        static_cast<DataType*>(data));
-// }
-
-// template <typename ContextType, typename DataType, typename CallJs>
-// typename std::enable_if<call == nullptr>::type static inline CallJsWrapper(
-//     napi_env env, napi_value jsCallback, void* /*context*/, void* /*data*/,
-//     CallJs call) {
-
-//   if (jsCallback != nullptr) {
-//     Function(env, jsCallback).Call(0, nullptr);
-//   }
-// }
-
 template <typename ContextType, typename DataType, typename CallJs>
 void static inline CallJsWrapper(napi_env env,
                                  napi_value jsCallback,

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -254,18 +254,39 @@ struct ThreadSafeFinalize {
   Finalizer callback;
 };
 
-template <typename ContextType, typename DataType, typename CallJs, CallJs call>
-typename std::enable_if<call != nullptr>::type static inline CallJsWrapper(
-    napi_env env, napi_value jsCallback, void* context, void* data) {
-  call(env,
-       Function(env, jsCallback),
-       static_cast<ContextType*>(context),
-       static_cast<DataType*>(data));
-}
+// template <typename ContextType, typename DataType, typename CallJs>
+// typename std::enable_if<call != nullptr>::type static inline CallJsWrapper(
+//     napi_env env, napi_value jsCallback, void* context, void* data, CallJs
+//     call) {
+//   call(env,
+//        Function(env, jsCallback),
+//        static_cast<ContextType*>(context),
+//        static_cast<DataType*>(data));
+// }
 
-template <typename ContextType, typename DataType, typename CallJs, CallJs call>
-typename std::enable_if<call == nullptr>::type static inline CallJsWrapper(
-    napi_env env, napi_value jsCallback, void* /*context*/, void* /*data*/) {
+// template <typename ContextType, typename DataType, typename CallJs>
+// typename std::enable_if<call == nullptr>::type static inline CallJsWrapper(
+//     napi_env env, napi_value jsCallback, void* /*context*/, void* /*data*/,
+//     CallJs call) {
+
+//   if (jsCallback != nullptr) {
+//     Function(env, jsCallback).Call(0, nullptr);
+//   }
+// }
+
+template <typename ContextType, typename DataType, typename CallJs>
+void static inline CallJsWrapper(napi_env env,
+                                 napi_value jsCallback,
+                                 void* context,
+                                 void* data,
+                                 CallJs call) {
+  if (call) {
+    call(env,
+         Function(env, jsCallback),
+         static_cast<ContextType*>(context),
+         static_cast<DataType*>(data));
+    return;
+  }
   if (jsCallback != nullptr) {
     Function(env, jsCallback).Call(0, nullptr);
   }
@@ -5348,8 +5369,8 @@ template <typename ContextType,
           void (*CallJs)(Napi::Env, Napi::Function, ContextType*, DataType*)>
 void TypedThreadSafeFunction<ContextType, DataType, CallJs>::CallJsInternal(
     napi_env env, napi_value jsCallback, void* context, void* data) {
-  details::CallJsWrapper<ContextType, DataType, decltype(CallJs), CallJs>(
-      env, jsCallback, context, data);
+  details::CallJsWrapper<ContextType, DataType, decltype(CallJs)>(
+      env, jsCallback, context, data, CallJs);
 }
 
 #if NAPI_VERSION == 4


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
The visual studio compiler seems to have an issue with deducting the type of  `call`, which prevents us from using the `std::enable_if` statement to handle cases where `CallJs` isn't provided by the user.  This PR aims to work around this issue. 