### PR TITLE
src: handle failure during error wrap of primitive

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2757,6 +2757,22 @@ inline Error::Error(napi_env env, napi_value value)
           nullptr};
 
       status = napi_define_properties(env, wrappedErrorObj, 1, &wrapObjFlag);
+#ifdef NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS
+      if (status == napi_pending_exception) {
+        // Test if the pending exception was reported because the environment is
+        // shutting down. We assume that a status of napi_pending_exception
+        // coupled with the absence of an actual pending exception means that
+        // the environment is shutting down. If so, we replace the
+        // napi_pending_exception status with napi_ok.
+        bool is_exception_pending = false;
+        status = napi_is_exception_pending(env, &is_exception_pending);
+        if (status == napi_ok && !is_exception_pending) {
+          status = napi_ok;
+        } else {
+          status = napi_pending_exception;
+        }
+      }
+#endif  // NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS
       NAPI_FATAL_IF_FAILED(status, "Error::Error", "napi_define_properties");
 
       // Create a reference on the newly wrapped object


### PR DESCRIPTION
When we wrap a primitive value into an object in order to throw it as an error, we call `napi_define_properties()` which may return `napi_pending_exception` if the environment is shutting down. Handle this case when `NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS` is given by checking whether we're in an environment shutdown scenario and ignore the failure of `napi_define_properties()`, since the error will not reach JS anyway.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
