### PR TITLE
chore: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: weekly
     groups:
       all:
-        patterns: '*'
+        patterns:
+        - '*'
 
   - package-ecosystem: npm
     directory: /
@@ -14,7 +15,8 @@ updates:
       interval: weekly
     groups:
       all:
-        patterns: '*'
+        patterns:
+        - '*'
 
   - package-ecosystem: npm
     directory: /test/addon_build/tpl
@@ -22,4 +24,5 @@ updates:
       interval: weekly
     groups:
       all:
-        patterns: '*'
+        patterns:
+        - '*'


### PR DESCRIPTION
https://github.com/nodejs/node-addon-api/network/updates reports that the config file contains errors:

```
The property '#/updates/0/groups/all/patterns' of type string did not match the following type: array
The property '#/updates/1/groups/all/patterns' of type string did not match the following type: array
The property '#/updates/2/groups/all/patterns' of type string did not match the following type: array
```