### PR TITLE
test: Add tests for escape and handlescope

### DIFF
--- a/test/handlescope.cc
+++ b/test/handlescope.cc
@@ -13,11 +13,33 @@ Value createScope(const CallbackInfo& info) {
   return String::New(info.Env(), "scope");
 }
 
+Value createScopeFromExisting(const CallbackInfo& info) {
+  {
+    napi_handle_scope scope;
+    napi_open_handle_scope(info.Env(), &scope);
+    HandleScope scope_existing(info.Env(), scope);
+    String::New(scope_existing.Env(), "inner-existing-scope");
+  }
+  return String::New(info.Env(), "existing_scope");
+}
+
 Value escapeFromScope(const CallbackInfo& info) {
   Value result;
   {
     EscapableHandleScope scope(info.Env());
     result = scope.Escape(String::New(info.Env(), "inner-scope"));
+  }
+  return result;
+}
+
+Value escapeFromExistingScope(const CallbackInfo& info) {
+  Value result;
+  {
+    napi_escapable_handle_scope scope;
+    napi_open_escapable_handle_scope(info.Env(), &scope);
+    EscapableHandleScope scope_existing(info.Env(), scope);
+    result = scope_existing.Escape(
+        String::New(scope_existing.Env(), "inner-existing-scope"));
   }
   return result;
 }
@@ -52,7 +74,11 @@ Object InitHandleScope(Env env) {
   Object exports = Object::New(env);
 
   exports["createScope"] = Function::New(env, createScope);
+  exports["createScopeFromExisting"] =
+      Function::New(env, createScopeFromExisting);
   exports["escapeFromScope"] = Function::New(env, escapeFromScope);
+  exports["escapeFromExistingScope"] =
+      Function::New(env, escapeFromExistingScope);
   exports["stressEscapeFromScope"] = Function::New(env, stressEscapeFromScope);
   exports["doubleEscapeFromScope"] = Function::New(env, doubleEscapeFromScope);
 

--- a/test/handlescope.js
+++ b/test/handlescope.js
@@ -6,7 +6,9 @@ module.exports = require('./common').runTest(test);
 
 function test (binding) {
   assert.strictEqual(binding.handlescope.createScope(), 'scope');
+  assert.strictEqual(binding.handlescope.createScopeFromExisting(), 'existing_scope');
   assert.strictEqual(binding.handlescope.escapeFromScope(), 'inner-scope');
+  assert.strictEqual(binding.handlescope.escapeFromExistingScope(), 'inner-existing-scope');
   assert.strictEqual(binding.handlescope.stressEscapeFromScope(), 'inner-scope999999');
   assert.throws(() => binding.handlescope.doubleEscapeFromScope(),
     Error,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Adding test coverage for `Escape` and `HandleScope`, closes https://github.com/nodejs/node-addon-api/issues/990