### PR TITLE
fix: add missing const to ObjectReference::Set string parameter

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -3809,8 +3809,8 @@ inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
   return Value().Set(utf8name, value);
 }
 
-inline MaybeOrValue<bool> ObjectReference::Set(const std::string& utf8name,
-                                               std::string& utf8value) const {
+inline MaybeOrValue<bool> ObjectReference::Set(
+    const std::string& utf8name, const std::string& utf8value) const {
   HandleScope scope(_env);
   return Value().Set(utf8name, utf8value);
 }

--- a/napi.h
+++ b/napi.h
@@ -1733,7 +1733,7 @@ class ObjectReference : public Reference<Object> {
   MaybeOrValue<bool> Set(const std::string& utf8name, napi_value value) const;
   MaybeOrValue<bool> Set(const std::string& utf8name, Napi::Value value) const;
   MaybeOrValue<bool> Set(const std::string& utf8name,
-                         std::string& utf8value) const;
+                         const std::string& utf8value) const;
   MaybeOrValue<bool> Set(const std::string& utf8name, bool boolValue) const;
   MaybeOrValue<bool> Set(const std::string& utf8name, double numberValue) const;
 

--- a/test/object_reference.cc
+++ b/test/object_reference.cc
@@ -28,6 +28,25 @@ ObjectReference casted_reference;
 
 enum VAL_TYPES { JS = 0, C_STR, CPP_STR, BOOL, INT, DOUBLE, JS_CAST };
 
+// Test that Set() with std::string key and value accepts temporaries (rvalues).
+// This verifies that the parameter is `const std::string&` rather than
+// `std::string&`.
+void SetWithTempString(const Napi::CallbackInfo& info) {
+  Env env = info.Env();
+  HandleScope scope(env);
+
+  Napi::ObjectReference ref = Persistent(Object::New(env));
+  ref.SuppressDestruct();
+
+  ref.Set(std::string("tempKey"), std::string("tempValue"));
+  ref.Set(std::string("anotherKey"), info[0].As<Napi::String>().Utf8Value());
+
+  assert(MaybeUnwrap(ref.Get("tempKey")).As<Napi::String>().Utf8Value() ==
+         "tempValue");
+  assert(MaybeUnwrap(ref.Get("anotherKey")).As<Napi::String>().Utf8Value() ==
+         info[0].As<Napi::String>().Utf8Value());
+}
+
 void MoveOperatorsTest(const Napi::CallbackInfo& info) {
   Napi::ObjectReference existingRef;
   Napi::ObjectReference existingRef2;
@@ -412,6 +431,7 @@ Object InitObjectReference(Env env) {
   exports["unrefObjects"] = Function::New(env, UnrefObjects);
   exports["refObjects"] = Function::New(env, RefObjects);
   exports["moveOpTest"] = Function::New(env, MoveOperatorsTest);
+  exports["setWithTempString"] = Function::New(env, SetWithTempString);
 
   return exports;
 }

--- a/test/object_reference.js
+++ b/test/object_reference.js
@@ -47,6 +47,8 @@ const configObjects = [
 
 function test (binding) {
   binding.objectreference.moveOpTest();
+  binding.objectreference.setWithTempString('testValue');
+
   function testCastedEqual (testToCompare) {
     const compareTest = ['hello', 'world', '!'];
     if (testToCompare instanceof Array) {


### PR DESCRIPTION
The `ObjectReference::Set(const std::string&, std::string&)` overload was missing a `const` qualifier on the value parameter, making it inconsistent with other Set overloads. This prevented passing temporary `std::string` objects (rvalues). 
Adding `const` allows for more flexible usage without unnecessary string copies.