### PR TITLE
feat: allow catching all exceptions

### DIFF
--- a/doc/cmake-js.md
+++ b/doc/cmake-js.md
@@ -45,6 +45,25 @@ The following line in the `CMakeLists.txt` file will enable Node-API experimenta
 add_definitions(-DNAPI_EXPERIMENTAL)
 ```
 
+### Exception Handling
+
+To enable C++ exception handling (for more info see: [Setup](setup.md)), define
+the corresponding preprocessor directives depending on which exception handling
+behavior is desired.
+
+To enable C++ exception handling with `Napi::Error` objects only:
+
+```
+add_definitions(-DNAPI_EXPERIMENTAL)
+```
+
+To enable C++ exception handling for all exceptions thrown:
+
+```
+add_definitions(-DNODE_ADDON_API_CPP_EXCEPTIONS)
+add_definitions(-DNODE_ADDON_API_CPP_EXCEPTIONS_ALL)
+```
+
 ### node-addon-api
 
 If your Node-API native add-on uses the optional [**node-addon-api**](https://github.com/nodejs/node-addon-api#node-addon-api-module) C++ wrapper, the `CMakeLists.txt` file requires additional configuration information as described on the [CMake.js README file](https://github.com/cmake-js/cmake-js#node-api-and-node-addon-api).

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -48,6 +48,18 @@ method.
 If a C++ exception of type `Napi::Error` escapes from a Node-API C++ callback, then
 the Node-API wrapper automatically converts and throws it as a JavaScript exception.
 
+If other types of C++ exceptions are thrown, node-addon-api will either abort
+the process or wrap the exception in an `Napi::Error` in order to throw it as a
+JavaScript exception. This behavior is determined by which node-gyp dependency
+used:
+
+- When using the `node_addon_api_except` dependency, only `Napi::Error` objects
+  will be handled.
+- When using the `node_addon_api_except_all` dependency, all exceptions will be
+handled. For exceptions derived from `std::exception`, an `Napi::Error` will be
+created with the message of the exception's `what()` member function. For all
+other exceptions, an `Napi::Error` will be created with a generic error message.
+
 On return from a native method, node-addon-api will automatically convert a pending
 `Napi::Error` C++ exception to a JavaScript exception.
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -38,11 +38,23 @@ To use **Node-API** in a native module:
        ],
      ```
 
-     To enable that capability, add an alternative dependency in `binding.gyp`:
+     To enable that capability, add an alternative dependency in `binding.gyp`
+     depending on if you want to integrate C++ exception handling for exceptions
+     derived from `Napi::Error` or all C++ exceptions. To catch only
+     `Napi::Error` exceptions, use:
 
      ```gyp
        'dependencies': [
          "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+       ],
+     ```
+
+     Or, to allow catching all native C++ exceptions, use the
+     `node_addon_api_except_all` dependency:
+
+     ```gyp
+       'dependencies': [
+         "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except_all",
        ],
      ```
 

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -150,8 +150,9 @@ inline void WrapVoidCallback(napi_env, Callable callback) {
   }
 #endif  // NODE_ADDON_API_CPP_EXCEPTIONS_ALL
 #else
