### PR TITLE
Expose version property in public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { version } = require('./package.json');
 
 const includeDir = path.relative('.', __dirname);
 
@@ -7,6 +8,7 @@ module.exports = {
   include_dir: includeDir,
   gyp: path.join(includeDir, 'node_api.gyp:nothing'), // deprecated.
   targets: path.join(includeDir, 'node_addon_api.gyp'),
+  version,
   isNodeApiBuiltin: true,
   needsFlag: false
 };

--- a/package.json
+++ b/package.json
@@ -431,7 +431,8 @@
     "fs-extra": "^11.1.1",
     "path": "^0.12.7",
     "pre-commit": "^1.2.2",
-    "safe-buffer": "^5.1.1"
+    "safe-buffer": "^5.1.1",
+    "semver": "^7.6.0"
   },
   "directories": {},
   "gypfile": false,

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { strictEqual } = require('assert');
+const { valid } = require('semver');
+
+const nodeAddonApi = require('../');
+
+module.exports = function test () {
+  strictEqual(nodeAddonApi.include.startsWith('"'), true);
+  strictEqual(nodeAddonApi.include.endsWith('"'), true);
+  strictEqual(nodeAddonApi.include.includes('node-addon-api'), true);
+  strictEqual(nodeAddonApi.include_dir, '');
+  strictEqual(nodeAddonApi.gyp, 'node_api.gyp:nothing');
+  strictEqual(nodeAddonApi.targets, 'node_addon_api.gyp');
+  strictEqual(valid(nodeAddonApi.version), true);
+  strictEqual(nodeAddonApi.version, require('../package.json').version);
+  strictEqual(nodeAddonApi.isNodeApiBuiltin, true);
+  strictEqual(nodeAddonApi.needsFlag, false);
+};

--- a/tools/conversion.js
+++ b/tools/conversion.js
@@ -12,7 +12,7 @@ if (!dir) {
   process.exit(1);
 }
 
-const NodeApiVersion = require('../package.json').version;
+const NodeApiVersion = require('../').version;
 
 const disable = args[1];
 let ConfigFileOperations;


### PR DESCRIPTION
This PR contains a proposal to expose the package `version` property in the public API.

The `version` value is already used by the conversion tooling and is additionally useful in external contexts too, for example when specifying/detecting `node-addon-api` as an optional and/or peer dependency.

This would bring `node-addon-api` in line with `node-gyp`, which already exports `require('node-gyp').version`. The change in the PR will allow me to improve the install-time detecting/logging for `node-addon-api` within `sharp`.

It also adds a test with expectations for this property as well as all existing exported properties.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
