### PR TITLE
chore(ci): update runners, removing windows-2019 and adding windows-2025

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -23,8 +23,8 @@ jobs:
           - 22.x
         architecture: [x64, x86]
         os:
-          - windows-2019
           - windows-2022
+          - windows-2025
     runs-on: ${{ matrix.os }}
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Remove `windows-2019` as it has been removed from GitLab-hosted runners. Example failed [run](https://github.com/nodejs/node-addon-api/actions/runs/15984058040/job/45114874014) shows:

> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

Add the most recent Windows runner, `windows-2025`.