### PR TITLE
doc,chore: drop support for Node.js v14, v19

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -7,14 +7,11 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x, 19.x ]
+        node-version: [ 16.x, 18.x, 20.x ]
         architecture: [x64, x86]
         os:
           - windows-2019
           - windows-2022
-        exclude:
-          - node-version: 14.x
-            os: windows-2022 # Node.JS 14.x GYP does not support Visual Studio 2022
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x, 19.x ]
+        node-version: [ 16.x, 18.x, 20.x ]
         os:
           - macos-latest
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This allows addons built with it to run with Node.js versions which support the 
 **However** the node-addon-api support model is to support only the active LTS Node.js versions. This means that
 every year there will be a new major which drops support for the Node.js LTS version which has gone out of service.
 
-The oldest Node.js version supported by the current version of node-addon-api is Node.js 18.x.
+The oldest Node.js version supported by the current version of node-addon-api is Node.js 16.x.
 
 ## Setup
   - [Installation and usage](doc/setup.md)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This allows addons built with it to run with Node.js versions which support the 
 **However** the node-addon-api support model is to support only the active LTS Node.js versions. This means that
 every year there will be a new major which drops support for the Node.js LTS version which has gone out of service.
 
-The oldest Node.js version supported by the current version of node-addon-api is Node.js 14.x.
+The oldest Node.js version supported by the current version of node-addon-api is Node.js 18.x.
 
 ## Setup
   - [Installation and usage](doc/setup.md)
@@ -275,6 +275,7 @@ available:
 ![Node-API v6 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v6%20Badge.svg)
 ![Node-API v7 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v7%20Badge.svg)
 ![Node-API v8 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v8%20Badge.svg)
+![Node-API v9 Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20v9%20Badge.svg)
 ![Node-API Experimental Version Badge](https://github.com/nodejs/abi-stable-node/blob/doc/assets/Node-API%20Experimental%20Version%20Badge.svg)
 
 ## **Contributing**

--- a/doc/creating_a_release.md
+++ b/doc/creating_a_release.md
@@ -60,3 +60,24 @@ and that the correct version is installed.
 and close the issue.
 
 * Tweet that the release has been created.
+
+## Optional Steps
+
+Depending on circumstances for the release, additional steps may be required to
+support the release process.
+
+### Major Releases to Drop Support Node.js Versions
+
+`node-addon-api` provides support for Node.js versions following the same
+[release schedule](https://nodejs.dev/en/about/releases/): once a Node.js
+version leaves maintenance mode, the next major version of `node-addon-api`
+published will drop support for that version. These are the steps to follow to
+drop support for a Node.js version:
+
+* Update minimum version supported in documentation ([README.md](../README.md))
+
+* Remove from GitHub actions ([ci.yml](../.github/workflows/ci.yml) and
+  [ci-win.yml](../.github/workflows/ci-win.yml))
+
+* Remove from Jenkins CI ([node-test-node-addon-api-LTS versions
+  [Jenkins]](https://ci.nodejs.org/view/x%20-%20Abi%20stable%20module%20API/job/node-test-node-addon-api-LTS%20versions/))


### PR DESCRIPTION
Adds documentation for how to drop support, as well as dropping support for Node.js v14 and v19.

Relates: https://github.com/nodejs/node-addon-api/issues/1315