### PR TITLE
Silence a legitimate sanitizer warning that's enabled by default in Android NDK 29

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -21,6 +21,12 @@
 #include <type_traits>
 #include <utility>
 
+#if defined(__clang__) || defined(__GNUC__)
+#define NAPI_NO_SANITIZE_VPTR __attribute__((no_sanitize("vptr")))
+#else
+#define NAPI_NO_SANITIZE_VPTR
+#endif
+
 namespace Napi {
 
 #ifdef NAPI_CPP_CUSTOM_NAMESPACE
@@ -4717,7 +4723,8 @@ inline napi_value InstanceWrap<T>::WrappedMethod(
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
+inline NAPI_NO_SANITIZE_VPTR ObjectWrap<T>::ObjectWrap(
+    const Napi::CallbackInfo& callbackInfo) {
   napi_env env = callbackInfo.Env();
   napi_value wrapper = callbackInfo.This();
   napi_status status;
@@ -4731,7 +4738,7 @@ inline ObjectWrap<T>::ObjectWrap(const Napi::CallbackInfo& callbackInfo) {
 }
 
 template <typename T>
-inline ObjectWrap<T>::~ObjectWrap() {
+inline NAPI_NO_SANITIZE_VPTR ObjectWrap<T>::~ObjectWrap() {
   // If the JS object still exists at this point, remove the finalizer added
   // through `napi_wrap()`.
   if (!IsEmpty() && !_finalized) {
@@ -4744,8 +4751,12 @@ inline ObjectWrap<T>::~ObjectWrap() {
   }
 }
 
+// with RTTI turned on, modern compilers check to see if virtual function
+// pointers are stripped of RTTI by void casts. this is intrinsic to how Unwrap
+// works, so we inject a compiler pragma to turn off that check just for the
+// affected methods. this compiler check is on by default in Android NDK 29.
 template <typename T>
-inline T* ObjectWrap<T>::Unwrap(Object wrapper) {
+inline NAPI_NO_SANITIZE_VPTR T* ObjectWrap<T>::Unwrap(Object wrapper) {
   void* unwrapped;
   napi_status status = napi_unwrap(wrapper.Env(), wrapper, &unwrapped);
   NAPI_THROW_IF_FAILED(wrapper.Env(), status, nullptr);
@@ -7029,5 +7040,7 @@ inline void BasicEnv::PostFinalizer(FinalizerType finalizeCallback,
 #endif
 
 }  // namespace Napi
+
+#undef NAPI_NO_SANITIZE_VPTR
 
 #endif  // SRC_NAPI_INL_H_


### PR DESCRIPTION
Silence a legitimate vfptr sanitizer warning that is on by default in Android NDK 29's clang. Stripping RTTI from a vfptr is usually a no-no for debugging and field-supportability reasons, but it's intrinsic to how ObjectWrap works right now.

This was found whilst porting BabylonNative (which implements NAPI for add-ons) to Android XR, and was integrated (and tested) there as a local patch:
https://github.com/BabylonJS/JsRuntimeHost/pull/118/files#diff-a9d53b78150c809d9bf63a90260b4f823918bc6e6d9c3e02eb68d855bf9deda1R4499