### PR TITLE
fix: mark external memory and version APIs as basic

### DIFF
--- a/doc/memory_management.md
+++ b/doc/memory_management.md
@@ -17,7 +17,7 @@ more often than it would otherwise in an attempt to garbage collect the JavaScri
 objects that keep the externally allocated memory alive.
 
 ```cpp
-static int64_t Napi::MemoryManagement::AdjustExternalMemory(Napi::Env env, int64_t change_in_bytes);
+static int64_t Napi::MemoryManagement::AdjustExternalMemory(Napi::BasicEnv env, int64_t change_in_bytes);
 ```
 
 - `[in] env`: The environment in which the API is invoked under.

--- a/doc/version_management.md
+++ b/doc/version_management.md
@@ -11,7 +11,7 @@ important to make decisions based on different versions of the system.
 Retrieves the highest Node-API version supported by Node.js runtime.
 
 ```cpp
-static uint32_t Napi::VersionManagement::GetNapiVersion(Env env);
+static uint32_t Napi::VersionManagement::GetNapiVersion(Napi::BasicEnv env);
 ```
 
 - `[in] env`: The environment in which the API is invoked under.
@@ -34,7 +34,7 @@ typedef struct {
 ````
 
 ```cpp
-static const napi_node_version* Napi::VersionManagement::GetNodeVersion(Env env);
+static const napi_node_version* Napi::VersionManagement::GetNodeVersion(Napi::BasicEnv env);
 ```
 
 - `[in] env`: The environment in which the API is invoked under.

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -6699,12 +6699,14 @@ inline void AsyncProgressQueueWorker<T>::ExecutionProgress::Send(
 // Memory Management class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline int64_t MemoryManagement::AdjustExternalMemory(Env env,
+inline int64_t MemoryManagement::AdjustExternalMemory(BasicEnv env,
                                                       int64_t change_in_bytes) {
   int64_t result;
   napi_status status =
       napi_adjust_external_memory(env, change_in_bytes, &result);
-  NAPI_THROW_IF_FAILED(env, status, 0);
+  NAPI_FATAL_IF_FAILED(status,
+                       "MemoryManagement::AdjustExternalMemory",
+                       "napi_adjust_external_memory");
   return result;
 }
 
@@ -6712,17 +6714,20 @@ inline int64_t MemoryManagement::AdjustExternalMemory(Env env,
 // Version Management class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline uint32_t VersionManagement::GetNapiVersion(Env env) {
+inline uint32_t VersionManagement::GetNapiVersion(BasicEnv env) {
   uint32_t result;
   napi_status status = napi_get_version(env, &result);
-  NAPI_THROW_IF_FAILED(env, status, 0);
+  NAPI_FATAL_IF_FAILED(
+      status, "VersionManagement::GetNapiVersion", "napi_get_version");
   return result;
 }
 
-inline const napi_node_version* VersionManagement::GetNodeVersion(Env env) {
+inline const napi_node_version* VersionManagement::GetNodeVersion(
+    BasicEnv env) {
   const napi_node_version* result;
   napi_status status = napi_get_node_version(env, &result);
-  NAPI_THROW_IF_FAILED(env, status, 0);
+  NAPI_FATAL_IF_FAILED(
+      status, "VersionManagement::GetNodeVersion", "napi_get_node_version");
   return result;
 }
 

--- a/napi.h
+++ b/napi.h
@@ -3234,14 +3234,14 @@ class AsyncProgressQueueWorker
 // Memory management.
 class MemoryManagement {
  public:
-  static int64_t AdjustExternalMemory(Env env, int64_t change_in_bytes);
+  static int64_t AdjustExternalMemory(BasicEnv env, int64_t change_in_bytes);
 };
 
 // Version management
 class VersionManagement {
  public:
-  static uint32_t GetNapiVersion(Env env);
-  static const napi_node_version* GetNodeVersion(Env env);
+  static uint32_t GetNapiVersion(BasicEnv env);
+  static const napi_node_version* GetNodeVersion(BasicEnv env);
 };
 
 #if NAPI_VERSION > 5


### PR DESCRIPTION
Fixes https://github.com/nodejs/node-addon-api/issues/1594