### PR TITLE
doc: add instructions to build with ninja

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,9 @@ Multiple filter conditions can be joined to broaden the test selection
  compile and run all tests under folders threadsafe_function and typed_threadsafe_function and also the objectwrap.cc file
     npm run unit --filter='*function objectwrap'
 
+As an alternative, `ninja` can be used to build the tests. Please
+follow the instructions in [Build with ninja](doc/contributing/build_with_ninja.md).
+
 ## Debug
 
 To run the **node-addon-api** tests with `--debug` option:

--- a/doc/contributing/build_with_ninja.md
+++ b/doc/contributing/build_with_ninja.md
@@ -1,0 +1,16 @@
+# Build Test with Ninja
+
+Ninja can be used to speed up building tests with optimized parallelism.
+
+To build the tests with ninja and node-gyp, run the following commands:
+
+```sh
+/node-addon-api $ node-gyp configure -C test -- -f ninja
+/node-addon-api $ ninja -C test/build/Release
+# Run tests
+/node-addon-api $ node ./test/index.js
+
+# Run tests with debug addon
+/node-addon-api $ ninja -C test/build/Debug
+/node-addon-api $ NODE_API_BUILD_CONFIG=Debug node ./test/index.js
+```


### PR DESCRIPTION
Add instructions to build with ninja locally, which could speed up building test addons significantly.