### PR TITLE
src, test: fix errors and warnings in VS 2017

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -30,11 +30,11 @@ namespace details {
 // TODO: Replace this code with `napi_add_finalizer()` whenever it becomes
 // available on all supported versions of Node.js.
 template <typename FreeType>
-static inline napi_status AttachData(napi_env env,
-                                     napi_value obj,
-                                     FreeType* data,
-                                     napi_finalize finalizer = nullptr,
-                                     void* hint = nullptr) {
+inline napi_status AttachData(napi_env env,
+                              napi_value obj,
+                              FreeType* data,
+                              napi_finalize finalizer = nullptr,
+                              void* hint = nullptr) {
   napi_status status;
   if (finalizer == nullptr) {
     finalizer = [](napi_env /*env*/, void* data, void* /*hint*/) {
@@ -134,8 +134,8 @@ struct CallbackData<Callable, void> {
 };
 
 template <void (*Callback)(const CallbackInfo& info)>
-static napi_value TemplatedVoidCallback(napi_env env,
-                                        napi_callback_info info) NAPI_NOEXCEPT {
+napi_value TemplatedVoidCallback(napi_env env,
+                                 napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     Callback(cbInfo);
@@ -144,8 +144,8 @@ static napi_value TemplatedVoidCallback(napi_env env,
 }
 
 template <Napi::Value (*Callback)(const CallbackInfo& info)>
-static napi_value TemplatedCallback(napi_env env,
-                                    napi_callback_info info) NAPI_NOEXCEPT {
+napi_value TemplatedCallback(napi_env env,
+                             napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     return Callback(cbInfo);
@@ -154,8 +154,8 @@ static napi_value TemplatedCallback(napi_env env,
 
 template <typename T,
           Napi::Value (T::*UnwrapCallback)(const CallbackInfo& info)>
-static napi_value TemplatedInstanceCallback(
-    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+napi_value TemplatedInstanceCallback(napi_env env,
+                                     napi_callback_info info) NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -164,8 +164,8 @@ static napi_value TemplatedInstanceCallback(
 }
 
 template <typename T, void (T::*UnwrapCallback)(const CallbackInfo& info)>
-static napi_value TemplatedInstanceVoidCallback(
-    napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
+napi_value TemplatedInstanceVoidCallback(napi_env env, napi_callback_info info)
+    NAPI_NOEXCEPT {
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
@@ -2177,11 +2177,11 @@ inline const T* TypedArrayOf<T>::Data() const {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename CbData>
-static inline napi_status CreateFunction(napi_env env,
-                                         const char* utf8name,
-                                         napi_callback cb,
-                                         CbData* data,
-                                         napi_value* result) {
+inline napi_status CreateFunction(napi_env env,
+                                  const char* utf8name,
+                                  napi_callback cb,
+                                  CbData* data,
+                                  napi_value* result) {
   napi_status status =
       napi_create_function(env, utf8name, NAPI_AUTO_LENGTH, cb, data, result);
   if (status == napi_ok) {

--- a/test/addon_data.cc
+++ b/test/addon_data.cc
@@ -59,7 +59,7 @@ class Addon {
 
   static void DeleteAddon(Napi::Env, Addon* addon, uint32_t* hint) {
     delete addon;
-    fprintf(stderr, "hint: %d\n", *hint);
+    fprintf(stderr, "hint: %u\n", *hint);
     delete hint;
   }
 

--- a/test/async_worker.cc
+++ b/test/async_worker.cc
@@ -152,7 +152,7 @@ class FailCancelWorker : public AsyncWorker {
 #ifdef NAPI_CPP_EXCEPTIONS
     try {
       cancelWorker->Cancel();
-    } catch (Napi::Error& e) {
+    } catch (Napi::Error&) {
       Napi::Error::New(info.Env(), "Unable to cancel async worker tasks")
           .ThrowAsJavaScriptException();
     }
@@ -193,7 +193,7 @@ class CancelWorker : public AsyncWorker {
 #ifdef NAPI_CPP_EXCEPTIONS
     try {
       cancelWorker->Cancel();
-    } catch (Napi::Error& e) {
+    } catch (Napi::Error&) {
       Napi::Error::New(info.Env(), "Unable to cancel async worker tasks")
           .ThrowAsJavaScriptException();
     }

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -50,7 +50,7 @@
         'object/subscript_operator.cc',
         'promise.cc',
         'run_script.cc',
-        "symbol.cc",
+        'symbol.cc',
         'threadsafe_function/threadsafe_function_ctx.cc',
         'threadsafe_function/threadsafe_function_existing_tsfn.cc',
         'threadsafe_function/threadsafe_function_ptr.cc',

--- a/test/typed_threadsafe_function/typed_threadsafe_function.cc
+++ b/test/typed_threadsafe_function/typed_threadsafe_function.cc
@@ -40,23 +40,23 @@ static void TSFNCallJS(Env env,
 }
 
 using TSFN = TypedThreadSafeFunction<ThreadSafeFunctionInfo, int, TSFNCallJS>;
-static TSFN tsfn;
+static TSFN s_tsfn;
 
 // Thread data to transmit to JS
 static int ints[ARRAY_LENGTH];
 
 static void SecondaryThread() {
-  if (tsfn.Release() != napi_ok) {
+  if (s_tsfn.Release() != napi_ok) {
     Error::Fatal("TypedSecondaryThread", "ThreadSafeFunction.Release() failed");
   }
 }
 
 // Source thread producing the data
 static void DataSourceThread() {
-  ThreadSafeFunctionInfo* info = tsfn.GetContext();
+  ThreadSafeFunctionInfo* info = s_tsfn.GetContext();
 
   if (info->startSecondary) {
-    if (tsfn.Acquire() != napi_ok) {
+    if (s_tsfn.Acquire() != napi_ok) {
       Error::Fatal("TypedDataSourceThread",
                    "ThreadSafeFunction.Acquire() failed");
     }
@@ -71,13 +71,13 @@ static void DataSourceThread() {
 
     switch (info->type) {
       case ThreadSafeFunctionInfo::DEFAULT:
-        status = tsfn.BlockingCall();
+        status = s_tsfn.BlockingCall();
         break;
       case ThreadSafeFunctionInfo::BLOCKING:
-        status = tsfn.BlockingCall(&ints[index]);
+        status = s_tsfn.BlockingCall(&ints[index]);
         break;
       case ThreadSafeFunctionInfo::NON_BLOCKING:
-        status = tsfn.NonBlockingCall(&ints[index]);
+        status = s_tsfn.NonBlockingCall(&ints[index]);
         break;
     }
 
@@ -117,7 +117,7 @@ static void DataSourceThread() {
     Error::Fatal("TypedDataSourceThread", "Queue was never closing");
   }
 
-  if (!queueWasClosing && tsfn.Release() != napi_ok) {
+  if (!queueWasClosing && s_tsfn.Release() != napi_ok) {
     Error::Fatal("TypedDataSourceThread",
                  "ThreadSafeFunction.Release() failed");
   }
@@ -127,9 +127,9 @@ static Value StopThread(const CallbackInfo& info) {
   tsfnInfo.jsFinalizeCallback = Napi::Persistent(info[0].As<Function>());
   bool abort = info[1].As<Boolean>();
   if (abort) {
-    tsfn.Abort();
+    s_tsfn.Abort();
   } else {
-    tsfn.Release();
+    s_tsfn.Release();
   }
   {
     std::lock_guard<std::mutex> _(tsfnInfo.protect);
@@ -160,15 +160,15 @@ static Value StartThreadInternal(const CallbackInfo& info,
   tsfnInfo.maxQueueSize = info[3].As<Number>().Uint32Value();
   tsfnInfo.closeCalledFromJs = false;
 
-  tsfn = TSFN::New(info.Env(),
-                   info[0].As<Function>(),
-                   Object::New(info.Env()),
-                   "Test",
-                   tsfnInfo.maxQueueSize,
-                   2,
-                   &tsfnInfo,
-                   JoinTheThreads,
-                   threads);
+  s_tsfn = TSFN::New(info.Env(),
+                     info[0].As<Function>(),
+                     Object::New(info.Env()),
+                     "Test",
+                     tsfnInfo.maxQueueSize,
+                     2,
+                     &tsfnInfo,
+                     JoinTheThreads,
+                     threads);
 
   threads[0] = std::thread(DataSourceThread);
 
@@ -176,7 +176,7 @@ static Value StartThreadInternal(const CallbackInfo& info,
 }
 
 static Value Release(const CallbackInfo& /* info */) {
-  if (tsfn.Release() != napi_ok) {
+  if (s_tsfn.Release() != napi_ok) {
     Error::Fatal("Release", "TypedThreadSafeFunction.Release() failed");
   }
   return Value();


### PR DESCRIPTION
This PR has fixes for errors and warnings when running `npm test` with Visual Studio 2017.
- `napi-inl.h` has changes to address the same issue as PR #1242
  - fixed use of `static` keyword for standalone functions. Each `static` function is duplicated in every cpp file that includes the header. Thus, it produces code that is unnecessary bigger.
- `addon_data.cc` - warning about incorrect use of format specifier
- `async_worker.cc` - unused variable warning
- `binding.gyp` - no warning - just using the same Python quotes as the rest of the code
- `function_reference.cc` - warning about possible buffer overflow. The code is changed to avoid memory leak.
- `threadsafe_function.cc`, `typed_threadsafe_function.cc` - warning about `napi-inl.h` shadowing the `tsfn` global variable declared in these files.