### PR TITLE
fix compilation for Visual Studio 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,14 @@
 # ignore node-gyp generated files outside its build directory
 /test/*.Makefile
 /test/*.mk
+
+# ignore node-gyp generated Visual Studio files
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.vsidx
+*.sln
+*.suo
+/test/.vs/
+/test/Release/
+/test/Debug/

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2988,10 +2988,9 @@ inline Object Error::Value() const {
   return Object(_env, refValue);
 }
 
-inline Error::Error(Error&& other) NAPI_NOEXCEPT
-    : ObjectReference(std::move(other)) {}
+inline Error::Error(Error&& other) : ObjectReference(std::move(other)) {}
 
-inline Error& Error::operator=(Error&& other) NAPI_NOEXCEPT {
+inline Error& Error::operator=(Error&& other) {
   static_cast<Reference<Object>*>(this)->operator=(std::move(other));
   return *this;
 }
@@ -3200,7 +3199,7 @@ inline Reference<T>::~Reference() {
 }
 
 template <typename T>
-inline Reference<T>::Reference(Reference<T>&& other) NAPI_NOEXCEPT
+inline Reference<T>::Reference(Reference<T>&& other)
     : _env(other._env),
       _ref(other._ref),
       _suppressDestruct(other._suppressDestruct) {
@@ -3210,8 +3209,7 @@ inline Reference<T>::Reference(Reference<T>&& other) NAPI_NOEXCEPT
 }
 
 template <typename T>
-inline Reference<T>& Reference<T>::operator=(Reference<T>&& other)
-    NAPI_NOEXCEPT {
+inline Reference<T>& Reference<T>::operator=(Reference<T>&& other) {
   Reset();
   _env = other._env;
   _ref = other._ref;
@@ -3361,11 +3359,10 @@ inline ObjectReference& ObjectReference::operator=(Reference<Object>&& other) {
   return *this;
 }
 
-inline ObjectReference::ObjectReference(ObjectReference&& other) NAPI_NOEXCEPT
+inline ObjectReference::ObjectReference(ObjectReference&& other)
     : Reference<Object>(std::move(other)) {}
 
-inline ObjectReference& ObjectReference::operator=(ObjectReference&& other)
-    NAPI_NOEXCEPT {
+inline ObjectReference& ObjectReference::operator=(ObjectReference&& other) {
   static_cast<Reference<Object>*>(this)->operator=(std::move(other));
   return *this;
 }
@@ -3529,19 +3526,19 @@ inline FunctionReference::FunctionReference(napi_env env, napi_ref ref)
     : Reference<Function>(env, ref) {}
 
 inline FunctionReference::FunctionReference(Reference<Function>&& other)
-    NAPI_NOEXCEPT : Reference<Function>(std::move(other)) {}
+    : Reference<Function>(std::move(other)) {}
 
 inline FunctionReference& FunctionReference::operator=(
-    Reference<Function>&& other) NAPI_NOEXCEPT {
+    Reference<Function>&& other) {
   static_cast<Reference<Function>*>(this)->operator=(std::move(other));
   return *this;
 }
 
 inline FunctionReference::FunctionReference(FunctionReference&& other)
-    NAPI_NOEXCEPT : Reference<Function>(std::move(other)) {}
+    : Reference<Function>(std::move(other)) {}
 
 inline FunctionReference& FunctionReference::operator=(
-    FunctionReference&& other) NAPI_NOEXCEPT {
+    FunctionReference&& other) {
   static_cast<Reference<Function>*>(this)->operator=(std::move(other));
   return *this;
 }
@@ -5020,15 +5017,14 @@ inline AsyncContext::~AsyncContext() {
   }
 }
 
-inline AsyncContext::AsyncContext(AsyncContext&& other) NAPI_NOEXCEPT {
+inline AsyncContext::AsyncContext(AsyncContext&& other) {
   _env = other._env;
   other._env = nullptr;
   _context = other._context;
   other._context = nullptr;
 }
 
-inline AsyncContext& AsyncContext::operator=(AsyncContext&& other)
-    NAPI_NOEXCEPT {
+inline AsyncContext& AsyncContext::operator=(AsyncContext&& other) {
   _env = other._env;
   other._env = nullptr;
   _context = other._context;

--- a/napi.h
+++ b/napi.h
@@ -1268,7 +1268,7 @@ class TypedArrayOf : public TypedArray {
       napi_typedarray_type type =
           TypedArray::TypedArrayTypeForPrimitiveType<T>()
 #else
-        napi_typedarray_type type
+      napi_typedarray_type type
 #endif
       ///< Type of array, if different from the default array type for the
       ///< template parameter T.
@@ -1291,7 +1291,7 @@ class TypedArrayOf : public TypedArray {
       napi_typedarray_type type =
           TypedArray::TypedArrayTypeForPrimitiveType<T>()
 #else
-        napi_typedarray_type type
+      napi_typedarray_type type
 #endif
       ///< Type of array, if different from the default array type for the
       ///< template parameter T.
@@ -1381,8 +1381,8 @@ class DataView : public Object {
   template <typename T>
   void WriteData(size_t byteOffset, T value) const;
 
-  void* _data;
-  size_t _length;
+  void* _data{};
+  size_t _length{};
 };
 
 class Function : public Object {
@@ -1554,8 +1554,8 @@ class Reference {
   ~Reference();
 
   // A reference can be moved but cannot be copied.
-  Reference(Reference<T>&& other);
-  Reference<T>& operator=(Reference<T>&& other);
+  Reference(Reference<T>&& other) NAPI_NOEXCEPT;
+  Reference<T>& operator=(Reference<T>&& other) NAPI_NOEXCEPT;
   NAPI_DISALLOW_ASSIGN(Reference<T>)
 
   operator napi_ref() const;
@@ -1601,8 +1601,8 @@ class ObjectReference : public Reference<Object> {
   // A reference can be moved but cannot be copied.
   ObjectReference(Reference<Object>&& other);
   ObjectReference& operator=(Reference<Object>&& other);
-  ObjectReference(ObjectReference&& other);
-  ObjectReference& operator=(ObjectReference&& other);
+  ObjectReference(ObjectReference&& other) NAPI_NOEXCEPT;
+  ObjectReference& operator=(ObjectReference&& other) NAPI_NOEXCEPT;
   NAPI_DISALLOW_ASSIGN(ObjectReference)
 
   MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
@@ -1637,10 +1637,10 @@ class FunctionReference : public Reference<Function> {
   FunctionReference(napi_env env, napi_ref ref);
 
   // A reference can be moved but cannot be copied.
-  FunctionReference(Reference<Function>&& other);
-  FunctionReference& operator=(Reference<Function>&& other);
-  FunctionReference(FunctionReference&& other);
-  FunctionReference& operator=(FunctionReference&& other);
+  FunctionReference(Reference<Function>&& other) NAPI_NOEXCEPT;
+  FunctionReference& operator=(Reference<Function>&& other) NAPI_NOEXCEPT;
+  FunctionReference(FunctionReference&& other) NAPI_NOEXCEPT;
+  FunctionReference& operator=(FunctionReference&& other) NAPI_NOEXCEPT;
   NAPI_DISALLOW_ASSIGN_COPY(FunctionReference)
 
   MaybeOrValue<Napi::Value> operator()(
@@ -1715,7 +1715,7 @@ FunctionReference Persistent(Function value);
 ///
 /// Following C++ statements will not be executed. The exception will bubble
 /// up as a C++ exception of type `Napi::Error`, until it is either caught
-/// while still in C++, or else automatically propataged as a JavaScript
+/// while still in C++, or else automatically propagated as a JavaScript
 /// exception when the callback returns to JavaScript.
 ///
 /// #### Example 2A - Propagating a Node-API C++ exception:
@@ -1801,8 +1801,8 @@ class Error : public ObjectReference
   Error(napi_env env, napi_value value);
 
   // An error can be moved or copied.
-  Error(Error&& other);
-  Error& operator=(Error&& other);
+  Error(Error&& other) NAPI_NOEXCEPT;
+  Error& operator=(Error&& other) NAPI_NOEXCEPT;
   Error(const Error&);
   Error& operator=(const Error&);
 
@@ -1888,7 +1888,7 @@ class CallbackInfo {
   napi_value _this;
   size_t _argc;
   napi_value* _argv;
-  napi_value _staticArgs[6];
+  napi_value _staticArgs[6]{};
   napi_value* _dynamicArgs;
   void* _data;
 };
@@ -2507,8 +2507,8 @@ class AsyncContext {
                         const Object& resource);
   virtual ~AsyncContext();
 
-  AsyncContext(AsyncContext&& other);
-  AsyncContext& operator=(AsyncContext&& other);
+  AsyncContext(AsyncContext&& other) NAPI_NOEXCEPT;
+  AsyncContext& operator=(AsyncContext&& other) NAPI_NOEXCEPT;
   NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
 
   operator napi_async_context() const;

--- a/napi.h
+++ b/napi.h
@@ -1554,8 +1554,8 @@ class Reference {
   ~Reference();
 
   // A reference can be moved but cannot be copied.
-  Reference(Reference<T>&& other) NAPI_NOEXCEPT;
-  Reference<T>& operator=(Reference<T>&& other) NAPI_NOEXCEPT;
+  Reference(Reference<T>&& other);
+  Reference<T>& operator=(Reference<T>&& other);
   NAPI_DISALLOW_ASSIGN(Reference<T>)
 
   operator napi_ref() const;
@@ -1601,8 +1601,8 @@ class ObjectReference : public Reference<Object> {
   // A reference can be moved but cannot be copied.
   ObjectReference(Reference<Object>&& other);
   ObjectReference& operator=(Reference<Object>&& other);
-  ObjectReference(ObjectReference&& other) NAPI_NOEXCEPT;
-  ObjectReference& operator=(ObjectReference&& other) NAPI_NOEXCEPT;
+  ObjectReference(ObjectReference&& other);
+  ObjectReference& operator=(ObjectReference&& other);
   NAPI_DISALLOW_ASSIGN(ObjectReference)
 
   MaybeOrValue<Napi::Value> Get(const char* utf8name) const;
@@ -1637,10 +1637,10 @@ class FunctionReference : public Reference<Function> {
   FunctionReference(napi_env env, napi_ref ref);
 
   // A reference can be moved but cannot be copied.
-  FunctionReference(Reference<Function>&& other) NAPI_NOEXCEPT;
-  FunctionReference& operator=(Reference<Function>&& other) NAPI_NOEXCEPT;
-  FunctionReference(FunctionReference&& other) NAPI_NOEXCEPT;
-  FunctionReference& operator=(FunctionReference&& other) NAPI_NOEXCEPT;
+  FunctionReference(Reference<Function>&& other);
+  FunctionReference& operator=(Reference<Function>&& other);
+  FunctionReference(FunctionReference&& other);
+  FunctionReference& operator=(FunctionReference&& other);
   NAPI_DISALLOW_ASSIGN_COPY(FunctionReference)
 
   MaybeOrValue<Napi::Value> operator()(
@@ -1801,8 +1801,8 @@ class Error : public ObjectReference
   Error(napi_env env, napi_value value);
 
   // An error can be moved or copied.
-  Error(Error&& other) NAPI_NOEXCEPT;
-  Error& operator=(Error&& other) NAPI_NOEXCEPT;
+  Error(Error&& other);
+  Error& operator=(Error&& other);
   Error(const Error&);
   Error& operator=(const Error&);
 
@@ -2507,8 +2507,8 @@ class AsyncContext {
                         const Object& resource);
   virtual ~AsyncContext();
 
-  AsyncContext(AsyncContext&& other) NAPI_NOEXCEPT;
-  AsyncContext& operator=(AsyncContext&& other) NAPI_NOEXCEPT;
+  AsyncContext(AsyncContext&& other);
+  AsyncContext& operator=(AsyncContext&& other);
   NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
 
   operator napi_async_context() const;


### PR DESCRIPTION
Fix PR fixes compilation errors and warnings while compiling code in VS 2022.
- async_worker.cc used deprecated `std::allocator` APIs. Their use is is replaced with APIs that is still valid.
- There was a strange error in `ObjectWrap<T>::WrappedMethod`. It was saying that `&` operation requires an l-value. The issue is fixed by copying `method` pointer to a local variable before invocation.
- VS identified that some fields were not initialized. They are changed to initialize with `{}`.
- VS identified that some functions must be `noexcept`. They are augmented with `NAPI_NOEXCEPT`.
