### PR TITLE
src: add Env::GetModuleFileName

### DIFF
--- a/doc/env.md
+++ b/doc/env.md
@@ -134,13 +134,13 @@ be passed to `fini`.
 ### GetModuleFileName
 
 ```cpp
-std::string_view Napi::Env::GetModuleFileName() const;
+const char* Napi::Env::GetModuleFileName() const;
 ```
 
 Returns a A URL containing the absolute path of the location from which the
 add-on was loaded. For a file on the local file system it will start with
-`file://`. The `string_view` data is null-terminated and owned by env and is
-only valid while the add-on is loaded.
+`file://`. The string is null-terminated and owned by env and must thus not be
+modified or freed. It is only valid while the add-on is loaded.
 
 ### AddCleanupHook
 

--- a/doc/env.md
+++ b/doc/env.md
@@ -131,6 +131,17 @@ addon. The item will be passed to the function `fini` which gets called when an
 instance of the addon is unloaded. This overload accepts an additional hint to
 be passed to `fini`.
 
+### GetModuleFileName
+
+```cpp
+std::string_view Napi::Env::GetModuleFileName() const;
+```
+
+Returns a A URL containing the absolute path of the location from which the
+add-on was loaded. For a file on the local file system it will start with
+`file://`. The `string_view` data is null-terminated and owned by env and is
+only valid while the add-on is loaded.
+
 ### AddCleanupHook
 
 ```cpp

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -572,6 +572,14 @@ void Env::DefaultFiniWithHint(Env, DataType* data, HintType*) {
 }
 #endif  // NAPI_VERSION > 5
 
+#if NAPI_VERSION > 8
+inline std::string_view Env::GetModuleFileName() const {
+  const char* result;
+  napi_status status = node_api_get_module_file_name(_env, &result);
+  NAPI_THROW_IF_FAILED(*this, status, std::string_view());
+  return std::string_view(result);
+}
+#endif  // NAPI_VERSION > 8
 ////////////////////////////////////////////////////////////////////////////////
 // Value class
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -573,11 +573,11 @@ void Env::DefaultFiniWithHint(Env, DataType* data, HintType*) {
 #endif  // NAPI_VERSION > 5
 
 #if NAPI_VERSION > 8
-inline std::string_view Env::GetModuleFileName() const {
+inline const char* Env::GetModuleFileName() const {
   const char* result;
   napi_status status = node_api_get_module_file_name(_env, &result);
   NAPI_THROW_IF_FAILED(*this, status, std::string_view());
-  return std::string_view(result);
+  return result;
 }
 #endif  // NAPI_VERSION > 8
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -576,7 +576,7 @@ void Env::DefaultFiniWithHint(Env, DataType* data, HintType*) {
 inline const char* Env::GetModuleFileName() const {
   const char* result;
   napi_status status = node_api_get_module_file_name(_env, &result);
-  NAPI_THROW_IF_FAILED(*this, status, std::string_view());
+  NAPI_THROW_IF_FAILED(*this, status, nullptr);
   return result;
 }
 #endif  // NAPI_VERSION > 8

--- a/napi.h
+++ b/napi.h
@@ -367,6 +367,10 @@ class Env {
     } * data;
   };
 #endif  // NAPI_VERSION > 2
+
+#if NAPI_VERSION > 8
+  std::string_view GetModuleFileName() const;
+#endif  // NAPI_VERSION > 8
 };
 
 /// A JavaScript value of unknown type.

--- a/napi.h
+++ b/napi.h
@@ -369,7 +369,7 @@ class Env {
 #endif  // NAPI_VERSION > 2
 
 #if NAPI_VERSION > 8
-  std::string_view GetModuleFileName() const;
+  const char* GetModuleFileName() const;
 #endif  // NAPI_VERSION > 8
 };
 

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -78,7 +78,9 @@ Object InitThunkingManual(Env env);
 Object InitObjectFreezeSeal(Env env);
 Object InitTypeTaggable(Env env);
 #endif
-
+#if (NAPI_VERSION > 8)
+Object InitEnvMiscellaneous(Env env);
+#endif
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
 Object InitMaybeCheck(Env env);
 #endif
@@ -170,6 +172,9 @@ Object Init(Env env, Object exports) {
 #if (NAPI_VERSION > 7)
   exports.Set("object_freeze_seal", InitObjectFreezeSeal(env));
   exports.Set("type_taggable", InitTypeTaggable(env));
+#endif
+#if (NAPI_VERSION > 8)
+  exports.Set("env_misc", InitEnvMiscellaneous(env));
 #endif
 
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -26,6 +26,7 @@
         'dataview/dataview.cc',
         'dataview/dataview_read_write.cc',
         'env_cleanup.cc',
+        'env_misc.cc',
         'error.cc',
         'error_handling_for_primitives.cc',
         'external.cc',

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -164,7 +164,7 @@ exports.runTest = async function (test, buildType, buildPathRoot = process.env.B
   ].map(it => require.resolve(it));
 
   for (const item of bindings) {
-    await Promise.resolve(test(require(item)))
+    await Promise.resolve(test(require(item), { bindingPath: item }))
       .finally(exports.mustCall());
   }
 };

--- a/test/env_misc.cc
+++ b/test/env_misc.cc
@@ -1,0 +1,25 @@
+#include "napi.h"
+#include "test_helper.h"
+
+#if (NAPI_VERSION > 8)
+
+using namespace Napi;
+
+namespace {
+
+Value GetModuleFileName(const CallbackInfo& info) {
+  Env env = info.Env();
+  return String::New(env, env.GetModuleFileName().data());
+}
+
+}  // end anonymous namespace
+
+Object InitEnvMiscellaneous(Env env) {
+  Object exports = Object::New(env);
+
+  exports["get_module_file_name"] = Function::New(env, GetModuleFileName);
+
+  return exports;
+}
+
+#endif

--- a/test/env_misc.cc
+++ b/test/env_misc.cc
@@ -9,7 +9,7 @@ namespace {
 
 Value GetModuleFileName(const CallbackInfo& info) {
   Env env = info.Env();
-  return String::New(env, env.GetModuleFileName().data());
+  return String::New(env, env.GetModuleFileName());
 }
 
 }  // end anonymous namespace

--- a/test/env_misc.js
+++ b/test/env_misc.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const assert = require('assert');
+const { pathToFileURL } = require('url');
+
+module.exports = require('./common').runTest(test);
+
+function test (binding, { bindingPath } = {}) {
+  const path = binding.env_misc.get_module_file_name();
+  const bindingFileUrl = pathToFileURL(bindingPath).toString();
+  assert(bindingFileUrl === path);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -137,6 +137,10 @@ if (napiVersion < 8 && !filterConditionsProvided) {
   testModules.splice(testModules.indexOf('type_taggable'), 1);
 }
 
+if (napiVersion < 9 && !filterConditionsProvided) {
+  testModules.splice(testModules.indexOf('env_misc'), 1);
+}
+
 (async function () {
   console.log(`Testing with Node-API Version '${napiVersion}'.`);
 


### PR DESCRIPTION
Adds wrapper for `Napi::Env::GetModuleFileName()` from release of Node-API v9.