### PR TITLE
doc: update class hierarchy for TypeTaggable

### DIFF
--- a/doc/hierarchy.md
+++ b/doc/hierarchy.md
@@ -20,7 +20,7 @@
 | [`Napi::Env`][] |  |
 | [`Napi::Error`][] | [`Napi::ObjectReference`][], [`std::exception`][] |
 | [`Napi::EscapableHandleScope`][] |  |
-| [`Napi::External`][] | [`Napi::Value`][] |
+| [`Napi::External`][] | [`Napi::TypeTaggable`][] |
 | [`Napi::Function`][] | [`Napi::Object`][] |
 | [`Napi::FunctionReference`][] | [`Napi::Reference<Napi::Function>`][] |
 | [`Napi::HandleScope`][] |  |
@@ -28,7 +28,7 @@
 | [`Napi::MemoryManagement`][] |  |
 | [`Napi::Name`][] | [`Napi::Value`][] |
 | [`Napi::Number`][] | [`Napi::Value`][] |
-| [`Napi::Object`][] | [`Napi::Value`][] |
+| [`Napi::Object`][] | [`Napi::TypeTaggable`][] |
 | [`Napi::ObjectReference`][] | [`Napi::Reference<Napi::Object>`][] |
 | [`Napi::ObjectWrap`][] | [`Napi::InstanceWrap`][], [`Napi::Reference<Napi::Object>`][] |
 | [`Napi::Promise`][] | [`Napi::Object`][] |
@@ -38,6 +38,7 @@
 | [`Napi::String`][] | [`Napi::Name`][] |
 | [`Napi::Symbol`][] | [`Napi::Name`][] |
 | [`Napi::ThreadSafeFunction`][] |  |
+| [`Napi::TypeTaggable`][] | [`Napi::Value][] |
 | [`Napi::TypeError`][] | [`Napi::Error`][] |
 | [`Napi::TypedArray`][] | [`Napi::Object`][] |
 | [`Napi::TypedArrayOf`][] | [`Napi::TypedArray`][] |
@@ -83,6 +84,7 @@
 [`Napi::Symbol`]: ./symbol.md
 [`Napi::ThreadSafeFunction`]: ./threadsafe_function.md
 [`Napi::TypeError`]: ./type_error.md
+[`Napi::TypeTaggable`]: ./type_taggable.md
 [`Napi::TypedArray`]: ./typed_array.md
 [`Napi::TypedArrayOf`]: ./typed_array_of.md
 [`Napi::Uint8Array`]: ./typed_array_of.md

--- a/doc/type_taggable.md
+++ b/doc/type_taggable.md
@@ -36,3 +36,5 @@ return value is `false`. If a tag is found and it matches `type_tag`, then the
 return value is `true`.
 
 [`Napi::Value`]: ./value.md
+[`Napi::Object`]: ./object.md
+[`Napi::External`]: ./external.md


### PR DESCRIPTION
Reflect in the class hierarchy that `Napi::TypeTaggable` was injected between `Napi::Object` and `Napi:External`, and their parent class, `Napi::Value`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
