### PR TITLE
test: add basic coverage support

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -1,0 +1,78 @@
+name: Coverage Linux
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - benchmark/**
+      - doc/**
+      - tools/**
+      - unit-test/**
+      - .github/**
+      - '!.github/workflows/coverage-linux.yml'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - benchmark/**
+      - doc/**
+      - tools/**
+      - unit-test/**
+      - .github/**
+      - '!.github/workflows/coverage-linux.yml'
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20.x'
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-linux:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Environment Information
+        run: npx envinfo
+      - name: Install gcovr
+        run: pip install gcovr==6.0
+      - name: Install dependencies
+        run: npm install
+      - name: Test with coverage
+        run: |
+          npm run create-coverage
+      - name: Generate coverage report (XML)
+        run: |
+          npm run report-coverage-xml
+      - name: Generate coverage report (HTML)
+        run: |
+          npm run report-coverage-html
+      - name: Upload
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab  # v4.1.0
+        with:
+          directory: ./coverage-xml
+          token: ${{ secrets.CODECOV_TOKEN }} # To bypass public API rate limiting, see https://github.com/codecov/codecov-action/issues/557
+      - name: Upload XML coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-xml
+          path: coverage-xml/
+      - name: Upload HTML coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-html
+          path: coverage-html/

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -2,7 +2,7 @@ name: Coverage Linux
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
       - benchmark/**
@@ -32,7 +32,6 @@ permissions:
 
 jobs:
   coverage-linux:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
@@ -58,21 +57,8 @@ jobs:
       - name: Generate coverage report (XML)
         run: |
           npm run report-coverage-xml
-      - name: Generate coverage report (HTML)
-        run: |
-          npm run report-coverage-html
       - name: Upload
         uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab  # v4.1.0
         with:
           directory: ./coverage-xml
           token: ${{ secrets.CODECOV_TOKEN }} # To bypass public API rate limiting, see https://github.com/codecov/codecov-action/issues/557
-      - name: Upload XML coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-xml
-          path: coverage-xml/
-      - name: Upload HTML coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-html
-          path: coverage-html/

--- a/package.json
+++ b/package.json
@@ -463,7 +463,9 @@
   "scripts": {
     "prebenchmark": "node-gyp rebuild -C benchmark",
     "benchmark": "node benchmark",
-    "coverage": "npm test --coverage && rm -rf coverage && mkdir coverage && gcovr -e test --merge-mode-functions merge-use-line-max --html-nested coverage/index.html test",
+    "create-coverage": "npm test --coverage",
+    "report-coverage-html": "rm -rf coverage-html && mkdir coverage-html && gcovr -e test --merge-mode-functions merge-use-line-max --html-nested ./coverage-html/index.html test",
+    "report-coverage-xml": "rm -rf coverage-xml && mkdir coverage-xml && gcovr -e test --merge-mode-functions merge-use-line-max --xml -o ./coverage-xml/coverage-cxx.xml test",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
     "test:debug": "node-gyp rebuild -C test --debug && NODE_API_BUILD_CONFIG=Debug node ./test/index.js",

--- a/package.json
+++ b/package.json
@@ -463,6 +463,7 @@
   "scripts": {
     "prebenchmark": "node-gyp rebuild -C benchmark",
     "benchmark": "node benchmark",
+    "coverage": "npm test --coverage && rm -rf coverage && mkdir coverage && gcovr -e test --merge-mode-functions merge-use-line-max --html-nested coverage/index.html test",
     "pretest": "node-gyp rebuild -C test",
     "test": "node test",
     "test:debug": "node-gyp rebuild -C test --debug && NODE_API_BUILD_CONFIG=Debug node ./test/index.js",

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -87,12 +87,19 @@
       'build_sources_type_check': [
         'value_type_cast.cc'
       ],
+      'want_coverage': '<!(node -p process.env.npm_config_coverage)',
       'conditions': [
         ['disable_deprecated!="true"', {
           'build_sources': ['object/object_deprecated.cc']
         }]
       ]
     },
+    'conditions': [
+      ['want_coverage=="true" and OS=="linux"', {
+        'cflags_cc': ['--coverage'],
+        'ldflags': ['--coverage'],
+      }]
+    ],
   },
   'targets': [
     {


### PR DESCRIPTION
The result looks pretty decent at first blush:

![image](https://github.com/nodejs/node-addon-api/assets/976081/0b9066e3-c7e1-4154-9998-504719cac26f)

AFAICT, this only works on Linux, and doesn't integrate with any online coverage tools.