### PR TITLE
feat: add std::string_view overload for Symbol::For

### DIFF
--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -50,6 +50,7 @@ Returns a `Napi::Symbol` representing a well-known `Symbol` from the
 ### For
 ```cpp
 static Napi::Symbol Napi::Symbol::For(napi_env env, const std::string& description);
+static Napi::Symbol Napi::Symbol::For(napi_env env, std::string_view description);
 static Napi::Symbol Napi::Symbol::For(napi_env env, const char* description);
 static Napi::Symbol Napi::Symbol::For(napi_env env, String description);
 static Napi::Symbol Napi::Symbol::For(napi_env env, napi_value description);
@@ -57,6 +58,12 @@ static Napi::Symbol Napi::Symbol::For(napi_env env, napi_value description);
 
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Symbol` object.
 - `[in] description`: The C++ string representing the `Napi::Symbol` in the global registry to retrieve.
+  `description` may be any of:
+  - `std::string&` - UTF8 string description.
+  - `std::string_view` - represents a UTF8 string view.
+  - `const char*` - represents a UTF8 string description.
+  - `String` - Node addon API String description.
+  - `napi_value` - Node-API `napi_value` description.
 
 Searches in the global registry for existing symbol with the given name. If the symbol already exist it will be returned, otherwise a new symbol will be created in the registry. It's equivalent to Symbol.for() called from JavaScript.
 

--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -26,7 +26,7 @@ Napi::Symbol::New(napi_env env, napi_value description);
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Symbol` object.
 - `[in] value`: The C++ primitive which represents the description hint for the `Napi::Symbol`.
   `description` may be any of:
-  - `std::string&` - UTF8 string description.
+  - `const std::string&` - UTF8 string description.
   - `const char*` - represents a UTF8 string description.
   - `std::string_view` - represents a UTF8 string view.
   - `String` - Node addon API String description.

--- a/doc/symbol.md
+++ b/doc/symbol.md
@@ -59,7 +59,7 @@ static Napi::Symbol Napi::Symbol::For(napi_env env, napi_value description);
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Symbol` object.
 - `[in] description`: The C++ string representing the `Napi::Symbol` in the global registry to retrieve.
   `description` may be any of:
-  - `std::string&` - UTF8 string description.
+  - `const std::string&` - UTF8 string description.
   - `std::string_view` - represents a UTF8 string view.
   - `const char*` - represents a UTF8 string description.
   - `String` - Node addon API String description.

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1422,6 +1422,12 @@ inline MaybeOrValue<Symbol> Symbol::For(napi_env env,
   return Symbol::For(env, descriptionValue);
 }
 
+inline MaybeOrValue<Symbol> Symbol::For(napi_env env,
+                                        std::string_view description) {
+  napi_value descriptionValue = String::New(env, description);
+  return Symbol::For(env, descriptionValue);
+}
+
 inline MaybeOrValue<Symbol> Symbol::For(napi_env env, const char* description) {
   napi_value descriptionValue = String::New(env, description);
   return Symbol::For(env, descriptionValue);

--- a/napi.h
+++ b/napi.h
@@ -828,6 +828,9 @@ class Symbol : public Name {
   // Create a symbol in the global registry, UTF-8 Encoded cpp string
   static MaybeOrValue<Symbol> For(napi_env env, const std::string& description);
 
+  // Create a symbol in the global registry, UTF-8 encoded cpp string view
+  static MaybeOrValue<Symbol> For(napi_env env, std::string_view description);
+
   // Create a symbol in the global registry, C style string (null terminated)
   static MaybeOrValue<Symbol> For(napi_env env, const char* description);
 

--- a/test/symbol.cc
+++ b/test/symbol.cc
@@ -1,4 +1,7 @@
 #include <napi.h>
+
+#include <string_view>
+
 #include "test_helper.h"
 using namespace Napi;
 
@@ -37,6 +40,13 @@ Symbol FetchSymbolFromGlobalRegistryWithCppKey(const Napi::CallbackInfo& info) {
   return MaybeUnwrap(Napi::Symbol::For(info.Env(), cppStringKey.Utf8Value()));
 }
 
+Symbol FetchSymbolFromGlobalRegistryWithStringViewKey(
+    const Napi::CallbackInfo& info) {
+  String cppStringKey = info[0].As<String>();
+  std::string key = cppStringKey.Utf8Value();
+  return MaybeUnwrap(Napi::Symbol::For(info.Env(), std::string_view(key)));
+}
+
 Symbol FetchSymbolFromGlobalRegistryWithCKey(const Napi::CallbackInfo& info) {
   String cppStringKey = info[0].As<String>();
   return MaybeUnwrap(
@@ -71,6 +81,8 @@ Object InitSymbol(Env env) {
       Function::New(env, FetchSymbolFromGlobalRegistryWithCKey);
   exports["getSymbolFromGlobalRegistryWithCppKey"] =
       Function::New(env, FetchSymbolFromGlobalRegistryWithCppKey);
+  exports["getSymbolFromGlobalRegistryWithStringViewKey"] =
+      Function::New(env, FetchSymbolFromGlobalRegistryWithStringViewKey);
   exports["testUndefinedSymbolCanBeCreated"] =
       Function::New(env, TestUndefinedSymbolsCanBeCreated);
   exports["testNullSymbolCanBeCreated"] =

--- a/test/symbol.js
+++ b/test/symbol.js
@@ -54,6 +54,7 @@ function test (binding) {
 
   assertCanCreateOrFetchGlobalSymbols('data', binding.symbol.getSymbolFromGlobalRegistry);
   assertCanCreateOrFetchGlobalSymbols('CppKey', binding.symbol.getSymbolFromGlobalRegistryWithCppKey);
+  assertCanCreateOrFetchGlobalSymbols('StringViewKey', binding.symbol.getSymbolFromGlobalRegistryWithStringViewKey);
   assertCanCreateOrFetchGlobalSymbols('CKey', binding.symbol.getSymbolFromGlobalRegistryWithCKey);
 
   assert(binding.symbol.createNewSymbolWithNoArgs() === undefined);


### PR DESCRIPTION
`Symbol::For` had overloads for const std::string&, const char*, String, and napi_value, but was missing a std::string_view overload. This made it inconsistent with other APIs like String::New which already accept std::string_view, and forced users to convert std::string_view to std::string or const char* before calling Symbol::For.

Adding the std::string_view overload provides a more consistent API surface and avoids unnecessary string copies.