### PR TITLE
test: run interfering tests in their own process

### DIFF
--- a/test/addon.cc
+++ b/test/addon.cc
@@ -17,6 +17,8 @@ class TestAddon : public Napi::Addon<TestAddon> {
                  {InstanceMethod("decrement", &TestAddon::Decrement)}))});
   }
 
+  ~TestAddon() { fprintf(stderr, "TestAddon::~TestAddon\n"); }
+
  private:
   Napi::Value Increment(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), ++value);
@@ -29,10 +31,14 @@ class TestAddon : public Napi::Addon<TestAddon> {
   uint32_t value = 42;
 };
 
+Napi::Value CreateAddon(const Napi::CallbackInfo& info) {
+  return TestAddon::Init(info.Env(), Napi::Object::New(info.Env()));
+}
+
 }  // end of anonymous namespace
 
 Napi::Object InitAddon(Napi::Env env) {
-  return TestAddon::Init(env, Napi::Object::New(env));
+  return Napi::Function::New<CreateAddon>(env, "CreateAddon");
 }
 
 #endif  // (NAPI_VERSION > 5)

--- a/test/addon.js
+++ b/test/addon.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const assert = require('assert');
-
-module.exports = require('./common').runTest(test);
-
-function test (binding) {
-  assert.strictEqual(binding.addon.increment(), 43);
-  assert.strictEqual(binding.addon.increment(), 44);
-  assert.strictEqual(binding.addon.subObject.decrement(), 43);
-}
+module.exports = require('./common').runTestInChildProcess({
+  suite: 'addon',
+  testName: 'workingCode',
+  expectedStderr: ['TestAddon::~TestAddon']
+});

--- a/test/addon_data.cc
+++ b/test/addon_data.cc
@@ -4,10 +4,10 @@
 #include "test_helper.h"
 
 // An overly elaborate way to get/set a boolean stored in the instance data:
-// 0. A boolean named "verbose" is stored in the instance data. The constructor
-//    for JS `VerboseIndicator` instances is also stored in the instance data.
+// 0. The constructor for JS `VerboseIndicator` instances, which have a private
+//    member named "verbose", is stored in the instance data.
 // 1. Add a property named "verbose" onto exports served by a getter/setter.
-// 2. The getter returns a object of type VerboseIndicator, which itself has a
+// 2. The getter returns an object of type VerboseIndicator, which itself has a
 //    property named "verbose", also served by a getter/setter:
 //    * The getter returns a boolean, indicating whether "verbose" is set.
 //    * The setter sets "verbose" on the instance data.

--- a/test/addon_data.js
+++ b/test/addon_data.js
@@ -1,46 +1,24 @@
 'use strict';
 
-const assert = require('assert');
-const { spawn } = require('child_process');
-const readline = require('readline');
+const common = require('./common');
 
-module.exports = require('./common').runTestWithBindingPath(test);
+module.exports = common.runTest(test);
 
