### PR TITLE
chore: enable tokenless Codecov uploads

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -63,7 +63,6 @@ jobs:
         run: |
           npm run report-coverage-xml
       - name: Upload
-        uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a  # v5.0.2
+        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a  # v5.0.7
         with:
           directory: ./coverage-xml
-          token: ${{ secrets.CODECOV_TOKEN }} # To bypass public API rate limiting, see https://github.com/codecov/codecov-action/issues/557


### PR DESCRIPTION
Refs: https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
