### PR TITLE
Add Node.js version restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -468,5 +468,8 @@
   },
   "pre-commit": "lint",
   "version": "7.0.0",
-  "support": true
+  "support": true,
+  "engines": {
+    "node": "^16 || ^18 || >= 20"
+  }
 }


### PR DESCRIPTION
Assumed from last Changelog the current version supports Node.js 16, 18, 20 and we should also not block 21+ for now, Right?

fixes #1339 