### PR TITLE
chore: fix release-please config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: node
+          config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
   npm-publish:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,3 @@
 {
-  "pull-request-title-pattern": "chore: release v${version}",
-  "extra-files": [
-    "README.md"
-  ]
+  ".": "8.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "pull-request-title-pattern": "chore: release v${version}",
+  "bootstrap-sha": "d1ba547e91b192152bfc314ab85436de1538b4ec",
+  "packages": {
+    ".": {
+      "extra-files": [
+        "README.md"
+      ],
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
Fix release-please config since googleapis/release-please-action ignores config file when `release-type` present in the action input.

Refs: https://github.com/googleapis/release-please-action/blob/7987652d64b4581673a76e33ad5e98e3dd56832f/src/index.ts#L86

Example PR: https://github.com/legendecas/node-addon-api/pull/11

