### PR TITLE
chore: reduce dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,23 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      all:
+        patterns: '*'
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      all:
+        patterns: '*'
 
   - package-ecosystem: npm
     directory: /test/addon_build/tpl
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      all:
+        patterns: '*'


### PR DESCRIPTION
Dependabot creates a lot of trivial updates of dependencies. See https://github.com/nodejs/node-addon-api/releases/tag/v7.1.0.

This patch reduces the noise that can created by the dependabot by grouping the updates and reducing the frequency of PRs.