### PR TITLE
chore: add Windows with VS 2022 and Node.JS 19.x to the CI matrix

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -10,6 +10,7 @@ jobs:
         node-version:  [14.x, 16.x, 18.x]
         os:
           - windows-2019
+          - windows-2022
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,10 +7,11 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version:  [14.x, 16.x, 18.x]
-        os:
-          - windows-2019
-          - windows-2022
+        node-version: [14.x, 16.x, 18.x]
+        os: [ windows-2019 ]
+        include:
+          - node-version: 18.x
+            os: windows-2022
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x, 18.x, 19.x ]
-        os: [ windows-2019, windows-2022 ]
+        os:
+          - windows-2019
+          - windows-2022
         include:
           - node-version: 14.x
             os: windows-2019

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,13 +7,13 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 19.x ]
+        node-version: [ 14.x, 16.x, 18.x, 19.x ]
         os:
           - windows-2019
           - windows-2022
-        include:
+        exclude:
           - node-version: 14.x
-            os: windows-2019
+            os: windows-2022 # Node.JS 14.x GYP does not support Visual Studio 2022
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,11 +7,11 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
-        os: [ windows-2019 ]
+        node-version: [ 16.x, 18.x, 19.x ]
+        os: [ windows-2019, windows-2022 ]
         include:
-          - node-version: 18.x
-            os: windows-2022
+          - node-version: 14.x
+            os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
       matrix:
         node-version: [ 14.x, 16.x, 18.x, 19.x ]
         os:
-          - ubuntu-latest
           - macos-latest
+          - ubuntu-latest
         compiler:
-          - gcc
           - clang
-        include:
+          - gcc
+        exclude:
           - os: macos-latest
-            compiler: clang
+            compiler: gcc # GCC is an alias for clang on the MacOS image.
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,23 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version:  [14.x, 16.x, 18.x]
+        node-version: [ 14.x, 16.x, 18.x, 19.x ]
         compiler:
           - gcc
           - clang
         os:
           - ubuntu-latest
           - macos-latest
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-version: "gcc 6.5"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Install system dependencies
       run: |
-        if [ "${{ matrix.compiler }}" = "gcc" -a "${{ matrix.os }}" = ubuntu-* ]; then
+        if [ "${{ compiler-version }}" = "gcc 6.5" ]; then
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install g++-6.5
@@ -40,12 +44,15 @@ jobs:
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           export CC="gcc" CXX="g++"
         fi
-        if [ "${{ matrix.compiler }}" = "gcc" -a "${{ matrix.os }}" = ubuntu-* ]; then
+        if [ "${{ compiler-version }}" = "gcc 6.5" ]; then
           export CC="gcc-6.5" CXX="g++-6.5" AR="gcc-ar-6.5" RANLIB="gcc-ranlib-6.5" NM="gcc-nm-6.5"
         fi
         if [ "${{ matrix.compiler }}" = "clang" ]; then
           export CC="clang" CXX="clang++"
         fi
+        echo "CC=\"$CC\" CXX=\"$CXX\""
+        $CC --version
+        $CXX --version
         export CFLAGS="$CFLAGS -O3 --coverage" LDFLAGS="$LDFLAGS --coverage"
         echo "CFLAGS=\"$CFLAGS\" LDFLAGS=\"$LDFLAGS\""
         npm run pretest -- --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ jobs:
     strategy:
       matrix:
         node-version: [ 14.x, 16.x, 18.x, 19.x ]
+        os:
+          - ubuntu-latest
         compiler:
           - gcc
           - clang
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - os: macos-latest
+            compiler: clang
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
         node-version: [ 14.x, 16.x, 18.x, 19.x ]
         os:
           - ubuntu-latest
+          - macos-latest
         compiler:
           - gcc
           - clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,9 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        include:
-          - os: ubuntu-latest
-            compiler: gcc
-            compiler-version: "gcc 6.5"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Install system dependencies
-      run: |
-        if [ "${{ matrix.compiler-version }}" = "gcc 6.5" ]; then
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
-          sudo apt-get install g++-6.5
-        fi
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
@@ -44,14 +33,13 @@ jobs:
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           export CC="gcc" CXX="g++"
         fi
-        if [ "${{ matrix.compiler-version }}" = "gcc 6.5" ]; then
-          export CC="gcc-6.5" CXX="g++-6.5" AR="gcc-ar-6.5" RANLIB="gcc-ranlib-6.5" NM="gcc-nm-6.5"
-        fi
         if [ "${{ matrix.compiler }}" = "clang" ]; then
           export CC="clang" CXX="clang++"
         fi
         echo "CC=\"$CC\" CXX=\"$CXX\""
+        echo "$CC --version"
         $CC --version
+        echo "$CXX --version"
         $CXX --version
         export CFLAGS="$CFLAGS -O3 --coverage" LDFLAGS="$LDFLAGS --coverage"
         echo "CFLAGS=\"$CFLAGS\" LDFLAGS=\"$LDFLAGS\""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install system dependencies
       run: |
-        if [ "${{ compiler-version }}" = "gcc 6.5" ]; then
+        if [ "${{ matrix.compiler-version }}" = "gcc 6.5" ]; then
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install g++-6.5
@@ -44,7 +44,7 @@ jobs:
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           export CC="gcc" CXX="g++"
         fi
-        if [ "${{ compiler-version }}" = "gcc 6.5" ]; then
+        if [ "${{ matrix.compiler-version }}" = "gcc 6.5" ]; then
           export CC="gcc-6.5" CXX="g++-6.5" AR="gcc-ar-6.5" RANLIB="gcc-ranlib-6.5" NM="gcc-nm-6.5"
         fi
         if [ "${{ matrix.compiler }}" = "clang" ]; then


### PR DESCRIPTION
In this PR we are adding `windows-2022` OS image to the CI to test Node-API with Visual Studio 2022.
We are also adding verification for Node.JS version 19.x.

The new verification matrix for Windows is:
- `windows-2022` - Node,JS [ `16.x`, `18.x`, `19.x` ]
- `windows-2019` - Node,JS [ `14.x`, `16.x`, `18.x`, `19.x` ]
Note that VS 2022 is not supported by Node.JS 14.x GYP and it is not in the matrix.

For the MacOS and Ubuntu we have added printing of compiler version.
It helped to identify that:
- On MacOS the `gcc` is an alias for `clang`. So, we are removing the `MacOS + gcc` from the test matrix.
- On Ubuntu the condition `"${{ matrix.os }}" = ubuntu-*` seems to always fail and we never install the GCC version 6.5. Fixing this condition caused the script error because the package could not be found. CI uses preinstalled GCC version with the Ubuntu image which is currently `11.3`. Thus, the custom logic to install compiler is removed.

The new verification matrix for MacOS and Ubuntu is:
- `ubuntu-latest` - compiler: [ `gcc`, `clang` ] - Node,JS [ `14.x`, `16.x`, `18.x`, `19.x` ]
- `macos-latest` - compiler:  [ `clang` ] - Node,JS [ `14.x`, `16.x`, `18.x`, `19.x` ]

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
