### PR TITLE
src: Avoid calling into C++ with a null this

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -165,7 +165,7 @@ napi_value TemplatedInstanceCallback(napi_env env,
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
-    return (instance->*UnwrapCallback)(cbInfo);
+    return instance ? (instance->*UnwrapCallback)(cbInfo) : Napi::Value();
   });
 }
 
@@ -175,7 +175,7 @@ napi_value TemplatedInstanceVoidCallback(napi_env env, napi_callback_info info)
   return details::WrapCallback([&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
-    (instance->*UnwrapCallback)(cbInfo);
+    if (instance) (instance->*UnwrapCallback)(cbInfo);
     return nullptr;
   });
 }
@@ -4340,7 +4340,7 @@ inline napi_value InstanceWrap<T>::InstanceVoidMethodCallbackWrapper(
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->callback;
-    (instance->*cb)(callbackInfo);
+    if (instance) (instance->*cb)(callbackInfo);
     return nullptr;
   });
 }
@@ -4355,7 +4355,7 @@ inline napi_value InstanceWrap<T>::InstanceMethodCallbackWrapper(
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->callback;
-    return (instance->*cb)(callbackInfo);
+    return instance ? (instance->*cb)(callbackInfo) : Napi::Value();
   });
 }
 
@@ -4369,7 +4369,7 @@ inline napi_value InstanceWrap<T>::InstanceGetterCallbackWrapper(
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->getterCallback;
-    return (instance->*cb)(callbackInfo);
+    return instance ? (instance->*cb)(callbackInfo) : Napi::Value();
   });
 }
 
@@ -4383,7 +4383,7 @@ inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
     callbackInfo.SetData(callbackData->data);
     T* instance = T::Unwrap(callbackInfo.This().As<Object>());
     auto cb = callbackData->setterCallback;
-    (instance->*cb)(callbackInfo, callbackInfo[0]);
+    if (instance) (instance->*cb)(callbackInfo, callbackInfo[0]);
     return nullptr;
   });
 }
@@ -4395,7 +4395,7 @@ inline napi_value InstanceWrap<T>::WrappedMethod(
   return details::WrapCallback([&] {
     const CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
-    (instance->*method)(cbInfo, cbInfo[0]);
+    if (instance) (instance->*method)(cbInfo, cbInfo[0]);
     return nullptr;
   });
 }

--- a/test/objectwrap.js
+++ b/test/objectwrap.js
@@ -24,6 +24,9 @@ async function test (binding) {
       obj.testSetter = 'instance getter 2';
       assert.strictEqual(obj.testGetter, 'instance getter 2');
       assert.strictEqual(obj.testGetterT, 'instance getter 2');
+
+      assert.throws(() => clazz.prototype.testGetter, /Invalid argument/);
+      assert.throws(() => clazz.prototype.testGetterT, /Invalid argument/);
     }
 
     // read write-only
@@ -61,6 +64,9 @@ async function test (binding) {
 
       obj.testGetSetT = 'instance getset 4';
       assert.strictEqual(obj.testGetSetT, 'instance getset 4');
+
+      assert.throws(() => { clazz.prototype.testGetSet = 'instance getset'; }, /Invalid argument/);
+      assert.throws(() => { clazz.prototype.testGetSetT = 'instance getset'; }, /Invalid argument/);
     }
 
     // rw symbol
@@ -98,6 +104,9 @@ async function test (binding) {
     assert.strictEqual(obj.testMethodT(), 'method<>(const char*)');
     obj[clazz.kTestVoidMethodTInternal]('method<>(Symbol)');
     assert.strictEqual(obj[clazz.kTestMethodTInternal](), 'method<>(Symbol)');
+    assert.throws(() => clazz.prototype.testMethod('method'));
+    assert.throws(() => clazz.prototype.testMethodT());
+    assert.throws(() => clazz.prototype.testVoidMethodT('method<>(const char*)'));
   };
 
   const testEnumerables = (obj, clazz) => {


### PR DESCRIPTION
These tests all crash the process because `instance` is null when exceptions are off. If ObjectWrap methods try to access anything on `this`, it's bad news. I don't think the method should get called at all in this case since there's a pending JS exception anyways.

Context: I recently [ported node-canvas](https://github.com/Automattic/node-canvas/pull/2235) to `node-addon-api` and we have tests for this. It was a pain in v8/NAN, and we could remove a lot of code with these changes. I had a positive experience working with `node-addon-api`, great work everyone!