### PR TITLE
feat: add Object::GetPrototype and Object::SetPrototype

### DIFF
--- a/doc/object.md
+++ b/doc/object.md
@@ -241,6 +241,28 @@ from being added to it and marking all existing properties as non-configurable.
 Values of present properties can still be changed as long as they are
 writable.
 
+### GetPrototype()
+
+```cpp
+Napi::Object Napi::Object::GetPrototype() const;
+```
+
+The `Napi::Object::GetPrototype()` method returns the prototype of the object.
+
+### SetPrototype()
+
+```cpp
+bool Napi::Object::SetPrototype(const Napi::Object& value) const;
+```
+
+- `[in] value`: The prototype value.
+
+The `Napi::Object::SetPrototype()` method sets the prototype of the object.
+
+**NOTE**: The support for `Napi::Object::SetPrototype` is only available when
+using `NAPI_EXPERIMENTAL` and building against Node.js headers that support this
+feature.
+
 ### operator\[\]()
 
 ```cpp

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1966,6 +1966,19 @@ inline MaybeOrValue<bool> Object::Seal() const {
 }
 #endif  // NAPI_VERSION >= 8
 
+inline MaybeOrValue<Object> Object::GetPrototype() const {
+  napi_value result;
+  napi_status status = napi_get_prototype(_env, _value, &result);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, Object(_env, result), Object);
+}
+
+#ifdef NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
+inline MaybeOrValue<bool> Object::SetPrototype(const Object& value) const {
+  napi_status status = node_api_set_prototype(_env, _value, value);
+  NAPI_RETURN_OR_THROW_IF_FAILED(_env, status, status == napi_ok, bool);
+}
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 // External class
 ////////////////////////////////////////////////////////////////////////////////

--- a/napi.h
+++ b/napi.h
@@ -1118,6 +1118,12 @@ class Object : public TypeTaggable {
   /// https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
   MaybeOrValue<bool> Seal() const;
 #endif  // NAPI_VERSION >= 8
+
+  MaybeOrValue<Object> GetPrototype() const;
+
+#ifdef NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
+  MaybeOrValue<bool> SetPrototype(const Object& value) const;
+#endif
 };
 
 template <typename T>

--- a/test/object/object.cc
+++ b/test/object/object.cc
@@ -343,6 +343,19 @@ Value InstanceOf(const CallbackInfo& info) {
   return Boolean::New(info.Env(), MaybeUnwrap(obj.InstanceOf(constructor)));
 }
 
+Value GetPrototype(const CallbackInfo& info) {
+  Object obj = info[0].UnsafeAs<Object>();
+  return MaybeUnwrap(obj.GetPrototype());
+}
+
+#ifdef NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
+Value SetPrototype(const CallbackInfo& info) {
+  Object obj = info[0].UnsafeAs<Object>();
+  Object prototype = info[1].UnsafeAs<Object>();
+  return Boolean::New(info.Env(), MaybeUnwrap(obj.SetPrototype(prototype)));
+}
+#endif  // NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
+
 Object InitObject(Env env) {
   Object exports = Object::New(env);
 
@@ -425,6 +438,11 @@ Object InitObject(Env env) {
   exports["subscriptSetWithCppStyleString"] =
       Function::New(env, SubscriptSetWithCppStyleString);
   exports["subscriptSetAtIndex"] = Function::New(env, SubscriptSetAtIndex);
+
+  exports["getPrototype"] = Function::New(env, GetPrototype);
+#ifdef NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
+  exports["setPrototype"] = Function::New(env, SetPrototype);
+#endif  // NODE_API_EXPERIMENTAL_HAS_SET_PROTOTYPE
 
   return exports;
 }

--- a/test/object/object.js
+++ b/test/object/object.js
@@ -215,4 +215,16 @@ function test (binding) {
       c: 3
     });
   }
+
+  for (const prototype of [null, {}, Object.prototype]) {
+    const obj = Object.create(prototype);
+    assert.strictEqual(binding.object.getPrototype(obj), prototype);
+  }
+
+  if ('setPrototype' in binding.object) {
+    const prototype = {};
+    const obj = Object.create(null);
+    assert.strictEqual(binding.object.setPrototype(obj, prototype), true);
+    assert.strictEqual(Object.getPrototypeOf(obj), prototype);
+  }
 }


### PR DESCRIPTION
- Add `Object::GetPrototype` and `Object::SetPrototype`
- Update docs and tests

Fixes: #1691
