### PR TITLE
fix: missing napi_delete_reference on ObjectWrap ref

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -2514,6 +2514,7 @@ class ObjectWrap : public InstanceWrap<T>, public Reference<Object> {
   }
 
   bool _construction_failed = true;
+  bool _finalized = false;
 };
 
 class HandleScope {


### PR DESCRIPTION
According to https://nodejs.org/api/n-api.html#napi_wrap, the `napi_reference` returned from `napi_wrap` should be deleted with `napi_delete_reference`. In node-addon-api, for an `ObjectWrap`, this is done with `~Reference` destructor when the `_ref` is not `nullptr`.

To prevent `~ObjectWrap` from creating a handle during finalization, add a new flag to guard on it, instead of nullify `_ref`.

Submitted https://github.com/nodejs/node/pull/55620 to allow `napi_delete_reference` been immediately invoked in an `node_api_basic_finalizer`.

Fixes https://github.com/nodejs/node-addon-api/issues/1602