### PR TITLE
Plumb node api version through to build

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -1,6 +1,6 @@
 {
   'variables': {
-    'NAPI_VERSION%': "<!(node -p \"process.versions.napi\")",
+    'NAPI_VERSION%': "<!(node -p \"process.env.NAPI_VERSION || process.versions.napi\")",
     'disable_deprecated': "<!(node -p \"process.env['npm_config_disable_deprecated']\")"
   },
   'conditions': [

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -148,7 +148,7 @@ async function whichBuildType () {
       if (await checkBuildType(envBuildType)) {
         buildType = envBuildType;
       } else {
-        throw new Error(`The ${envBuildType} build doesn't exists.`);
+        throw new Error(`The ${envBuildType} build doesn't exist.`);
       }
     } else {
       throw new Error('Invalid value for NODE_API_BUILD_CONFIG environment variable. It should be set to Release or Debug.');


### PR DESCRIPTION
* pass finalizer to `AttachData` as a template parameter.
* plumb the environments `NAPI_VERSION` through to the build.
* fix a typo.

These are preparatory steps for building with `NAPI_EXPERIMENTAL` once more. Currently doing so bumps against the new `env->CheckGCAccess()` in core.