-  // When C++ exceptions are disabled, errors are immediately thrown as JS
-  // exceptions, so there is no need to catch and rethrow them here.
+  // When C++ exceptions are disabled, there is no need to catch and rethrow C++
+  // exceptions. JS errors should be thrown with
+  // `Error::ThrowAsJavaScriptException`.
   callback();
 #endif  // NODE_ADDON_API_CPP_EXCEPTIONS
 }

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -79,19 +79,33 @@ inline napi_status AttachData(napi_env env,
 // For use in JS to C++ callback wrappers to catch any Napi::Error exceptions
 // and rethrow them as JavaScript exceptions before returning from the callback.
 template <typename Callable>
-inline napi_value WrapCallback(Callable callback) {
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+inline napi_value WrapCallback(napi_env env, Callable callback) {
+#else
+inline napi_value WrapCallback(napi_env, Callable callback) {
+#endif
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
   try {
     return callback();
   } catch (const Error& e) {
     e.ThrowAsJavaScriptException();
     return nullptr;
   }
-#else   // NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+  catch (const std::exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+    return nullptr;
+  } catch (...) {
+    Napi::Error::New(env, "A native exception was thrown")
+        .ThrowAsJavaScriptException();
+    return nullptr;
+  }
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+#else   // NODE_ADDON_API_CPP_EXCEPTIONS
   // When C++ exceptions are disabled, errors are immediately thrown as JS
   // exceptions, so there is no need to catch and rethrow them here.
   return callback();
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
 }
 
 // For use in JS to C++ void callback wrappers to catch any Napi::Error
@@ -99,7 +113,7 @@ inline napi_value WrapCallback(Callable callback) {
 // the callback.
 template <typename Callable>
 inline void WrapVoidCallback(Callable callback) {
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
   try {
     callback();
   } catch (const Error& e) {
@@ -112,10 +126,40 @@ inline void WrapVoidCallback(Callable callback) {
 #endif  // NAPI_CPP_EXCEPTIONS
 }
 
+// For use in JS to C++ void callback wrappers to catch _any_ thrown exception
+// and rethrow them as JavaScript exceptions before returning from the callback,
+// wrapping in an Napi::Error as needed.
+template <typename Callable>
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+inline void WrapVoidCallback(napi_env env, Callable callback) {
+#else
+inline void WrapVoidCallback(napi_env, Callable callback) {
+#endif
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
+  try {
+    callback();
+  } catch (const Error& e) {
+    e.ThrowAsJavaScriptException();
+  }
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+  catch (const std::exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+  } catch (...) {
+    Napi::Error::New(env, "A native exception was thrown")
+        .ThrowAsJavaScriptException();
+  }
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS_ALL
+#else
+  // When C++ exceptions are disabled, errors are immediately thrown as JS
+  // exceptions, so there is no need to catch and rethrow them here.
+  callback();
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
+}
+
 template <typename Callable, typename Return>
 struct CallbackData {
   static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
-    return details::WrapCallback([&] {
+    return details::WrapCallback(env, [&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
           static_cast<CallbackData*>(callbackInfo.Data());
@@ -131,7 +175,7 @@ struct CallbackData {
 template <typename Callable>
 struct CallbackData<Callable, void> {
   static inline napi_value Wrapper(napi_env env, napi_callback_info info) {
-    return details::WrapCallback([&] {
+    return details::WrapCallback(env, [&] {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
           static_cast<CallbackData*>(callbackInfo.Data());
@@ -148,7 +192,7 @@ struct CallbackData<Callable, void> {
 template <void (*Callback)(const CallbackInfo& info)>
 napi_value TemplatedVoidCallback(napi_env env,
                                  napi_callback_info info) NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo cbInfo(env, info);
     Callback(cbInfo);
     return nullptr;
@@ -158,7 +202,7 @@ napi_value TemplatedVoidCallback(napi_env env,
 template <Napi::Value (*Callback)(const CallbackInfo& info)>
 napi_value TemplatedCallback(napi_env env,
                              napi_callback_info info) NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo cbInfo(env, info);
     // MSVC requires to copy 'Callback' function pointer to a local variable
     // before invoking it.
@@ -171,7 +215,7 @@ template <typename T,
           Napi::Value (T::*UnwrapCallback)(const CallbackInfo& info)>
 napi_value TemplatedInstanceCallback(napi_env env,
                                      napi_callback_info info) NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
     return instance ? (instance->*UnwrapCallback)(cbInfo) : Napi::Value();
@@ -181,7 +225,7 @@ napi_value TemplatedInstanceCallback(napi_env env,
 template <typename T, void (T::*UnwrapCallback)(const CallbackInfo& info)>
 napi_value TemplatedInstanceVoidCallback(napi_env env, napi_callback_info info)
     NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
     if (instance) (instance->*UnwrapCallback)(cbInfo);
@@ -264,7 +308,7 @@ struct FinalizeData {
   static inline void WrapperGCWithoutData(napi_env env,
                                           void* /*data*/,
                                           void* finalizeHint) NAPI_NOEXCEPT {
-    WrapVoidCallback([&] {
+    WrapVoidCallback(env, [&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(env);
       delete finalizeData;
@@ -274,7 +318,7 @@ struct FinalizeData {
   static inline void WrapperGC(napi_env env,
                                void* data,
                                void* finalizeHint) NAPI_NOEXCEPT {
-    WrapVoidCallback([&] {
+    WrapVoidCallback(env, [&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(env, static_cast<T*>(data));
       delete finalizeData;
@@ -284,7 +328,7 @@ struct FinalizeData {
   static inline void WrapperGCWithHint(napi_env env,
                                        void* data,
                                        void* finalizeHint) NAPI_NOEXCEPT {
-    WrapVoidCallback([&] {
+    WrapVoidCallback(env, [&] {
       FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
       finalizeData->callback(env, static_cast<T*>(data), finalizeData->hint);
       delete finalizeData;
@@ -351,7 +395,7 @@ struct ThreadSafeFinalize {
 template <typename ContextType, typename DataType, typename CallJs, CallJs call>
 inline typename std::enable_if<call != static_cast<CallJs>(nullptr)>::type
 CallJsWrapper(napi_env env, napi_value jsCallback, void* context, void* data) {
-  details::WrapVoidCallback([&]() {
+  details::WrapVoidCallback(env, [&]() {
     call(env,
          Function(env, jsCallback),
          static_cast<ContextType*>(context),
@@ -365,7 +409,7 @@ CallJsWrapper(napi_env env,
               napi_value jsCallback,
               void* /*context*/,
               void* /*data*/) {
-  details::WrapVoidCallback([&]() {
+  details::WrapVoidCallback(env, [&]() {
     if (jsCallback != nullptr) {
       Function(env, jsCallback).Call(0, nullptr);
     }
@@ -399,7 +443,7 @@ template <typename Getter, typename Setter>
 struct AccessorCallbackData {
   static inline napi_value GetterWrapper(napi_env env,
                                          napi_callback_info info) {
-    return details::WrapCallback([&] {
+    return details::WrapCallback(env, [&] {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
           static_cast<AccessorCallbackData*>(callbackInfo.Data());
@@ -410,7 +454,7 @@ struct AccessorCallbackData {
 
   static inline napi_value SetterWrapper(napi_env env,
                                          napi_callback_info info) {
-    return details::WrapCallback([&] {
+    return details::WrapCallback(env, [&] {
       CallbackInfo callbackInfo(env, info);
       AccessorCallbackData* callbackData =
           static_cast<AccessorCallbackData*>(callbackInfo.Data());
@@ -501,7 +545,7 @@ class HasBasicFinalizer {
 inline napi_value RegisterModule(napi_env env,
                                  napi_value exports,
                                  ModuleRegisterCallback registerCallback) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     return napi_value(
         registerCallback(Napi::Env(env), Napi::Object(env, exports)));
   });
@@ -1808,7 +1852,7 @@ inline void Object::AddFinalizer(Finalizer finalizeCallback,
   }
 }
 
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
 inline Object::const_iterator::const_iterator(const Object* object,
                                               const Type type) {
   _object = object;
@@ -1883,7 +1927,7 @@ Object::iterator::operator*() {
   PropertyLValue<Value> value = (*_object)[key];
   return {key, value};
 }
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
 
 #if NAPI_VERSION >= 8
 inline MaybeOrValue<bool> Object::Freeze() const {
@@ -3159,14 +3203,14 @@ inline Error& Error::operator=(const Error& other) {
 
 inline const std::string& Error::Message() const NAPI_NOEXCEPT {
   if (_message.size() == 0 && _env != nullptr) {
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
     try {
       _message = Get("message").As<String>();
     } catch (...) {
       // Catch all errors here, to include e.g. a std::bad_alloc from
       // the std::string::operator=, because this method may not throw.
     }
-#else  // NAPI_CPP_EXCEPTIONS
+#else  // NODE_ADDON_API_CPP_EXCEPTIONS
 #if defined(NODE_ADDON_API_ENABLE_MAYBE)
     Napi::Value message_val;
     if (Get("message").UnwrapTo(&message_val)) {
@@ -3175,7 +3219,7 @@ inline const std::string& Error::Message() const NAPI_NOEXCEPT {
 #else
     _message = Get("message").As<String>();
 #endif
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
   }
   return _message;
 }
@@ -3222,24 +3266,24 @@ inline void Error::ThrowAsJavaScriptException() const {
     napi_status status = napi_throw(_env, Value());
 #endif
 
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
     if (status != napi_ok) {
       throw Error::New(_env);
     }
-#else   // NAPI_CPP_EXCEPTIONS
+#else   // NODE_ADDON_API_CPP_EXCEPTIONS
     NAPI_FATAL_IF_FAILED(
         status, "Error::ThrowAsJavaScriptException", "napi_throw");
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
   }
 }
 
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
 
 inline const char* Error::what() const NAPI_NOEXCEPT {
   return Message().c_str();
 }
 
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
 
 inline const char* Error::ERROR_WRAP_VALUE() NAPI_NOEXCEPT {
   return "4bda9e7e-4913-4dbc-95de-891cbf66598e-errorVal";
@@ -4508,7 +4552,7 @@ inline ClassPropertyDescriptor<T> InstanceWrap<T>::InstanceValue(
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceVoidMethodCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     InstanceVoidMethodCallbackData* callbackData =
         reinterpret_cast<InstanceVoidMethodCallbackData*>(callbackInfo.Data());
@@ -4523,7 +4567,7 @@ inline napi_value InstanceWrap<T>::InstanceVoidMethodCallbackWrapper(
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceMethodCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     InstanceMethodCallbackData* callbackData =
         reinterpret_cast<InstanceMethodCallbackData*>(callbackInfo.Data());
@@ -4537,7 +4581,7 @@ inline napi_value InstanceWrap<T>::InstanceMethodCallbackWrapper(
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceGetterCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     InstanceAccessorCallbackData* callbackData =
         reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
@@ -4551,7 +4595,7 @@ inline napi_value InstanceWrap<T>::InstanceGetterCallbackWrapper(
 template <typename T>
 inline napi_value InstanceWrap<T>::InstanceSetterCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     InstanceAccessorCallbackData* callbackData =
         reinterpret_cast<InstanceAccessorCallbackData*>(callbackInfo.Data());
@@ -4567,7 +4611,7 @@ template <typename T>
 template <typename InstanceWrap<T>::InstanceSetterCallback method>
 inline napi_value InstanceWrap<T>::WrappedMethod(
     napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     const CallbackInfo cbInfo(env, info);
     T* instance = T::Unwrap(cbInfo.This().As<Object>());
     if (instance) (instance->*method)(cbInfo, cbInfo[0]);
@@ -4962,13 +5006,13 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
   bool isConstructCall = (new_target != nullptr);
   if (!isConstructCall) {
     return details::WrapCallback(
-        [&] { return T::OnCalledAsFunction(CallbackInfo(env, info)); });
+        env, [&] { return T::OnCalledAsFunction(CallbackInfo(env, info)); });
   }
 
-  napi_value wrapper = details::WrapCallback([&] {
+  napi_value wrapper = details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     T* instance = new T(callbackInfo);
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
     instance->_construction_failed = false;
 #else
     if (callbackInfo.Env().IsExceptionPending()) {
@@ -4979,7 +5023,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
     } else {
       instance->_construction_failed = false;
     }
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
     return callbackInfo.This();
   });
 
@@ -4989,7 +5033,7 @@ inline napi_value ObjectWrap<T>::ConstructorCallbackWrapper(
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticVoidMethodCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     StaticVoidMethodCallbackData* callbackData =
         reinterpret_cast<StaticVoidMethodCallbackData*>(callbackInfo.Data());
@@ -5002,7 +5046,7 @@ inline napi_value ObjectWrap<T>::StaticVoidMethodCallbackWrapper(
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticMethodCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     StaticMethodCallbackData* callbackData =
         reinterpret_cast<StaticMethodCallbackData*>(callbackInfo.Data());
@@ -5014,7 +5058,7 @@ inline napi_value ObjectWrap<T>::StaticMethodCallbackWrapper(
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticGetterCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     StaticAccessorCallbackData* callbackData =
         reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
@@ -5026,7 +5070,7 @@ inline napi_value ObjectWrap<T>::StaticGetterCallbackWrapper(
 template <typename T>
 inline napi_value ObjectWrap<T>::StaticSetterCallbackWrapper(
     napi_env env, napi_callback_info info) {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     CallbackInfo callbackInfo(env, info);
     StaticAccessorCallbackData* callbackData =
         reinterpret_cast<StaticAccessorCallbackData*>(callbackInfo.Data());
@@ -5101,7 +5145,7 @@ template <typename T>
 template <typename ObjectWrap<T>::StaticSetterCallback method>
 inline napi_value ObjectWrap<T>::WrappedMethod(
     napi_env env, napi_callback_info info) NAPI_NOEXCEPT {
-  return details::WrapCallback([&] {
+  return details::WrapCallback(env, [&] {
     const CallbackInfo cbInfo(env, info);
     // MSVC requires to copy 'method' function pointer to a local variable
     // before invoking it.
@@ -5402,15 +5446,15 @@ inline void AsyncWorker::OnAsyncWorkExecute(napi_env env, void* asyncworker) {
 // must not run any method that would cause JavaScript to run. In practice,
 // this means that almost any use of napi_env will be incorrect.
 inline void AsyncWorker::OnExecute(Napi::Env /*DO_NOT_USE*/) {
-#ifdef NAPI_CPP_EXCEPTIONS
+#ifdef NODE_ADDON_API_CPP_EXCEPTIONS
   try {
     Execute();
   } catch (const std::exception& e) {
     SetError(e.what());
   }
-#else   // NAPI_CPP_EXCEPTIONS
+#else   // NODE_ADDON_API_CPP_EXCEPTIONS
   Execute();
-#endif  // NAPI_CPP_EXCEPTIONS
+#endif  // NODE_ADDON_API_CPP_EXCEPTIONS
 }
 
 inline void AsyncWorker::OnAsyncWorkComplete(napi_env env,
@@ -5419,10 +5463,10 @@ inline void AsyncWorker::OnAsyncWorkComplete(napi_env env,
   AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
   self->OnWorkComplete(env, status);
 }
-inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
+inline void AsyncWorker::OnWorkComplete(Napi::Env env, napi_status status) {
   if (status != napi_cancelled) {
     HandleScope scope(_env);
-    details::WrapCallback([&] {
+    details::WrapCallback(env, [&] {
       if (_error.size() == 0) {
         OnOK();
       } else {
@@ -6334,7 +6378,7 @@ inline void ThreadSafeFunction::CallJS(napi_env env,
     return;
   }
 
-  details::WrapVoidCallback([&]() {
+  details::WrapVoidCallback(env, [&]() {
     if (data != nullptr) {
       auto* callbackWrapper = static_cast<CallbackWrapper*>(data);
       (*callbackWrapper)(env, Function(env, jsCallback));

--- a/node_addon_api.gyp
+++ b/node_addon_api.gyp
@@ -19,6 +19,16 @@
       }
     },
     {
+      'target_name': 'node_addon_api_except_all',
+      'type': 'none',
+      'sources': [ 'napi.h', 'napi-inl.h' ],
+      'direct_dependent_settings': {
+        'include_dirs': [ '.' ],
+        'includes': ['except.gypi'],
+        'defines': [ 'NODE_ADDON_API_CPP_EXCEPTIONS_ALL' ]
+      }
+    },
+    {
       'target_name': 'node_addon_api_maybe',
       'type': 'none',
       'sources': [ 'napi.h', 'napi-inl.h' ],

--- a/noexcept.gypi
+++ b/noexcept.gypi
@@ -1,5 +1,5 @@
 {
-  'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+  'defines': [ 'NODE_ADDON_API_DISABLE_CPP_EXCEPTIONS' ],
   'cflags': [ '-fno-exceptions' ],
   'cflags_cc': [ '-fno-exceptions' ],
   'conditions': [

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -85,6 +85,9 @@
         'binding-swallowexcept.cc',
         'error.cc',
       ],
+      'build_sources_except_all': [
+        'except_all.cc',
+      ],
       'build_sources_type_check': [
         'value_type_cast.cc'
       ],
@@ -113,6 +116,11 @@
       'dependencies': ['../node_addon_api.gyp:node_addon_api_except'],
       'sources': ['>@(build_sources)'],
       'defines': ['NODE_ADDON_API_ENABLE_TYPE_CHECK_ON_AS']
+    },
+    {
+      'target_name': 'binding_except_all',
+      'dependencies': ['../node_addon_api.gyp:node_addon_api_except_all'],
+      'sources': [ '>@(build_sources_except_all)']
     },
     {
       'target_name': 'binding_noexcept',

--- a/test/except_all.cc
+++ b/test/except_all.cc
@@ -1,0 +1,21 @@
+#include "napi.h"
+
+using namespace Napi;
+
+void ThrowStdException(const CallbackInfo& info) {
+  std::string message = info[0].As<String>().Utf8Value();
+  throw std::runtime_error(message);
+}
+
+void ThrowPrimitiveException(const CallbackInfo&) {
+  throw 0;
+}
+
+Object Init(Env env, Object exports) {
+  exports.Set("throwStdException", Napi::Function::New(env, ThrowStdException));
+  exports.Set("throwPrimitiveException",
+              Napi::Function::New(env, ThrowPrimitiveException));
+  return exports;
+}
+
+NODE_API_MODULE(addon, Init)

--- a/test/except_all.js
+++ b/test/except_all.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = require('./common').runTestWithBuildType(test);
+
+function test (buildType) {
+  const binding = require(`./build/${buildType}/binding_except_all.node`);
+
+  const message = 'error message';
+  assert.throws(binding.throwStdException.bind(undefined, message), { message });
+
+  assert.throws(binding.throwPrimitiveException.bind(undefined), { message: 'A native exception was thrown' });
+}


### PR DESCRIPTION
Add new compile-time define (`NODE_ADDON_API_CPP_EXCEPTIONS_ALL`)  to enable catching all exceptions. This must be used _in conjunction with_ `NODE_ADDON_API_CPP_EXCEPTIONS`.

Rename the `NAPI_` prefixed exception preprocessor definitions (`NAPI_CPP_EXCEPTIONS` and `NAPI_DISABLE_CPP_EXCEPTIONS`) to be prefixed with our standard `NODE_ADDON_API_` prefix in a backwards-compatible way.

Fixes: #1555 