### PR TITLE
chore: remove v16.x regular CI runs

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 21.x ]
         architecture: [x64, x86]
         os:
           - windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 21.x ]
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'nodejs/node-addon-api'
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This allows addons built with it to run with Node.js versions which support the 
 **However** the node-addon-api support model is to support only the active LTS Node.js versions. This means that
 every year there will be a new major which drops support for the Node.js LTS version which has gone out of service.
 
-The oldest Node.js version supported by the current version of node-addon-api is Node.js 16.x.
+The oldest Node.js version supported by the current version of node-addon-api is Node.js 18.x.
 
 ## Setup
   - [Installation and usage](doc/setup.md)


### PR DESCRIPTION
Add v21.x runs as well.

Refs: https://github.com/nodejs/node-addon-api/issues/1381