-// Make sure the instance data finalizer is called at process exit. If the hint
-// is non-zero, it will be printed out by the child process.
-function testFinalizer (bindingName, hint, expected) {
-  return new Promise((resolve) => {
-    bindingName = bindingName.split('\\').join('\\\\');
-    const child = spawn(process.execPath, [
-      '-e',
-      `require('${bindingName}').addon_data(${hint}).verbose = true;`
-    ]);
-    const actual = [];
-    readline
-      .createInterface({ input: child.stderr })
-      .on('line', (line) => {
-        if (expected.indexOf(line) >= 0) {
-          actual.push(line);
-        }
-      })
-      .on('close', () => {
-        assert.deepStrictEqual(expected, actual);
-        resolve();
-      });
+async function test () {
+  await common.runTestInChildProcess({
+    suite: 'addon_data',
+    testName: 'workingCode'
   });
-}
 
-async function test (bindingName) {
-  const binding = require(bindingName).addon_data(0);
+  await common.runTestInChildProcess({
+    suite: 'addon_data',
+    testName: 'cleanupWithoutHint',
+    expectedStderr: ['addon_data: Addon::~Addon']
+  });
 
-  // Make sure it is possible to get/set instance data.
-  assert.strictEqual(binding.verbose.verbose, false);
-  binding.verbose = true;
-  assert.strictEqual(binding.verbose.verbose, true);
-  binding.verbose = false;
-  assert.strictEqual(binding.verbose.verbose, false);
-
-  await testFinalizer(bindingName, 0, ['addon_data: Addon::~Addon']);
-  await testFinalizer(bindingName, 42,
-    ['addon_data: Addon::~Addon', 'hint: 42']);
+  await common.runTestInChildProcess({
+    suite: 'addon_data',
+    testName: 'cleanupWithHint',
+    expectedStderr: ['addon_data: Addon::~Addon', 'hint: 42']
+  });
 }

--- a/test/child_processes/addon.js
+++ b/test/child_processes/addon.js
@@ -1,0 +1,11 @@
+'use strict';
+const assert = require('assert');
+
+module.exports = {
+  workingCode: binding => {
+    const addon = binding.addon();
+    assert.strictEqual(addon.increment(), 43);
+    assert.strictEqual(addon.increment(), 44);
+    assert.strictEqual(addon.subObject.decrement(), 43);
+  }
+};

--- a/test/child_processes/addon_data.js
+++ b/test/child_processes/addon_data.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+
+// Make sure the instance data finalizer is called at process exit. If the hint
+// is non-zero, it will be printed out by the child process.
+const cleanupTest = (binding, hint) => {
+  binding.addon_data(hint).verbose = true;
+};
+
+module.exports = {
+  workingCode: binding => {
+    const addonData = binding.addon_data(0);
+
+    // Make sure it is possible to get/set instance data.
+    assert.strictEqual(addonData.verbose.verbose, false);
+    addonData.verbose = true;
+    assert.strictEqual(addonData.verbose.verbose, true);
+    addonData.verbose = false;
+    assert.strictEqual(addonData.verbose.verbose, false);
+  },
+  cleanupWithHint: binding => cleanupTest(binding, 42),
+  cleanupWithoutHint: binding => cleanupTest(binding, 0)
+};

--- a/test/child_processes/objectwrap_function.js
+++ b/test/child_processes/objectwrap_function.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assert = require('assert');
+const testUtil = require('../testUtil');
+
+module.exports = {
+  runTest: function (binding) {
+    return testUtil.runGCTests([
+      'objectwrap function',
+      () => {
+        const { FunctionTest } = binding.objectwrap_function();
+        const newConstructed = new FunctionTest();
+        const functionConstructed = FunctionTest();
+        assert(newConstructed instanceof FunctionTest);
+        assert(functionConstructed instanceof FunctionTest);
+        assert.throws(() => (FunctionTest(true)), /an exception/);
+      },
+      // Do one gc before returning.
+      () => {}
+    ]);
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,7 @@ function loadTestModules (currentDirectory = __dirname, pre = '') {
           file === 'binding.gyp' ||
           file === 'build' ||
           file === 'common' ||
+          file === 'child_processes' ||
           file === 'napi_child.js' ||
           file === 'testUtil.js' ||
           file === 'thunking_manual.cc' ||

--- a/test/objectwrap_function.js
+++ b/test/objectwrap_function.js
@@ -1,22 +1,6 @@
 'use strict';
 
-const assert = require('assert');
-const testUtil = require('./testUtil');
-
-function test (binding) {
-  return testUtil.runGCTests([
-    'objectwrap function',
-    () => {
-      const { FunctionTest } = binding.objectwrap_function;
-      const newConstructed = new FunctionTest();
-      const functionConstructed = FunctionTest();
-      assert(newConstructed instanceof FunctionTest);
-      assert(functionConstructed instanceof FunctionTest);
-      assert.throws(() => (FunctionTest(true)), /an exception/);
-    },
-    // Do on gc before returning.
-    () => {}
-  ]);
-}
-
-module.exports = require('./common').runTest(test);
+module.exports = require('./common').runTestInChildProcess({
+  suite: 'objectwrap_function',
+  testName: 'runTest'
+});


### PR DESCRIPTION
Tests such as addon and addon_data both use SetInstanceData. Thus, they overwrite each other's instance data. We change them both to run in a child process such that they do not call SetInstanceData on init, but rather they return a JS function on init which, when called, produces the actual binding which needs SetInstanceData.

We also introduce a utility function for launching a test in its own child process for the purpose of running tests that would otherwise interfere with each other.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
