### PR TITLE
gyp: add common targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /benchmark/src
 /test/addon_build/addons
 /.vscode
+
+# ignore node-gyp generated files outside its build directory
+/test/*.Makefile
+/test/*.mk

--- a/benchmark/binding.gyp
+++ b/benchmark/binding.gyp
@@ -4,22 +4,22 @@
     {
       'target_name': 'function_args',
       'sources': [ 'function_args.cc' ],
-      'includes': [ '../except.gypi' ],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_except'],
     },
     {
       'target_name': 'function_args_noexcept',
       'sources': [ 'function_args.cc' ],
-      'includes': [ '../noexcept.gypi' ],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
     },
     {
       'target_name': 'property_descriptor',
       'sources': [ 'property_descriptor.cc' ],
-      'includes': [ '../except.gypi' ],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_except'],
     },
     {
       'target_name': 'property_descriptor_noexcept',
       'sources': [ 'property_descriptor.cc' ],
-      'includes': [ '../noexcept.gypi' ],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
     },
   ]
 }

--- a/common.gypi
+++ b/common.gypi
@@ -15,7 +15,6 @@
       }
     }]
   ],
-  'include_dirs': ["<!(node -p \"require('../').include_dir\")"],
   'cflags': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ],
   'cflags_cc': [ '-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wunused-parameter' ]
 }

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -23,47 +23,27 @@ To use **Node-API** in a native module:
   }
 ```
 
-  2. Reference this package's include directory and gyp file in `binding.gyp`:
-
-```gyp
-  'include_dirs': ["<!(node -p \"require('node-addon-api').include_dir\")"],
-```
-
-  3. Decide whether the package will enable C++ exceptions in the Node-API wrapper.
+  2. Decide whether the package will enable C++ exceptions in the Node-API
+     wrapper, and reference this package as a dependency in `binding.gyp`.
      The base ABI-stable C APIs do not throw or handle C++ exceptions, but the
      Node-API C++ wrapper classes may _optionally_
      [integrate C++ and JavaScript exception-handling
      ](https://github.com/nodejs/node-addon-api/blob/HEAD/doc/error_handling.md).
-     To enable that capability, C++ exceptions must be enabled in `binding.gyp`:
+
+     To use without C++ exceptions, add the following to `binding.gyp`:
 
 ```gyp
-  'cflags!': [ '-fno-exceptions' ],
-  'cflags_cc!': [ '-fno-exceptions' ],
-  'conditions': [
-    ["OS=='win'", {
-      "defines": [
-        "_HAS_EXCEPTIONS=1"
-      ],
-      "msvs_settings": {
-        "VCCLCompilerTool": {
-          "ExceptionHandling": 1
-        },
-      },
-    }],
-    ["OS=='mac'", {
-      'xcode_settings': {
-        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-        'CLANG_CXX_LIBRARY': 'libc++',
-        'MACOSX_DEPLOYMENT_TARGET': '10.7',
-      },
-    }],
+  'dependencies': [
+    "<!(node -p \"require('node-addon-api').targets\"):node_addon_api",
   ],
 ```
 
-  Alternatively, disable use of C++ exceptions in Node-API:
+     To enable that capability, add an alternative dependency in `binding.gyp`:
 
 ```gyp
-  'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+  'dependencies': [
+    "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+  ],
 ```
 
   If you decide to use node-addon-api without C++ exceptions enabled, please
@@ -71,7 +51,9 @@ To use **Node-API** in a native module:
   exception handling pattern:
 
 ```gyp
-  'defines': [ 'NODE_ADDON_API_ENABLE_MAYBE' ],
+  'dependencies': [
+    "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_maybe",
+  ],
 ```
 
   4. If you would like your native addon to support OSX, please also add the

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const includeDir = path.relative('.', __dirname);
 module.exports = {
   include: `"${__dirname}"`, // deprecated, can be removed as part of 4.0.0
   include_dir: includeDir,
-  gyp: path.join(includeDir, 'node_api.gyp:nothing'),
+  gyp: path.join(includeDir, 'node_api.gyp:nothing'), // deprecated.
+  targets: path.join(includeDir, 'node_addon_api.gyp'),
   isNodeApiBuiltin: true,
   needsFlag: false
 };

--- a/node_addon_api.gyp
+++ b/node_addon_api.gyp
@@ -1,0 +1,32 @@
+{
+  'targets': [
+    {
+      'target_name': 'node_addon_api',
+      'type': 'none',
+      'sources': [ 'napi.h', 'napi-inl.h' ],
+      'direct_dependent_settings': {
+        'include_dirs': [ '.' ],
+        'includes': ['noexcept.gypi'],
+      }
+    },
+    {
+      'target_name': 'node_addon_api_except',
+      'type': 'none',
+      'sources': [ 'napi.h', 'napi-inl.h' ],
+      'direct_dependent_settings': {
+        'include_dirs': [ '.' ],
+        'includes': ['except.gypi'],
+      }
+    },
+    {
+      'target_name': 'node_addon_api_maybe',
+      'type': 'none',
+      'sources': [ 'napi.h', 'napi-inl.h' ],
+      'direct_dependent_settings': {
+        'include_dirs': [ '.' ],
+        'includes': ['noexcept.gypi'],
+        'defines': ['NODE_ADDON_API_ENABLE_MAYBE']
+      }
+    },
+  ]
+}

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -97,41 +97,40 @@
   'targets': [
     {
       'target_name': 'binding',
-      'includes': ['../except.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_except'],
       'sources': ['>@(build_sources)']
     },
     {
       'target_name': 'binding_noexcept',
-      'includes': ['../noexcept.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
       'sources': ['>@(build_sources)']
     },
     {
       'target_name': 'binding_noexcept_maybe',
-      'includes': ['../noexcept.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_maybe'],
       'sources': ['>@(build_sources)'],
-      'defines': ['NODE_ADDON_API_ENABLE_MAYBE']
     },
     {
       'target_name': 'binding_swallowexcept',
-      'includes': ['../except.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_except'],
       'sources': [ '>@(build_sources_swallowexcept)'],
       'defines': ['NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS']
     },
     {
       'target_name': 'binding_swallowexcept_noexcept',
-      'includes': ['../noexcept.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
       'sources': ['>@(build_sources_swallowexcept)'],
       'defines': ['NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS']
     },
     {
       'target_name': 'binding_type_check',
-      'includes': ['../noexcept.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
       'sources': ['>@(build_sources_type_check)'],
       'defines': ['NODE_ADDON_API_ENABLE_TYPE_CHECK_ON_AS']
     },
     {
       'target_name': 'binding_custom_namespace',
-      'includes': ['../noexcept.gypi'],
+      'dependencies': ['../node_addon_api.gyp:node_addon_api'],
       'sources': ['>@(build_sources)'],
       'defines': ['NAPI_CPP_CUSTOM_NAMESPACE=cstm']
     },


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-addon-api/issues/1379

As documented at https://gyp.gsrc.io/docs/InputFormatReference.md#processing-order, a dependency's setting is processed after merging the root target_defaults, and variable expansion is allowed in dependency specifiers. This allows addons to include node-addon-api and common configs with a single line of gyp config. For example, when the addon needs c++ exception feature, they can simply declare the dependency on `node-addon-api-except`:

```
{
  "targets": [
    {
      "target_name": "my_node_addon",
      "sources": [
        "src/my_node_addon.cc"
      ],
      'dependencies': [
        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
      ]
    }
  ]
}
```

No need to copy a paragraph of configs into addons' binding.gyp like documented at https://github.com/nodejs/node-addon-api/blob/9aaf3b1/doc/setup.md#installation-and-usage anymore.

- [x] update the document
- [x] add a test