### PR TITLE
suppress sanitizer for static cast with undefined behavior

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4576,17 +4576,18 @@ inline napi_value InstanceWrap<T>::WrappedMethod(
 ////////////////////////////////////////////////////////////////////////////////
 // ObjectWrap<T> class
 ////////////////////////////////////////////////////////////////////////////////
-
 template <typename T>
-inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
+inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo)
+    __attribute__((no_sanitize("vptr"))) {
   napi_env env = callbackInfo.Env();
   napi_value wrapper = callbackInfo.This();
   napi_status status;
   napi_ref ref;
-  status = napi_wrap(env, wrapper, this, FinalizeCallback, nullptr, &ref);
+  T* instance = static_cast<T*>(this);
+  status = napi_wrap(env, wrapper, instance, FinalizeCallback, nullptr, &ref);
   NAPI_THROW_IF_FAILED_VOID(env, status);
 
-  Reference<Object>* instanceRef = this;
+  Reference<Object>* instanceRef = instance;
   *instanceRef = Reference<Object>(env, ref);
 }
 

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -4583,11 +4583,10 @@ inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
   napi_value wrapper = callbackInfo.This();
   napi_status status;
   napi_ref ref;
-  T* instance = static_cast<T*>(this);
-  status = napi_wrap(env, wrapper, instance, FinalizeCallback, nullptr, &ref);
+  status = napi_wrap(env, wrapper, this, FinalizeCallback, nullptr, &ref);
   NAPI_THROW_IF_FAILED_VOID(env, status);
 
-  Reference<Object>* instanceRef = instance;
+  Reference<Object>* instanceRef = this;
   *instanceRef = Reference<Object>(env, ref);
 }
 


### PR DESCRIPTION
This undefined behavior was detected with UBSAN. Down casting to a derived type from the base class constructor is undefined behavior 

Introduced in #732

```c++
/root/Source/node_modules/node-addon-api/napi-inl.h:4429:17: runtime error: downcast of address 0x506000060200 which does not point to an object of type 'CustomObject'
0x506000060200: note: object is of type 'Napi::ObjectWrap<CustomObject>'
 00 00 00 00  28 78 5e 04 4f 7f 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 01 be be
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Napi::ObjectWrap<CustomObject>'
    #0 0x7f4f042894c4 in Napi::ObjectWrap<CustomObject>::ObjectWrap(Napi::CallbackInfo const&) (/root/Source/ninja/install/libAddon.node+0x4ca4c4) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #1 0x7f4f040ef0a2 in CustomObject::CustomObject(Napi::CallbackInfo const&) (/root/Source/ninja/install/libAddon.node+0x3300a2) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #2 0x7f4f043c87ed in Napi::ObjectWrap<CustomObject>::ConstructorCallbackWrapper(napi_env__*, napi_callback_info__*)::'lambda0'()::operator()() const (/root/Source/ninja/install/libAddon.node+0x6097ed) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #3 0x7f4f043c8514 in napi_value__* Napi::details::WrapCallback<Napi::ObjectWrap<CustomObject>::ConstructorCallbackWrapper(napi_env__*, napi_callback_info__*)::'lambda0'()>(Napi::ObjectWrap<CustomObject>::ConstructorCallbackWrapper(napi_env__*, napi_callback_info__*)::'lambda0'()) (/root/Source/ninja/install/libAddon.node+0x609514) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #4 0x7f4f043c6b84 in Napi::ObjectWrap<CustomObject>::ConstructorCallbackWrapper(napi_env__*, napi_callback_info__*) (/root/Source/ninja/install/libAddon.node+0x607b84) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #5 0x000000c55a68 in v8impl::(anonymous namespace)::FunctionCallbackWrapper::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) js_native_api_v8.cc
    #6 0x000000f5f8fe in v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) (/root/.nvm/versions/node/v20.17.0/bin/node+0xf5f8fe) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #7 0x000000f5feb4 in v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, unsigned long*, int) builtins-api.cc
    #8 0x000000f60954 in v8::internal::Builtins::InvokeApiFunction(v8::internal::Isolate*, bool, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*, v8::internal::Handle<v8::internal::HeapObject>) (/root/.nvm/versions/node/v20.17.0/bin/node+0xf60954) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #9 0x00000105844b in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) execution.cc
    #10 0x000001058f80 in v8::internal::Execution::New(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) (/root/.nvm/versions/node/v20.17.0/bin/node+0x1058f80) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #11 0x000000f187c7 in v8::Function::NewInstanceWithSideEffectType(v8::Local<v8::Context>, int, v8::Local<v8::Value>*, v8::SideEffectType) const (/root/.nvm/versions/node/v20.17.0/bin/node+0xf187c7) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #12 0x000000c627fa in napi_new_instance (/root/.nvm/versions/node/v20.17.0/bin/node+0xc627fa) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #13 0x7f4f043ddca0 in Napi::FunctionReference::New(std::initializer_list<napi_value__*> const&) const (/root/Source/ninja/install/libAddon.node+0x61eca0) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #14 0x7f4f0413ccc1 in GetFlags(Napi::CallbackInfo const&) (/root/Source/ninja/install/libAddon.node+0x37dcc1) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #15 0x7f4f043e5915 in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()::operator()() const (/root/Source/ninja/install/libAddon.node+0x626915) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #16 0x7f4f043e55a4 in napi_value__* Napi::details::WrapCallback<Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()>(Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()) (/root/Source/ninja/install/libAddon.node+0x6265a4) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #17 0x7f4f043e543f in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*) (/root/Source/ninja/install/libAddon.node+0x62643f) (BuildId: 44775edcb6976e14cf8bc470853fc0da5c5632f1)
    #18 0x000000c55a68 in v8impl::(anonymous namespace)::FunctionCallbackWrapper::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) js_native_api_v8.cc
    #19 0x000000f5f8fe in v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) (/root/.nvm/versions/node/v20.17.0/bin/node+0xf5f8fe) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #20 0x000000f6016c in v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, unsigned long*, int) builtins-api.cc
    #21 0x000000f60634 in v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) (/root/.nvm/versions/node/v20.17.0/bin/node+0xf60634) (BuildId: ec9c1cc13f942db3e300931a3a88fa33e22d6713)
    #22 0x00000196adf5 in Builtins_CEntry_Return1_ArgvOnStack_BuiltinExit /home/iojs/build/ws/out/Release/obj.target/v8_snapshot/geni/embedded.o

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /root/Source/node_modules/node-addon-api/napi-inl.h:4429:17 
```
