### PR TITLE
chore: do not include component name in tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,10 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "pull-request-title-pattern": "chore: release v${version}",
-  "bootstrap-sha": "d1ba547e91b192152bfc314ab85436de1538b4ec",
+  "bootstrap-sha": "bc5acef9dd5298cbbcabd5c01c9590ada683951d",
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "extra-files": [
         "README.md"
       ],


### PR DESCRIPTION
By default release-please creates a tag with component names: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#subsequent-versions

There is only one component in the repo so there is no need to include component name in tag name.

Refs: https://github.com/nodejs/node-addon-api/releases/tag/node-addon-api-v8.1.0