### PR TITLE
Fix incorrect instruction in cmake.js docs

### DIFF
--- a/doc/cmake-js.md
+++ b/doc/cmake-js.md
@@ -54,7 +54,7 @@ behavior is desired.
 To enable C++ exception handling with `Napi::Error` objects only:
 
 ```
-add_definitions(-DNAPI_EXPERIMENTAL)
+add_definitions(-DNODE_ADDON_API_CPP_EXCEPTIONS)
 ```
 
 To enable C++ exception handling for all exceptions thrown:


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-addon-api/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
