### PR TITLE
fix: allow const vectors with Object::New overload utilizing node_api_create_object_with_properties

### DIFF
--- a/doc/object.md
+++ b/doc/object.md
@@ -75,8 +75,8 @@ Creates a new `Napi::Object` value.
 Napi::Object Napi::Object::New(
       napi_env env,
       napi_value prototypeOrNull,
-      std::vector<napi_value>& propertyNames,
-      std::vector<napi_value>& propertyValues);
+      const std::vector<napi_value>& propertyNames,
+      const std::vector<napi_value>& propertyValues);
 ```
 - `[in] env`: The `napi_env` environment in which to construct the `Napi::Value`
   object.

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1644,8 +1644,8 @@ inline Object Object::New(napi_env env) {
 #ifdef NODE_API_EXPERIMENTAL_HAS_CREATE_OBJECT_WITH_PROPERTIES
 inline Object Object::New(napi_env env,
                           napi_value prototypeOrNull,
-                          std::vector<napi_value>& propertyNames,
-                          std::vector<napi_value>& propertyValues) {
+                          const std::vector<napi_value>& propertyNames,
+                          const std::vector<napi_value>& propertyValues) {
   if (propertyNames.size() != propertyValues.size()) {
     NAPI_THROW(
         Napi::Error::New(env, "Mismatch in size of property names and values"),
@@ -1653,13 +1653,15 @@ inline Object Object::New(napi_env env,
   }
 
   napi_value value;
-  napi_status status =
-      node_api_create_object_with_properties(env,
-                                             prototypeOrNull,
-                                             propertyNames.data(),
-                                             propertyValues.data(),
-                                             propertyNames.size(),
-                                             &value);
+  // TODO(@KevinEady): remove const_cast when
+  // https://github.com/nodejs/node/pull/65621 is fully backported.
+  napi_status status = node_api_create_object_with_properties(
+      env,
+      prototypeOrNull,
+      const_cast<napi_value*>(propertyNames.data()),
+      const_cast<napi_value*>(propertyValues.data()),
+      propertyNames.size(),
+      &value);
 
   NAPI_THROW_IF_FAILED(env, status, Object());
   return Object(env, value);

--- a/napi.h
+++ b/napi.h
@@ -955,8 +955,8 @@ class Object : public TypeTaggable {
   static Object New(
       napi_env env,                ///< Node-API environment
       napi_value prototypeOrNull,  ///< Prototype (Object) or null / empty Value
-      std::vector<napi_value>& propertyNames,  ///< Property names
-      std::vector<napi_value>& propertyValues  ///< Property values
+      const std::vector<napi_value>& propertyNames,  ///< Property names
+      const std::vector<napi_value>& propertyValues  ///< Property values
   );
 #endif
 


### PR DESCRIPTION
Use `const_cast` to remove `const`-qualifier from the pointer returned by the `vector`s' `data()` method.