### PR TITLE
Fix exits/exists typo in docs for Env::AddCleanupHook()

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -138,7 +138,7 @@ template <typename Hook>
 CleanupHook<Hook> AddCleanupHook(Hook hook);
 ```
 
-- `[in] hook`: A function to call when the environment exists. Accepts a
+- `[in] hook`: A function to call when the environment exits. Accepts a
   function of the form `void ()`.
 
 Registers `hook` as a function to be run once the current Node.js environment
@@ -156,7 +156,7 @@ template <typename Hook, typename Arg>
 CleanupHook<Hook, Arg> AddCleanupHook(Hook hook, Arg* arg);
 ```
 
-- `[in] hook`: A function to call when the environment exists. Accepts a
+- `[in] hook`: A function to call when the environment exits. Accepts a
   function of the form `void (Arg* arg)`.
 - `[in] arg`: A pointer to data that will be passed as the argument to `hook`.
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

I'm 99% sure that this was a typo that was then copy-pasted, but if not, please close.