### PR TITLE
test: Add tests for ThreadSafeFunction's NonBlock function overloads

### DIFF
--- a/test/threadsafe_function/threadsafe_function.cc
+++ b/test/threadsafe_function/threadsafe_function.cc
@@ -8,14 +8,26 @@
 
 using namespace Napi;
 
+// Array length of 10
 constexpr size_t ARRAY_LENGTH = 10;
+
+// The queue can at most be 2
 constexpr size_t MAX_QUEUE_SIZE = 2;
 
+// Two threads
 static std::thread threads[2];
 static ThreadSafeFunction s_tsfn;
 
+// Metadata that describes the threadsafe function at hand
+// Saved as the threadsafe function context
 struct ThreadSafeFunctionInfo {
-  enum CallType { DEFAULT, BLOCKING, NON_BLOCKING } type;
+  enum CallType {
+    DEFAULT,
+    BLOCKING,
+    NON_BLOCKING,
+    NON_BLOCKING_DEFAULT,
+    NON_BLOCKING_SINGLE_ARG
+  } type;
   bool abort;
   bool startSecondary;
   FunctionReference jsFinalizeCallback;
@@ -28,32 +40,47 @@ struct ThreadSafeFunctionInfo {
 // Thread data to transmit to JS
 static int ints[ARRAY_LENGTH];
 
+// "Secondary thread"
 static void SecondaryThread() {
   if (s_tsfn.Release() != napi_ok) {
     Error::Fatal("SecondaryThread", "ThreadSafeFunction.Release() failed");
   }
 }
 
+// The thread that is producing data
 // Source thread producing the data
 static void DataSourceThread() {
   ThreadSafeFunctionInfo* info = s_tsfn.GetContext();
 
+  // If we need to spawn a secondary thread from the main thread
   if (info->startSecondary) {
     if (s_tsfn.Acquire() != napi_ok) {
       Error::Fatal("DataSourceThread", "ThreadSafeFunction.Acquire() failed");
     }
-
+    // otherwise, spawn the secondary thread
     threads[1] = std::thread(SecondaryThread);
   }
 
   bool queueWasFull = false;
   bool queueWasClosing = false;
+
+  // for loop condition:
+  //   Index starts at the last idx of the array,
+  //   AND the queue wasn't closing, decreament index and keep going
   for (int index = ARRAY_LENGTH - 1; index > -1 && !queueWasClosing; index--) {
+    // Set status as generic failure
     napi_status status = napi_generic_failure;
+
+    // Generic callback function
     auto callback = [](Env env, Function jsCallback, int* data) {
+      // Calling js with the data
       jsCallback.Call({Number::New(env, *data)});
     };
 
+    auto noArgCallback = [](Env env, Function jsCallback) {
+      jsCallback.Call({Number::New(env, 42)});
+    };
+    // Swtich base on types
     switch (info->type) {
       case ThreadSafeFunctionInfo::DEFAULT:
         status = s_tsfn.BlockingCall();
@@ -64,9 +91,17 @@ static void DataSourceThread() {
       case ThreadSafeFunctionInfo::NON_BLOCKING:
         status = s_tsfn.NonBlockingCall(&ints[index], callback);
         break;
+      case ThreadSafeFunctionInfo::NON_BLOCKING_DEFAULT:
+        status = s_tsfn.NonBlockingCall();
+        break;
+
+      case ThreadSafeFunctionInfo::NON_BLOCKING_SINGLE_ARG:
+        status = s_tsfn.NonBlockingCall(noArgCallback);
+        break;
     }
 
-    if (info->abort && info->type != ThreadSafeFunctionInfo::NON_BLOCKING) {
+    if (info->abort && (info->type == ThreadSafeFunctionInfo::BLOCKING ||
+                        info->type == ThreadSafeFunctionInfo::DEFAULT)) {
       // Let's make this thread really busy to give the main thread a chance to
       // abort / close.
       std::unique_lock<std::mutex> lk(info->protect);
@@ -106,6 +141,7 @@ static void DataSourceThread() {
   }
 }
 
+// Stops the thread from js
 static Value StopThread(const CallbackInfo& info) {
   tsfnInfo.jsFinalizeCallback = Napi::Persistent(info[0].As<Function>());
   bool abort = info[1].As<Boolean>();
@@ -135,6 +171,7 @@ static void JoinTheThreads(Env /* env */,
   info->jsFinalizeCallback.Reset();
 }
 
+// The function that does the heavy liftin
 static Value StartThreadInternal(const CallbackInfo& info,
                                  ThreadSafeFunctionInfo::CallType type) {
   tsfnInfo.type = type;
@@ -164,18 +201,32 @@ static Value Release(const CallbackInfo& /* info */) {
   return Value();
 }
 
+// Entry point for starting thread, in blocking mode
 static Value StartThread(const CallbackInfo& info) {
   return StartThreadInternal(info, ThreadSafeFunctionInfo::BLOCKING);
 }
 
+// Entry point for starting thread, in nonblocking mode
 static Value StartThreadNonblocking(const CallbackInfo& info) {
   return StartThreadInternal(info, ThreadSafeFunctionInfo::NON_BLOCKING);
 }
 
+// Entry point for starting thread, in block, no args
 static Value StartThreadNoNative(const CallbackInfo& info) {
   return StartThreadInternal(info, ThreadSafeFunctionInfo::DEFAULT);
 }
 
+static Value StartThreadNonblockingNoNative(const CallbackInfo& info) {
+  return StartThreadInternal(info,
+                             ThreadSafeFunctionInfo::NON_BLOCKING_DEFAULT);
+}
+
+static Value StartThreadNonBlockingSingleArg(const CallbackInfo& info) {
+  return StartThreadInternal(info,
+                             ThreadSafeFunctionInfo::NON_BLOCKING_SINGLE_ARG);
+}
+
+// Entry point for the addon
 Object InitThreadSafeFunction(Env env) {
   for (size_t index = 0; index < ARRAY_LENGTH; index++) {
     ints[index] = index;
@@ -186,8 +237,12 @@ Object InitThreadSafeFunction(Env env) {
   exports["MAX_QUEUE_SIZE"] = Number::New(env, MAX_QUEUE_SIZE);
   exports["startThread"] = Function::New(env, StartThread);
   exports["startThreadNoNative"] = Function::New(env, StartThreadNoNative);
+  exports["startThreadNonblockingNoNative"] =
+      Function::New(env, StartThreadNonblockingNoNative);
   exports["startThreadNonblocking"] =
       Function::New(env, StartThreadNonblocking);
+  exports["startThreadNonblockSingleArg"] =
+      Function::New(env, StartThreadNonBlockingSingleArg);
   exports["stopThread"] = Function::New(env, StopThread);
   exports["release"] = Function::New(env, Release);
 

--- a/test/threadsafe_function/threadsafe_function.js
+++ b/test/threadsafe_function/threadsafe_function.js
@@ -43,7 +43,6 @@ async function test (binding) {
     });
   }
 
-  // function testWithoutJSMarshaller(promResolve, nativeFunction)
   function testWithoutJSMarshallers (nativeFunction) {
     return new Promise((resolve) => {
       let callCount = 0;


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Added test coverage for `ThreadSafeFunction` 's missing `NonBlockingCall` function overloads. In particular test cases for when we pass just the single `js` function into the tsfn, or nothing at all. 