### PR TITLE
chore: Build node-addon-api against X86

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        architecture: ${{ matrix.architecture }}
     - name: Check Node.js installation
       run: |
         node --version

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 14.x, 16.x, 18.x, 19.x ]
+        architecture: [x64, x86]
         os:
           - windows-2019
           - windows-2022


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
To be merged after #1275 is merged in. Update our windows CI to build node against X86 based on the [observation](https://github.com/nodejs/node-addon-api/issues/1272#issuecomment-1396389182) here. Main source of concern is that this will double the number of runs we will perform for windows CI. But It might be a worthy trade off to avoid issues like https://github.com/nodejs/node-addon-api/issues/1272
