### PR TITLE
fix: node-api version 10 support

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3244,7 +3244,7 @@ inline void Error::ThrowAsJavaScriptException() const {
 
       status = napi_throw(_env, Value());
 
-#ifdef NAPI_EXPERIMENTAL
+#if (NAPI_VERSION >= 10)
       napi_status expected_failure_mode = napi_cannot_run_js;
 #else
       napi_status expected_failure_mode = napi_pending_exception;


### PR DESCRIPTION
Fixes https://github.com/nodejs/node-addon-api/issues/1639

This does not add any new version 10 APIs in C++. This fixes a semantic experimental guard with  a version 10 guard.

Refs: https://github.com/nodejs/node/pull/55676